### PR TITLE
Replace `remove` lazy artifact with `insert`

### DIFF
--- a/crates/brioche/src/brioche/artifact.rs
+++ b/crates/brioche/src/brioche/artifact.rs
@@ -74,10 +74,11 @@ pub enum LazyArtifact {
         path: BString,
     },
     #[serde(rename_all = "camelCase")]
-    Remove {
+    Insert {
         directory: Box<WithMeta<LazyArtifact>>,
-        #[serde_as(as = "Vec<UrlEncoded>")]
-        paths: Vec<BString>,
+        #[serde_as(as = "UrlEncoded")]
+        path: BString,
+        artifact: Option<Box<WithMeta<LazyArtifact>>>,
     },
     #[serde(rename_all = "camelCase")]
     SetPermissions {
@@ -528,7 +529,7 @@ impl TryFrom<LazyArtifact> for CompleteArtifact {
             | LazyArtifact::Merge { .. }
             | LazyArtifact::Peel { .. }
             | LazyArtifact::Get { .. }
-            | LazyArtifact::Remove { .. }
+            | LazyArtifact::Insert { .. }
             | LazyArtifact::SetPermissions { .. }
             | LazyArtifact::Proxy { .. } => Err(ArtifactIncomplete),
         }


### PR DESCRIPTION
This PR replaces the `remove` artifact with `insert`. "Removal" is now handled by inserting a value of `null`, meaning this new `insert` artifact is strictly more general.