### PR TITLE
Optimize file sizes of `brioche-packed-exec` and `brioche-packed-userland-exec`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -379,6 +379,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "bincode"
+version = "2.0.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f11ea1a0346b94ef188834a65c068a03aec181c94896d481d7a0a40d85b0ce95"
+dependencies = [
+ "bincode_derive",
+ "serde",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e30759b3b99a1b802a7a3aa21c85c3ded5c28e1c83170d82d70f08bbf7f3e4c"
+dependencies = [
+ "virtue",
+]
+
+[[package]]
 name = "biome_console"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -620,7 +639,7 @@ dependencies = [
  "assert_matches",
  "async-compression",
  "async-recursion",
- "bincode",
+ "bincode 1.3.3",
  "biome_js_parser",
  "biome_js_syntax",
  "biome_rowan",
@@ -694,6 +713,7 @@ dependencies = [
 name = "brioche-pack"
 version = "0.0.1"
 dependencies = [
+ "bincode 2.0.0-rc.3",
  "blake3",
  "bstr 1.8.0",
  "clap",
@@ -720,6 +740,7 @@ dependencies = [
 name = "brioche-packed-userland-exec"
 version = "0.1.0"
 dependencies = [
+ "bincode 2.0.0-rc.3",
  "brioche-pack",
  "bstr 1.8.0",
  "thiserror",
@@ -5814,6 +5835,12 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "virtue"
+version = "0.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dcc60c0624df774c82a0ef104151231d37da4962957d691c011c852b2473314"
 
 [[package]]
 name = "void"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -743,6 +743,7 @@ dependencies = [
  "bincode 2.0.0-rc.3",
  "brioche-pack",
  "bstr 1.8.0",
+ "libc",
  "thiserror",
  "userland-execve",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -733,6 +733,7 @@ version = "0.1.0"
 dependencies = [
  "brioche-pack",
  "bstr 1.8.0",
+ "libc",
  "thiserror",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,8 @@ lto = true
 codegen-units = 1
 strip = "symbols"
 panic = "abort"
+
+# Like `release-tiny`, but with debug info needed for `cargo bloat`
+[profile.release-tiny-bloat]
+inherits = "release-tiny"
+strip = "debuginfo"

--- a/crates/brioche-pack/Cargo.toml
+++ b/crates/brioche-pack/Cargo.toml
@@ -4,14 +4,19 @@ version = "0.0.1"
 edition = "2021"
 
 [dependencies]
+bincode = { version = "2.0.0-rc.3" }
 blake3 = "1.5.0"
 bstr = { version = "1.8.0", features = ["serde"] }
 clap = { version = "4.4.11", features = ["derive"] }
 goblin = "0.7.1"
 pathdiff = "0.2.1"
-serde = { version = "1.0.193", features = ["derive"] }
-serde_json = "1.0.108"
-serde_with = "3.4.0"
+serde = { version = "1.0.193", features = ["derive"], optional = true }
+serde_with = { version = "3.4.0", optional = true }
+serde_json = { version = "1.0.108", optional = true }
 thiserror = "1.0.51"
 ulid = "1.1.0"
 urlencoding = "2.1.3"
+
+[features]
+default = ["serde"]
+serde = ["dep:serde", "dep:serde_with", "dep:serde_json"]

--- a/crates/brioche-pack/Cargo.toml
+++ b/crates/brioche-pack/Cargo.toml
@@ -10,13 +10,9 @@ bstr = { version = "1.8.0", features = ["serde"] }
 clap = { version = "4.4.11", features = ["derive"] }
 goblin = "0.7.1"
 pathdiff = "0.2.1"
-serde = { version = "1.0.193", features = ["derive"], optional = true }
-serde_with = { version = "3.4.0", optional = true }
-serde_json = { version = "1.0.108", optional = true }
+serde = { version = "1.0.193", features = ["derive"] }
+serde_with = { version = "3.4.0" }
+serde_json = { version = "1.0.108" }
 thiserror = "1.0.51"
 ulid = "1.1.0"
 urlencoding = "2.1.3"
-
-[features]
-default = ["serde"]
-serde = ["dep:serde", "dep:serde_with", "dep:serde_json"]

--- a/crates/brioche-pack/src/encoding.rs
+++ b/crates/brioche-pack/src/encoding.rs
@@ -4,7 +4,6 @@ use bstr::{ByteSlice, ByteVec as _};
 
 pub enum UrlEncoded {}
 
-#[cfg(feature = "serde")]
 impl<T> serde_with::SerializeAs<T> for UrlEncoded
 where
     T: AsRef<[u8]>,
@@ -18,7 +17,6 @@ where
     }
 }
 
-#[cfg(feature = "serde")]
 impl<'de, T> serde_with::DeserializeAs<'de, T> for UrlEncoded
 where
     T: TryFrom<Vec<u8>>,
@@ -37,7 +35,6 @@ where
 
 pub struct AsPath<T>(std::marker::PhantomData<T>);
 
-#[cfg(feature = "serde")]
 impl<T> serde_with::SerializeAs<PathBuf> for AsPath<T>
 where
     T: serde_with::SerializeAs<Vec<u8>>,
@@ -52,7 +49,6 @@ where
     }
 }
 
-#[cfg(feature = "serde")]
 impl<'de, T> serde_with::DeserializeAs<'de, PathBuf> for AsPath<T>
 where
     T: serde_with::DeserializeAs<'de, Vec<u8>>,

--- a/crates/brioche-pack/src/encoding.rs
+++ b/crates/brioche-pack/src/encoding.rs
@@ -4,6 +4,7 @@ use bstr::{ByteSlice, ByteVec as _};
 
 pub enum UrlEncoded {}
 
+#[cfg(feature = "serde")]
 impl<T> serde_with::SerializeAs<T> for UrlEncoded
 where
     T: AsRef<[u8]>,
@@ -17,6 +18,7 @@ where
     }
 }
 
+#[cfg(feature = "serde")]
 impl<'de, T> serde_with::DeserializeAs<'de, T> for UrlEncoded
 where
     T: TryFrom<Vec<u8>>,
@@ -35,6 +37,7 @@ where
 
 pub struct AsPath<T>(std::marker::PhantomData<T>);
 
+#[cfg(feature = "serde")]
 impl<T> serde_with::SerializeAs<PathBuf> for AsPath<T>
 where
     T: serde_with::SerializeAs<Vec<u8>>,
@@ -49,6 +52,7 @@ where
     }
 }
 
+#[cfg(feature = "serde")]
 impl<'de, T> serde_with::DeserializeAs<'de, PathBuf> for AsPath<T>
 where
     T: serde_with::DeserializeAs<'de, Vec<u8>>,

--- a/crates/brioche-pack/src/lib.rs
+++ b/crates/brioche-pack/src/lib.rs
@@ -1,7 +1,5 @@
 use std::path::{Path, PathBuf};
 
-use encoding::UrlEncoded;
-
 pub mod autowrap;
 mod encoding;
 pub mod resources;
@@ -13,12 +11,13 @@ const SEARCH_DEPTH_LIMIT: u32 = 64;
 const LENGTH_BYTES: usize = 4;
 type LengthInt = u32;
 
-#[serde_with::serde_as]
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", serde_with::serde_as)]
+#[derive(Debug, bincode::Encode, bincode::Decode)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct Pack {
-    #[serde_as(as = "UrlEncoded")]
-    pub program: bstr::BString,
+    #[cfg_attr(feature = "serde", serde_as(as = "UrlEncoded"))]
+    pub program: Vec<u8>,
     pub interpreter: Option<Interpreter>,
 }
 
@@ -31,15 +30,15 @@ impl Pack {
 
         let mut paths = vec![];
 
-        paths.push(program.clone());
+        paths.push(bstr::BString::from(program.clone()));
         if let Some(interpreter) = interpreter {
             match interpreter {
                 Interpreter::LdLinux {
                     path,
                     library_paths,
                 } => {
-                    paths.push(path.clone());
-                    paths.extend(library_paths.iter().cloned());
+                    paths.push(bstr::BString::from(path.clone()));
+                    paths.extend(library_paths.iter().cloned().map(bstr::BString::from));
                 }
             }
         }
@@ -48,17 +47,18 @@ impl Pack {
     }
 }
 
-#[serde_with::serde_as]
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
-#[serde(tag = "type")]
-#[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "serde", serde_with::serde_as)]
+#[derive(Debug, bincode::Encode, bincode::Decode)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(tag = "type"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 pub enum Interpreter {
-    #[serde(rename_all = "camelCase")]
+    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     LdLinux {
-        #[serde_as(as = "UrlEncoded")]
-        path: bstr::BString,
-        #[serde_as(as = "Vec<UrlEncoded>")]
-        library_paths: Vec<bstr::BString>,
+        #[cfg_attr(feature = "serde", serde_as(as = "UrlEncoded"))]
+        path: Vec<u8>,
+        #[cfg_attr(feature = "serde", serde_as(as = "Vec<UrlEncoded>"))]
+        library_paths: Vec<Vec<u8>>,
     },
 }
 
@@ -90,7 +90,8 @@ pub fn find_resource_dir(program: &Path) -> Result<PathBuf, PackResourceDirError
 }
 
 pub fn inject_pack(mut writer: impl std::io::Write, pack: &Pack) -> Result<(), InjectPackError> {
-    let pack_bytes = serde_json::to_vec(pack).map_err(InjectPackError::SerializeError)?;
+    let pack_bytes = bincode::encode_to_vec(pack, bincode::config::standard())
+        .map_err(InjectPackError::SerializeError)?;
     let pack_length: LengthInt = pack_bytes
         .len()
         .try_into()
@@ -132,7 +133,8 @@ pub fn extract_pack(mut reader: impl std::io::Read) -> Result<Pack, ExtractPackE
         .strip_suffix(MARKER)
         .ok_or_else(|| ExtractPackError::MalformedMarker)?;
 
-    let pack = serde_json::from_slice(pack).map_err(ExtractPackError::InvalidPack)?;
+    let (pack, _) = bincode::decode_from_slice(pack, bincode::config::standard())
+        .map_err(ExtractPackError::InvalidPack)?;
 
     Ok(pack)
 }
@@ -152,7 +154,7 @@ pub enum InjectPackError {
     #[error("failed to write packed program: {0}")]
     IoError(#[from] std::io::Error),
     #[error("failed to serialize pack: {0}")]
-    SerializeError(#[source] serde_json::Error),
+    SerializeError(#[source] bincode::error::EncodeError),
     #[error("pack JSON too large")]
     PackTooLarge,
 }
@@ -166,5 +168,5 @@ pub enum ExtractPackError {
     #[error("marker was malformed at the end of the packed program")]
     MalformedMarker,
     #[error("failed to parse pack: {0}")]
-    InvalidPack(#[source] serde_json::Error),
+    InvalidPack(#[source] bincode::error::DecodeError),
 }

--- a/crates/brioche-pack/src/lib.rs
+++ b/crates/brioche-pack/src/lib.rs
@@ -1,5 +1,7 @@
 use std::path::{Path, PathBuf};
 
+use encoding::UrlEncoded;
+
 pub mod autowrap;
 mod encoding;
 pub mod resources;
@@ -11,12 +13,11 @@ const SEARCH_DEPTH_LIMIT: u32 = 64;
 const LENGTH_BYTES: usize = 4;
 type LengthInt = u32;
 
-#[cfg_attr(feature = "serde", serde_with::serde_as)]
-#[derive(Debug, bincode::Encode, bincode::Decode)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[serde_with::serde_as]
+#[derive(Debug, bincode::Encode, bincode::Decode, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Pack {
-    #[cfg_attr(feature = "serde", serde_as(as = "UrlEncoded"))]
+    #[serde_as(as = "UrlEncoded")]
     pub program: Vec<u8>,
     pub interpreter: Option<Interpreter>,
 }
@@ -47,17 +48,16 @@ impl Pack {
     }
 }
 
-#[cfg_attr(feature = "serde", serde_with::serde_as)]
-#[derive(Debug, bincode::Encode, bincode::Decode)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(tag = "type"))]
-#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
+#[serde_with::serde_as]
+#[derive(Debug, bincode::Encode, bincode::Decode, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "type")]
+#[serde(rename_all = "snake_case")]
 pub enum Interpreter {
-    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+    #[serde(rename_all = "camelCase")]
     LdLinux {
-        #[cfg_attr(feature = "serde", serde_as(as = "UrlEncoded"))]
+        #[serde_as(as = "UrlEncoded")]
         path: Vec<u8>,
-        #[cfg_attr(feature = "serde", serde_as(as = "Vec<UrlEncoded>"))]
+        #[serde_as(as = "Vec<UrlEncoded>")]
         library_paths: Vec<Vec<u8>>,
     },
 }

--- a/crates/brioche-packed-exec/Cargo.toml
+++ b/crates/brioche-packed-exec/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-brioche-pack = { path = "../brioche-pack" }
+brioche-pack = { path = "../brioche-pack", default-features = false }
 bstr = "1.8.0"
 thiserror = "1.0.51"

--- a/crates/brioche-packed-exec/Cargo.toml
+++ b/crates/brioche-packed-exec/Cargo.toml
@@ -6,4 +6,5 @@ edition = "2021"
 [dependencies]
 brioche-pack = { path = "../brioche-pack", default-features = false }
 bstr = "1.8.0"
+libc = "0.2.151"
 thiserror = "1.0.51"

--- a/crates/brioche-packed-exec/src/main.rs
+++ b/crates/brioche-packed-exec/src/main.rs
@@ -1,19 +1,16 @@
-#![cfg_attr(not(test), no_main)]
-
-use std::os::unix::process::CommandExt as _;
+use std::{os::unix::process::CommandExt as _, process::ExitCode};
 
 use bstr::ByteSlice as _;
 
 const BRIOCHE_PACKED_ERROR: u8 = 121;
 
-#[cfg_attr(not(test), no_mangle)]
-pub extern "C" fn main(_argc: libc::c_int, _argv: *const *const libc::c_char) -> libc::c_int {
+pub fn main() -> ExitCode {
     let result = run();
     match result {
-        Ok(()) => libc::EXIT_SUCCESS,
+        Ok(()) => ExitCode::SUCCESS,
         Err(err) => {
             eprintln!("brioche-packed error: {err}");
-            BRIOCHE_PACKED_ERROR.into()
+            ExitCode::from(BRIOCHE_PACKED_ERROR)
         }
     }
 }

--- a/crates/brioche-packed-exec/src/main.rs
+++ b/crates/brioche-packed-exec/src/main.rs
@@ -1,4 +1,4 @@
-#![no_main]
+#![cfg_attr(not(test), no_main)]
 
 use std::os::unix::process::CommandExt as _;
 
@@ -6,7 +6,7 @@ use bstr::ByteSlice as _;
 
 const BRIOCHE_PACKED_ERROR: u8 = 121;
 
-#[no_mangle]
+#[cfg_attr(not(test), no_mangle)]
 pub extern "C" fn main(_argc: libc::c_int, _argv: *const *const libc::c_char) -> libc::c_int {
     let result = run();
     match result {

--- a/crates/brioche-packed-exec/src/main.rs
+++ b/crates/brioche-packed-exec/src/main.rs
@@ -1,16 +1,19 @@
-use std::{os::unix::process::CommandExt as _, process::ExitCode};
+#![no_main]
+
+use std::os::unix::process::CommandExt as _;
 
 use bstr::ByteSlice as _;
 
 const BRIOCHE_PACKED_ERROR: u8 = 121;
 
-fn main() -> ExitCode {
+#[no_mangle]
+pub extern "C" fn main(_argc: libc::c_int, _argv: *const *const libc::c_char) -> libc::c_int {
     let result = run();
     match result {
-        Ok(()) => ExitCode::SUCCESS,
+        Ok(()) => libc::EXIT_SUCCESS,
         Err(err) => {
             eprintln!("brioche-packed error: {err}");
-            ExitCode::from(BRIOCHE_PACKED_ERROR)
+            BRIOCHE_PACKED_ERROR.into()
         }
     }
 }
@@ -92,12 +95,42 @@ fn run() -> Result<(), PackedError> {
 
 #[derive(Debug, thiserror::Error)]
 enum PackedError {
-    #[error("{0}")]
     IoError(#[from] std::io::Error),
-    #[error("{0}")]
     ExtractPackError(#[from] brioche_pack::ExtractPackError),
-    #[error("{0}")]
     PackResourceDirError(#[from] brioche_pack::PackResourceDirError),
-    #[error("invalid path")]
     InvalidPath,
+}
+
+impl std::fmt::Display for PackedError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(error_summary(self))
+    }
+}
+
+fn error_summary(error: &PackedError) -> &'static str {
+    match error {
+        PackedError::IoError(_) => "io error",
+        PackedError::ExtractPackError(error) => match error {
+            brioche_pack::ExtractPackError::ReadPackedProgramError(_) => {
+                "failed to read packed program: io error"
+            }
+            brioche_pack::ExtractPackError::MarkerNotFound => {
+                "marker not found at the end of the packed program"
+            }
+            brioche_pack::ExtractPackError::MalformedMarker => {
+                "malformed marker at the end of the packed program"
+            }
+            brioche_pack::ExtractPackError::InvalidPack(_) => "failed to parse pack: bincode error",
+        },
+        PackedError::PackResourceDirError(error) => match error {
+            brioche_pack::PackResourceDirError::NotFound => "brioche pack resource dir not found",
+            brioche_pack::PackResourceDirError::DepthLimitReached => {
+                "reached depth limit while searching for brioche pack resource dir"
+            }
+            brioche_pack::PackResourceDirError::IoError(_) => {
+                "error while searching for brioche pack resource dir: io error"
+            }
+        },
+        PackedError::InvalidPath => "invalid path",
+    }
 }

--- a/crates/brioche-packed-userland-exec/Cargo.toml
+++ b/crates/brioche-packed-userland-exec/Cargo.toml
@@ -7,5 +7,6 @@ edition = "2021"
 bincode = "2.0.0-rc.3"
 brioche-pack = { path = "../brioche-pack", default-features = false }
 bstr = "1.8.0"
+libc = "0.2.151"
 thiserror = "1.0.51"
 userland-execve = { git = "https://github.com/brioche-dev/userland-execve-rust.git" }

--- a/crates/brioche-packed-userland-exec/Cargo.toml
+++ b/crates/brioche-packed-userland-exec/Cargo.toml
@@ -4,7 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-brioche-pack = { path = "../brioche-pack" }
+bincode = "2.0.0-rc.3"
+brioche-pack = { path = "../brioche-pack", default-features = false }
 bstr = "1.8.0"
 thiserror = "1.0.51"
 userland-execve = { git = "https://github.com/brioche-dev/userland-execve-rust.git" }

--- a/crates/brioche-packed-userland-exec/src/main.rs
+++ b/crates/brioche-packed-userland-exec/src/main.rs
@@ -10,7 +10,7 @@ const BRIOCHE_PACKED_ERROR: u8 = 121;
 pub extern "C" fn main(_argc: libc::c_int, _argv: *const *const libc::c_char) -> libc::c_int {
     let result = run();
     match result {
-        Ok(()) => 0,
+        Ok(()) => libc::EXIT_SUCCESS,
         Err(err) => {
             eprintln!("brioche-packed error: {err}");
             BRIOCHE_PACKED_ERROR.into()

--- a/crates/brioche-packed-userland-exec/src/main.rs
+++ b/crates/brioche-packed-userland-exec/src/main.rs
@@ -1,19 +1,19 @@
-use std::{
-    ffi::{CStr, CString},
-    process::ExitCode,
-};
+#![no_main]
+
+use std::ffi::{CStr, CString};
 
 use bstr::ByteSlice as _;
 
 const BRIOCHE_PACKED_ERROR: u8 = 121;
 
-fn main() -> ExitCode {
+#[no_mangle]
+pub extern "C" fn main(_argc: libc::c_int, _argv: *const *const libc::c_char) -> libc::c_int {
     let result = run();
     match result {
-        Ok(()) => ExitCode::SUCCESS,
+        Ok(()) => 0,
         Err(err) => {
             eprintln!("brioche-packed error: {err}");
-            ExitCode::from(BRIOCHE_PACKED_ERROR)
+            BRIOCHE_PACKED_ERROR.into()
         }
     }
 }

--- a/crates/brioche-packed-userland-exec/src/main.rs
+++ b/crates/brioche-packed-userland-exec/src/main.rs
@@ -1,4 +1,4 @@
-#![no_main]
+#![cfg_attr(not(test), no_main)]
 
 use std::ffi::{CStr, CString};
 
@@ -6,7 +6,7 @@ use bstr::ByteSlice as _;
 
 const BRIOCHE_PACKED_ERROR: u8 = 121;
 
-#[no_mangle]
+#[cfg_attr(not(test), no_mangle)]
 pub extern "C" fn main(_argc: libc::c_int, _argv: *const *const libc::c_char) -> libc::c_int {
     let result = run();
     match result {

--- a/crates/brioche-packed-userland-exec/src/main.rs
+++ b/crates/brioche-packed-userland-exec/src/main.rs
@@ -127,14 +127,44 @@ fn run() -> Result<(), PackedError> {
 
 #[derive(Debug, thiserror::Error)]
 enum PackedError {
-    #[error("{0}")]
     IoError(#[from] std::io::Error),
-    #[error("{0}")]
     ExtractPackError(#[from] brioche_pack::ExtractPackError),
-    #[error("{0}")]
     PackResourceDirError(#[from] brioche_pack::PackResourceDirError),
-    #[error("invalid path")]
     InvalidPath,
-    #[error("invalid env var")]
     InvalidEnvVar,
+}
+
+impl std::fmt::Display for PackedError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(error_summary(self))
+    }
+}
+
+fn error_summary(error: &PackedError) -> &'static str {
+    match error {
+        PackedError::IoError(_) => "io error",
+        PackedError::ExtractPackError(error) => match error {
+            brioche_pack::ExtractPackError::ReadPackedProgramError(_) => {
+                "failed to read packed program: io error"
+            }
+            brioche_pack::ExtractPackError::MarkerNotFound => {
+                "marker not found at the end of the packed program"
+            }
+            brioche_pack::ExtractPackError::MalformedMarker => {
+                "malformed marker at the end of the packed program"
+            }
+            brioche_pack::ExtractPackError::InvalidPack(_) => "failed to parse pack: bincode error",
+        },
+        PackedError::PackResourceDirError(error) => match error {
+            brioche_pack::PackResourceDirError::NotFound => "brioche pack resource dir not found",
+            brioche_pack::PackResourceDirError::DepthLimitReached => {
+                "reached depth limit while searching for brioche pack resource dir"
+            }
+            brioche_pack::PackResourceDirError::IoError(_) => {
+                "error while searching for brioche pack resource dir: io error"
+            }
+        },
+        PackedError::InvalidPath => "invalid path",
+        PackedError::InvalidEnvVar => "invalid env var",
+    }
 }


### PR DESCRIPTION
This PR decreases the file sizes of the `brioche-packed-exec` and `brioche-packed-userland-exec` packed binary wrappers. Based on some recent CI runs ([CI #16](https://github.com/brioche-dev/brioche/actions/runs/7384610242/job/20087850566), [CI #17](https://github.com/brioche-dev/brioche/actions/runs/7384714590/job/20088109401)), the new binary sizes are now:

- `brioche-packed-userland-exec`: 150KB → 86KB
- `brioche-packed-exec`: 130K → 78K

Most of the changes I made were inspired by tips from the [min-sized-rust](https://github.com/johnthagen/min-sized-rust) repo. Several changes were just compiler options that already landed in `main`, but this PR includes the spicier ones. To summarize the changes:

- Avoid `format!` as much as possible
  - There is still some use of `format!` in `goblin`. I made an experimental branch in my fork that avoids even more formatting ([`avoid-reformatting`](https://github.com/brioche-dev/goblin/tree/f70eea1c9cf35c758e699de332d58797244f0861)), but this only impacted binary sizes by <10KB, so I didn't feel it was worth pursuing for the time being.
- Use `bincode` instead of `serde` / `serde_json`
   - Originally I went with JSON due to the fact that it's easy to inspect and easy to make backwards-compatible changes, but since `brioche-packer` can still read/write as JSON, I felt like this wasn't a big loss.
   - It may be worth trying to use some other encoding scheme in the future (maybe `bson`, or maybe non-Serde JSON).
- Use `#![no_main]`
  - This only applies for `brioche-packed-userland-exec`. I wanted to keep `brioche-packed-exec` as simple and safe as possible, since it's more meant to be a fallback / reference implementation.