### PR TITLE
Improve project analysis

### DIFF
--- a/crates/brioche/src/brioche/project/analyze.rs
+++ b/crates/brioche/src/brioche/project/analyze.rs
@@ -1,12 +1,37 @@
+use std::{collections::HashMap, path::Path};
+
 use anyhow::Context as _;
 use biome_rowan::{AstNode as _, AstNodeList as _, AstSeparatedList as _};
 
-pub fn analyze_project(
-    file: &url::Url,
-    contents: &str,
-) -> anyhow::Result<super::ProjectDefinition> {
+use crate::brioche::script::specifier::{BriocheImportSpecifier, BriocheModuleSpecifier};
+
+#[derive(Debug)]
+pub struct ProjectAnalysis {
+    pub definition: super::ProjectDefinition,
+    pub local_modules: HashMap<BriocheModuleSpecifier, ModuleAnalysis>,
+    pub root_module: BriocheModuleSpecifier,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ModuleAnalysis {
+    pub specifier: BriocheModuleSpecifier,
+    pub imports: HashMap<BriocheImportSpecifier, ImportAnalysis>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ImportAnalysis {
+    ExternalProject(String),
+    LocalModule(BriocheModuleSpecifier),
+}
+
+// TODO: Make async
+pub fn analyze_project(project_path: &Path) -> anyhow::Result<ProjectAnalysis> {
+    let root_module_path = project_path.join("project.bri");
+    let file = root_module_path.display();
+    let contents = std::fs::read_to_string(&root_module_path)
+        .with_context(|| format!("{file}: Failed to read root module file"))?;
     let parsed = biome_js_parser::parse(
-        contents,
+        &contents,
         biome_js_syntax::JsFileSource::ts().with_module_kind(biome_js_syntax::ModuleKind::Module),
         biome_js_parser::JsParserOptions::default(),
     )
@@ -60,7 +85,176 @@ pub fn analyze_project(
     let project_definition = serde_json::from_value(json)
         .with_context(|| format!("{file_line}: invalid project definition"))?;
 
-    Ok(project_definition)
+    let mut local_modules = HashMap::new();
+    let root_module = analyze_module(
+        &root_module_path,
+        project_path,
+        Some(&contents),
+        Some(&module),
+        &mut local_modules,
+    )?;
+
+    Ok(ProjectAnalysis {
+        definition: project_definition,
+        local_modules,
+        root_module,
+    })
+}
+
+// TODO: Make async
+pub fn analyze_module(
+    module_path: &Path,
+    project_path: &Path,
+    contents: Option<&str>,
+    module: Option<&biome_js_syntax::JsModule>,
+    local_modules: &mut HashMap<BriocheModuleSpecifier, ModuleAnalysis>,
+) -> anyhow::Result<BriocheModuleSpecifier> {
+    let module_path = if module_path == project_path {
+        module_path.join("project.bri")
+    } else if module_path.is_dir() {
+        module_path.join("index.bri")
+    } else {
+        module_path.to_owned()
+    };
+
+    let module_specifier = BriocheModuleSpecifier::File {
+        path: module_path.clone(),
+    };
+    match local_modules.entry(module_specifier.clone()) {
+        std::collections::hash_map::Entry::Occupied(_) => {
+            // We've already analyzed this module (or we're still analyzing it)
+            return Ok(module_specifier);
+        }
+        std::collections::hash_map::Entry::Vacant(entry) => {
+            // We haven't analyzed this module yet. When recursing, we don't
+            // want to re-analyze this module again, so insert a placeholder
+            // that we'll update later.
+            entry.insert(ModuleAnalysis {
+                specifier: module_specifier.clone(),
+                imports: HashMap::new(),
+            });
+        }
+    };
+
+    let file = module_path.display();
+
+    let read_contents;
+    let contents = match contents {
+        Some(contents) => contents,
+        None => {
+            read_contents = std::fs::read_to_string(&module_path)
+                .with_context(|| format!("{file}: Failed to read file"))?;
+            &read_contents
+        }
+    };
+
+    let parsed_module;
+    let module = match module {
+        Some(module) => module,
+        None => {
+            let parsed = biome_js_parser::parse(
+                contents,
+                biome_js_syntax::JsFileSource::ts()
+                    .with_module_kind(biome_js_syntax::ModuleKind::Module),
+                biome_js_parser::JsParserOptions::default(),
+            )
+            .cast::<biome_js_syntax::JsModule>()
+            .expect("failed to cast module");
+
+            parsed_module = parsed
+                .try_tree()
+                .with_context(|| format!("{file}: failed to parse module"))?;
+            &parsed_module
+        }
+    };
+
+    let mut imports = HashMap::new();
+
+    for module_item in module.items() {
+        let line = contents[..module_item.syntax().text_range().start().into()]
+            .lines()
+            .count();
+
+        let import_source = match module_item {
+            biome_js_syntax::AnyJsModuleItem::JsExport(export_item) => {
+                let export_clause = export_item
+                    .export_clause()
+                    .with_context(|| format!("{file}:{line}: failed to parse export statement"))?;
+                match export_clause {
+                    biome_js_syntax::AnyJsExportClause::JsExportFromClause(clause) => {
+                        clause.source()
+                    }
+                    biome_js_syntax::AnyJsExportClause::JsExportNamedFromClause(clause) => {
+                        clause.source()
+                    }
+                    biome_js_syntax::AnyJsExportClause::AnyJsDeclarationClause(_)
+                    | biome_js_syntax::AnyJsExportClause::JsExportDefaultDeclarationClause(_)
+                    | biome_js_syntax::AnyJsExportClause::JsExportDefaultExpressionClause(_)
+                    | biome_js_syntax::AnyJsExportClause::JsExportNamedClause(_)
+                    | biome_js_syntax::AnyJsExportClause::TsExportAsNamespaceClause(_)
+                    | biome_js_syntax::AnyJsExportClause::TsExportAssignmentClause(_)
+                    | biome_js_syntax::AnyJsExportClause::TsExportDeclareClause(_) => {
+                        // Not an export from another module
+                        continue;
+                    }
+                }
+            }
+            biome_js_syntax::AnyJsModuleItem::JsImport(import_item) => {
+                let import_clause = import_item
+                    .import_clause()
+                    .with_context(|| format!("{file}:{line}: failed to parse import statement"))?;
+                import_clause.source()
+            }
+            biome_js_syntax::AnyJsModuleItem::AnyJsStatement(_) => {
+                // Not an import or export statement
+                continue;
+            }
+        };
+
+        let import_source = import_source
+            .with_context(|| format!("{file}:{line}: failed to parse import source"))?;
+        let import_source = import_source
+            .inner_string_text()
+            .with_context(|| format!("{file}:{line}: failed to get import source text"))?;
+        let import_source = import_source.text();
+        let import_specifier: BriocheImportSpecifier = import_source
+            .parse()
+            .with_context(|| format!("{file}:{line}: invalid import specifier"))?;
+
+        let import_analysis = match &import_specifier {
+            BriocheImportSpecifier::Local(local_import) => {
+                let import_module_path = match local_import {
+                    crate::brioche::script::specifier::BriocheLocalImportSpecifier::Relative(
+                        subpath,
+                    ) => module_path
+                        .parent()
+                        .context("invalid module path")?
+                        .join(subpath),
+                    crate::brioche::script::specifier::BriocheLocalImportSpecifier::ProjectRoot(
+                        subpath,
+                    ) => project_path.join(subpath),
+                };
+                anyhow::ensure!(
+                    import_module_path.starts_with(project_path),
+                    "invalid import path: must be within project root",
+                );
+                let import_module_specifier =
+                    analyze_module(&import_module_path, project_path, None, None, local_modules)?;
+                ImportAnalysis::LocalModule(import_module_specifier)
+            }
+            BriocheImportSpecifier::External(dependency) => {
+                ImportAnalysis::ExternalProject(dependency.to_string())
+            }
+        };
+        imports.insert(import_specifier, import_analysis);
+    }
+
+    let local_module = local_modules
+        .get_mut(&module_specifier)
+        .expect("module not found in local_modules after analyzing imports");
+    local_module.imports = imports;
+
+    Ok(module_specifier)
 }
 
 fn expression_to_json(

--- a/crates/brioche/src/brioche/script.rs
+++ b/crates/brioche/src/brioche/script.rs
@@ -7,6 +7,8 @@ use std::{
 use anyhow::Context as _;
 use deno_core::OpState;
 
+use crate::brioche::script::specifier::BriocheImportSpecifier;
+
 use self::specifier::BriocheModuleSpecifier;
 
 use super::{
@@ -52,7 +54,8 @@ impl deno_core::ModuleLoader for BriocheModuleLoader {
         }
 
         let referrer: BriocheModuleSpecifier = referrer.parse()?;
-        let resolved = specifier::resolve(&self.brioche, specifier, &referrer)?;
+        let specifier: BriocheImportSpecifier = specifier.parse()?;
+        let resolved = specifier::resolve(&self.brioche, &specifier, &referrer)?;
 
         tracing::debug!(%specifier, %referrer, %resolved, "resolved module");
 

--- a/crates/brioche/src/brioche/script.rs
+++ b/crates/brioche/src/brioche/script.rs
@@ -6,6 +6,7 @@ use std::{
 
 use anyhow::Context as _;
 use deno_core::OpState;
+use tokio::io::AsyncReadExt as _;
 
 use crate::brioche::script::specifier::BriocheImportSpecifier;
 
@@ -55,7 +56,7 @@ impl deno_core::ModuleLoader for BriocheModuleLoader {
 
         let referrer: BriocheModuleSpecifier = referrer.parse()?;
         let specifier: BriocheImportSpecifier = specifier.parse()?;
-        let resolved = specifier::resolve(&self.brioche, &specifier, &referrer)?;
+        let resolved = specifier::resolve_sync(&self.brioche, &specifier, &referrer)?;
 
         tracing::debug!(%specifier, %referrer, %resolved, "resolved module");
 
@@ -73,13 +74,13 @@ impl deno_core::ModuleLoader for BriocheModuleLoader {
         let sources = self.sources.clone();
         let future = async move {
             let module_specifier = module_specifier?;
-            let Some(mut reader) = specifier::read_specifier_contents_sync(&module_specifier)?
+            let Some(mut reader) = specifier::read_specifier_contents(&module_specifier).await?
             else {
                 anyhow::bail!("file not found for module {module_specifier}");
             };
 
             let mut code = String::new();
-            reader.read_to_string(&mut code)?;
+            reader.read_to_string(&mut code).await?;
 
             let parsed = deno_ast::parse_module(deno_ast::ParseParams {
                 specifier: module_specifier.to_string(),

--- a/crates/brioche/src/brioche/script/compiler_host.rs
+++ b/crates/brioche/src/brioche/script/compiler_host.rs
@@ -10,7 +10,7 @@ use deno_core::OpState;
 
 use crate::brioche::Brioche;
 
-use super::specifier::BriocheModuleSpecifier;
+use super::specifier::{BriocheImportSpecifier, BriocheModuleSpecifier};
 
 #[derive(Clone)]
 pub struct BriocheCompilerHost {
@@ -164,7 +164,8 @@ pub fn op_brioche_resolve_module(
     let compiler_host = brioche_compiler_host_state(state).ok()?;
 
     let referrer: BriocheModuleSpecifier = referrer.parse().ok()?;
-    let resolved = super::specifier::resolve(&compiler_host.brioche, specifier, &referrer).ok()?;
+    let specifier: BriocheImportSpecifier = specifier.parse().ok()?;
+    let resolved = super::specifier::resolve(&compiler_host.brioche, &specifier, &referrer).ok()?;
 
     Some(resolved.to_string())
 }

--- a/crates/brioche/src/brioche/script/specifier.rs
+++ b/crates/brioche/src/brioche/script/specifier.rs
@@ -1,4 +1,5 @@
 use std::{
+    borrow::Cow,
     path::{Path, PathBuf},
     pin::Pin,
 };
@@ -173,6 +174,17 @@ impl std::fmt::Display for BriocheModuleSpecifier {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", url::Url::from(self))
     }
+}
+
+pub fn runtime_specifiers_with_contents(
+) -> impl Iterator<Item = (BriocheModuleSpecifier, Cow<'static, [u8]>)> {
+    crate::brioche::RuntimeFiles::iter().flat_map(|path| {
+        let file = crate::brioche::RuntimeFiles::get(&path)?;
+        let specifier = BriocheModuleSpecifier::Runtime {
+            subpath: RelativePathBuf::from(&*path),
+        };
+        Some((specifier, file.data))
+    })
 }
 
 pub async fn read_specifier_contents(

--- a/crates/brioche/src/brioche/script/specifier.rs
+++ b/crates/brioche/src/brioche/script/specifier.rs
@@ -16,7 +16,7 @@ use crate::{
 
 /// A specifier from an `import` statement in a JavaScript module. Can
 /// be resolved to a module specifier using the `resolve` function.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum BriocheImportSpecifier {
     /// A local import.
     Local(BriocheLocalImportSpecifier),
@@ -80,7 +80,7 @@ impl std::fmt::Display for BriocheLocalImportSpecifier {
 }
 
 /// An `import` specifier referring to a file within the current project.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum BriocheLocalImportSpecifier {
     /// An import relative to the current module. Example: `import "./foo.bri";`
     Relative(String),

--- a/crates/brioche/src/fs_utils.rs
+++ b/crates/brioche/src/fs_utils.rs
@@ -2,6 +2,14 @@ use std::path::Path;
 
 use anyhow::Context as _;
 
+pub async fn is_file(path: &Path) -> bool {
+    let Ok(metadata) = tokio::fs::metadata(path).await else {
+        return false;
+    };
+
+    metadata.is_file()
+}
+
 pub async fn move_file(source: &Path, dest: &Path) -> anyhow::Result<MoveType> {
     let rename_result = tokio::fs::rename(source, dest).await;
 

--- a/crates/brioche/src/fs_utils.rs
+++ b/crates/brioche/src/fs_utils.rs
@@ -10,6 +10,14 @@ pub async fn is_file(path: &Path) -> bool {
     metadata.is_file()
 }
 
+pub async fn is_dir(path: &Path) -> bool {
+    let Ok(metadata) = tokio::fs::metadata(path).await else {
+        return false;
+    };
+
+    metadata.is_dir()
+}
+
 pub async fn move_file(source: &Path, dest: &Path) -> anyhow::Result<MoveType> {
     let rename_result = tokio::fs::rename(source, dest).await;
 

--- a/crates/brioche/src/main.rs
+++ b/crates/brioche/src/main.rs
@@ -10,6 +10,7 @@ enum Args {
     Build(BuildArgs),
     Check(CheckArgs),
     Lsp(LspArgs),
+    Analyze(AnalyzeArgs),
     RunSandbox(RunSandboxArgs),
 }
 
@@ -43,6 +44,15 @@ fn main() -> anyhow::Result<ExitCode> {
                 .build()?;
 
             rt.block_on(lsp(args))?;
+
+            Ok(ExitCode::SUCCESS)
+        }
+        Args::Analyze(args) => {
+            let rt = tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()?;
+
+            rt.block_on(analyze(args))?;
 
             Ok(ExitCode::SUCCESS)
         }
@@ -217,6 +227,18 @@ async fn lsp(_args: LspArgs) -> anyhow::Result<()> {
         .serve(service)
         .await;
 
+    Ok(())
+}
+
+#[derive(Debug, Parser)]
+struct AnalyzeArgs {
+    #[clap(short, long)]
+    project: PathBuf,
+}
+
+async fn analyze(args: AnalyzeArgs) -> anyhow::Result<()> {
+    let project = brioche::brioche::project::analyze::analyze_project(&args.project)?;
+    println!("{project:#?}");
     Ok(())
 }
 

--- a/crates/brioche/tests/script_project_analyze.rs
+++ b/crates/brioche/tests/script_project_analyze.rs
@@ -1,0 +1,247 @@
+use std::collections::HashMap;
+
+use assert_matches::assert_matches;
+use brioche::brioche::{
+    project::{
+        analyze::{analyze_project, ImportAnalysis, ProjectAnalysis},
+        DependencyDefinition, ProjectDefinition, Version,
+    },
+    script::specifier::{BriocheImportSpecifier, BriocheModuleSpecifier},
+};
+
+mod brioche_test;
+
+fn get_local_module(
+    project: &ProjectAnalysis,
+    referrer: &BriocheModuleSpecifier,
+    specifier: &str,
+) -> BriocheModuleSpecifier {
+    let specifier: BriocheImportSpecifier = specifier.parse().expect("invalid import specifier");
+    let Some(referrer_module) = project.local_modules.get(referrer) else {
+        panic!("referrer {referrer} not found as a local module");
+    };
+    let Some(module) = referrer_module.imports.get(&specifier) else {
+        panic!("module {specifier} not found as an import in {referrer}");
+    };
+
+    match module {
+        ImportAnalysis::LocalModule(module) => module.clone(),
+        ImportAnalysis::ExternalProject(_) => panic!("module {specifier} is an external module"),
+    }
+}
+
+#[tokio::test]
+async fn test_analyze_simple_project() -> anyhow::Result<()> {
+    let (_brioche, context) = brioche_test::brioche_test().await;
+
+    let project_dir = context.mkdir("myproject").await;
+    context
+        .write_file(
+            "myproject/project.bri",
+            r#"
+                export const project = {};
+            "#,
+        )
+        .await;
+
+    let project = analyze_project(&project_dir)?;
+
+    assert_eq!(
+        project.definition,
+        ProjectDefinition {
+            dependencies: HashMap::new(),
+        },
+    );
+
+    let root_module = &project.local_modules[&project.root_module];
+    assert!(root_module.imports.is_empty());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_analyze_imports() -> anyhow::Result<()> {
+    let (_brioche, context) = brioche_test::brioche_test().await;
+
+    let project_dir = context.mkdir("myproject").await;
+    context
+        .write_file(
+            "myproject/project.bri",
+            r#"
+                import foo from "./foo.bri";
+                import * from "/bar.bri";
+                export { baz } from "./baz";
+                export * from "/qux";
+                export * as asdf from "./asdf.bri";
+
+                export const project = {};
+            "#,
+        )
+        .await;
+    context
+        .write_file("myproject/foo.bri", "export default 'foo';")
+        .await;
+    context
+        .write_file("myproject/bar.bri", "export const bar = 'bar';")
+        .await;
+    context
+        .write_file("myproject/baz/index.bri", "export const baz = 'baz';")
+        .await;
+    context
+        .write_file("myproject/qux/index.bri", "export const qux = 'qux';")
+        .await;
+    context
+        .write_file("myproject/asdf.bri", "export const asdf = 'asdf';")
+        .await;
+
+    let project = analyze_project(&project_dir)?;
+
+    let root_module = &project.local_modules[&project.root_module];
+    assert_matches!(
+        root_module.imports[&"./foo.bri".parse().unwrap()],
+        ImportAnalysis::LocalModule(_)
+    );
+    assert_matches!(
+        root_module.imports[&"/bar.bri".parse().unwrap()],
+        ImportAnalysis::LocalModule(_)
+    );
+    assert_matches!(
+        root_module.imports[&"./baz".parse().unwrap()],
+        ImportAnalysis::LocalModule(_)
+    );
+    assert_matches!(
+        root_module.imports[&"/qux".parse().unwrap()],
+        ImportAnalysis::LocalModule(_)
+    );
+    assert_matches!(
+        root_module.imports[&"./asdf.bri".parse().unwrap()],
+        ImportAnalysis::LocalModule(_)
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_analyze_nested_imports() -> anyhow::Result<()> {
+    let (_brioche, context) = brioche_test::brioche_test().await;
+
+    let project_dir = context.mkdir("myproject").await;
+    context
+        .write_file(
+            "myproject/project.bri",
+            r#"
+                export { x } from "./foo";
+
+                export const project = {};
+            "#,
+        )
+        .await;
+    context
+        .write_file("myproject/foo/index.bri", "export { x } from '../bar';")
+        .await;
+    context
+        .write_file("myproject/bar/index.bri", "export { x } from '/baz';")
+        .await;
+    context
+        .write_file("myproject/baz/index.bri", "export const x = 'baz';")
+        .await;
+
+    let project = analyze_project(&project_dir)?;
+
+    let foo_module = get_local_module(&project, &project.root_module, "./foo");
+    let bar_module = get_local_module(&project, &foo_module, "../bar");
+    let baz_module = get_local_module(&project, &bar_module, "/baz");
+
+    assert!(project.local_modules[&baz_module].imports.is_empty());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_analyze_import_loop() -> anyhow::Result<()> {
+    let (_brioche, context) = brioche_test::brioche_test().await;
+
+    let project_dir = context.mkdir("myproject").await;
+    context
+        .write_file(
+            "myproject/project.bri",
+            r#"
+                import "./foo.bri";
+                import "./bar.bri";
+
+                export const project = {};
+            "#,
+        )
+        .await;
+    context
+        .write_file(
+            "myproject/foo.bri",
+            r#"
+                import "./bar.bri";
+            "#,
+        )
+        .await;
+    context
+        .write_file(
+            "myproject/bar.bri",
+            r#"
+                import "./foo.bri";
+            "#,
+        )
+        .await;
+
+    let project = analyze_project(&project_dir)?;
+
+    let foo_module_from_root = get_local_module(&project, &project.root_module, "./foo.bri");
+    let bar_module_from_root = get_local_module(&project, &project.root_module, "./bar.bri");
+    let bar_module_from_foo = get_local_module(&project, &foo_module_from_root, "./bar.bri");
+    let foo_module_from_bar = get_local_module(&project, &bar_module_from_root, "./foo.bri");
+
+    assert_eq!(foo_module_from_root, foo_module_from_bar);
+    assert_eq!(bar_module_from_root, bar_module_from_foo);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_analyze_external_dep() -> anyhow::Result<()> {
+    let (_brioche, context) = brioche_test::brioche_test().await;
+
+    let project_dir = context.mkdir("myproject").await;
+    context
+        .write_file(
+            "myproject/project.bri",
+            r#"
+                import "foo";
+
+                export const project = {
+                    dependencies: {
+                        foo: "*",
+                    },
+                };
+            "#,
+        )
+        .await;
+
+    let project = analyze_project(&project_dir)?;
+
+    assert_eq!(
+        project.definition,
+        ProjectDefinition {
+            dependencies: HashMap::from_iter([(
+                "foo".to_string(),
+                DependencyDefinition::Version(Version::Any),
+            ),]),
+        }
+    );
+
+    let root_module = &project.local_modules[&project.root_module];
+    let foo_module = &root_module.imports[&"foo".parse().unwrap()];
+
+    assert_eq!(
+        foo_module,
+        &ImportAnalysis::ExternalProject("foo".to_string())
+    );
+
+    Ok(())
+}

--- a/crates/brioche/tests/script_specifiers.rs
+++ b/crates/brioche/tests/script_specifiers.rs
@@ -1,26 +1,28 @@
 use assert_matches::assert_matches;
 use brioche::brioche::{
     script::specifier::{
-        self, read_specifier_contents_sync, BriocheImportSpecifier, BriocheModuleSpecifier,
+        self, read_specifier_contents, read_specifier_contents_sync, BriocheImportSpecifier,
+        BriocheModuleSpecifier,
     },
     Brioche,
 };
+use tokio::io::AsyncReadExt as _;
 
 mod brioche_test;
 
-fn resolve(
+async fn resolve(
     brioche: &Brioche,
     specifier: &str,
     referrer: &BriocheModuleSpecifier,
 ) -> anyhow::Result<BriocheModuleSpecifier> {
     let specifier: BriocheImportSpecifier = specifier.parse()?;
-    let resolved = specifier::resolve(brioche, &specifier, referrer)?;
+    let resolved = specifier::resolve(brioche, &specifier, referrer).await?;
 
     Ok(resolved)
 }
 
 #[tokio::test]
-async fn test_specifier_read_runtime() -> anyhow::Result<()> {
+async fn test_specifier_read_runtime_sync() -> anyhow::Result<()> {
     let (_brioche, _context) = brioche_test::brioche_test().await;
 
     let specifier: BriocheModuleSpecifier = "briocheruntime:///dist/index.js"
@@ -36,7 +38,51 @@ async fn test_specifier_read_runtime() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+async fn test_specifier_read_runtime() -> anyhow::Result<()> {
+    let (_brioche, _context) = brioche_test::brioche_test().await;
+
+    let specifier: BriocheModuleSpecifier = "briocheruntime:///dist/index.js"
+        .parse()
+        .expect("failed to parse specifier");
+    let mut reader = read_specifier_contents(&specifier)
+        .await?
+        .expect("specifier not found");
+    let mut contents = String::new();
+    reader.read_to_string(&mut contents).await?;
+
+    assert!(!contents.is_empty());
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_specifier_read_project() -> anyhow::Result<()> {
+    let (_brioche, context) = brioche_test::brioche_test().await;
+
+    context
+        .write_file(
+            "myproject/project.bri",
+            r#"
+                export const project = {};
+            "#,
+        )
+        .await;
+    let foo_path = context.write_file("myproject/foo.txt", "Hello world").await;
+
+    let specifier = BriocheModuleSpecifier::from_path(&foo_path);
+    let mut reader = read_specifier_contents(&specifier)
+        .await?
+        .expect("specifier not found");
+    let mut contents = String::new();
+    reader.read_to_string(&mut contents).await?;
+
+    assert_eq!(contents, "Hello world");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_specifier_read_project_sync() -> anyhow::Result<()> {
     let (_brioche, context) = brioche_test::brioche_test().await;
 
     context
@@ -85,19 +131,19 @@ async fn test_specifier_resolve_relative() -> anyhow::Result<()> {
 
     let referrer = BriocheModuleSpecifier::from_path(&foo_hello_path);
 
-    let sibling_specifier = resolve(&brioche, "./test.txt", &referrer)?;
+    let sibling_specifier = resolve(&brioche, "./test.txt", &referrer).await?;
     assert_eq!(
         sibling_specifier,
         BriocheModuleSpecifier::from_path(&foo_test_path),
     );
 
-    let inner_specifier = resolve(&brioche, "./inner/test.txt", &referrer)?;
+    let inner_specifier = resolve(&brioche, "./inner/test.txt", &referrer).await?;
     assert_eq!(
         inner_specifier,
         BriocheModuleSpecifier::from_path(&foo_inner_test_path),
     );
 
-    let outer_specifier = resolve(&brioche, "../test.txt", &referrer)?;
+    let outer_specifier = resolve(&brioche, "../test.txt", &referrer).await?;
     assert_eq!(
         outer_specifier,
         BriocheModuleSpecifier::from_path(&test_path),
@@ -131,19 +177,19 @@ async fn test_specifier_resolve_project_relative() -> anyhow::Result<()> {
 
     let referrer = BriocheModuleSpecifier::from_path(&foo_hello_path);
 
-    let root_specifier = resolve(&brioche, "/test.txt", &referrer)?;
+    let root_specifier = resolve(&brioche, "/test.txt", &referrer).await?;
     assert_eq!(
         root_specifier,
         BriocheModuleSpecifier::from_path(&test_path),
     );
 
-    let foo_specifier = resolve(&brioche, "/foo/test.txt", &referrer)?;
+    let foo_specifier = resolve(&brioche, "/foo/test.txt", &referrer).await?;
     assert_eq!(
         foo_specifier,
         BriocheModuleSpecifier::from_path(&foo_test_path),
     );
 
-    let inner_specifier = resolve(&brioche, "/foo/inner/test.txt", &referrer)?;
+    let inner_specifier = resolve(&brioche, "/foo/inner/test.txt", &referrer).await?;
     assert_eq!(
         inner_specifier,
         BriocheModuleSpecifier::from_path(&foo_inner_test_path),
@@ -174,31 +220,31 @@ async fn test_specifier_resolve_relative_dir() -> anyhow::Result<()> {
 
     let referrer = BriocheModuleSpecifier::from_path(&foo_hello_path);
 
-    let sibling_specifier = resolve(&brioche, "./", &referrer)?;
+    let sibling_specifier = resolve(&brioche, "./", &referrer).await?;
     assert_eq!(
         sibling_specifier,
         BriocheModuleSpecifier::from_path(&foo_main_path),
     );
 
-    let sibling_bare_specifier = resolve(&brioche, ".", &referrer)?;
+    let sibling_bare_specifier = resolve(&brioche, ".", &referrer).await?;
     assert_eq!(
         sibling_bare_specifier,
         BriocheModuleSpecifier::from_path(&foo_main_path),
     );
 
-    let inner_specifier = resolve(&brioche, "./inner", &referrer)?;
+    let inner_specifier = resolve(&brioche, "./inner", &referrer).await?;
     assert_eq!(
         inner_specifier,
         BriocheModuleSpecifier::from_path(&foo_inner_main_path),
     );
 
-    let outer_specifier = resolve(&brioche, "../", &referrer)?;
+    let outer_specifier = resolve(&brioche, "../", &referrer).await?;
     assert_eq!(
         outer_specifier,
         BriocheModuleSpecifier::from_path(&main_path),
     );
 
-    let outer_bare_specifier = resolve(&brioche, "..", &referrer)?;
+    let outer_bare_specifier = resolve(&brioche, "..", &referrer).await?;
     assert_eq!(
         outer_bare_specifier,
         BriocheModuleSpecifier::from_path(&main_path),
@@ -229,25 +275,25 @@ async fn test_specifier_resolve_project_relative_dir() -> anyhow::Result<()> {
 
     let referrer = BriocheModuleSpecifier::from_path(&foo_hello_path);
 
-    let root_specifier = resolve(&brioche, "/", &referrer)?;
+    let root_specifier = resolve(&brioche, "/", &referrer).await?;
     assert_eq!(
         root_specifier,
         BriocheModuleSpecifier::from_path(&main_path),
     );
 
-    let foo_specifier = resolve(&brioche, "/foo/", &referrer)?;
+    let foo_specifier = resolve(&brioche, "/foo/", &referrer).await?;
     assert_eq!(
         foo_specifier,
         BriocheModuleSpecifier::from_path(&foo_main_path),
     );
 
-    let foo_bare_specifier = resolve(&brioche, "/foo", &referrer)?;
+    let foo_bare_specifier = resolve(&brioche, "/foo", &referrer).await?;
     assert_eq!(
         foo_bare_specifier,
         BriocheModuleSpecifier::from_path(&foo_main_path),
     );
 
-    let inner_specifier = resolve(&brioche, "/foo/inner", &referrer)?;
+    let inner_specifier = resolve(&brioche, "/foo/inner", &referrer).await?;
     assert_eq!(
         inner_specifier,
         BriocheModuleSpecifier::from_path(&foo_inner_main_path),
@@ -315,7 +361,7 @@ async fn test_specifier_resolve_subproject() -> anyhow::Result<()> {
 
     let referrer = BriocheModuleSpecifier::from_path(&bar_file_path);
 
-    let baz_specifier = resolve(&brioche, "baz", &referrer)?;
+    let baz_specifier = resolve(&brioche, "baz", &referrer).await?;
     assert_eq!(
         baz_specifier,
         BriocheModuleSpecifier::from_path(&baz_main_path),
@@ -323,10 +369,10 @@ async fn test_specifier_resolve_subproject() -> anyhow::Result<()> {
 
     // Resolving paths under a dependency is not allowed
 
-    let baz_file_specifier = resolve(&brioche, "baz/file.txt", &referrer);
+    let baz_file_specifier = resolve(&brioche, "baz/file.txt", &referrer).await;
     assert_matches!(baz_file_specifier, Err(_));
 
-    let baz_inner_specifier = resolve(&brioche, "baz/inner/file.txt", &referrer);
+    let baz_inner_specifier = resolve(&brioche, "baz/inner/file.txt", &referrer).await;
     assert_matches!(baz_inner_specifier, Err(_));
 
     Ok(())

--- a/crates/brioche/tests/script_specifiers.rs
+++ b/crates/brioche/tests/script_specifiers.rs
@@ -1,9 +1,23 @@
 use assert_matches::assert_matches;
-use brioche::brioche::script::specifier::{
-    read_specifier_contents_sync, resolve, BriocheModuleSpecifier,
+use brioche::brioche::{
+    script::specifier::{
+        self, read_specifier_contents_sync, BriocheImportSpecifier, BriocheModuleSpecifier,
+    },
+    Brioche,
 };
 
 mod brioche_test;
+
+fn resolve(
+    brioche: &Brioche,
+    specifier: &str,
+    referrer: &BriocheModuleSpecifier,
+) -> anyhow::Result<BriocheModuleSpecifier> {
+    let specifier: BriocheImportSpecifier = specifier.parse()?;
+    let resolved = specifier::resolve(brioche, &specifier, referrer)?;
+
+    Ok(resolved)
+}
 
 #[tokio::test]
 async fn test_specifier_read_runtime() -> anyhow::Result<()> {


### PR DESCRIPTION
This PR overhauls the "project analysis" phase to find all imported file paths ahead-of-time. This doesn't have much impact on functionality, but it will be important for things like "format all files in this project".

One outcome of this PR that is an improvement though: the TypeScript Language Service Host no longer does blocking I/O to read files! 🎉 This is because we now asynchronously load documents into the `BriocheCompilerHost` type before calling into the TypeScript code. Then, the TypeScript code uses Deno ops that just read from `BriocheCompilerHost`, and assume that the documents have already been loaded asynchronously.

There are still some instances of blocking I/O-- namely when resolving import specifiers-- but it'll take some more work to fix those cases.