### PR TITLE
Show summary line during build

### DIFF
--- a/crates/brioche/src/main.rs
+++ b/crates/brioche/src/main.rs
@@ -3,6 +3,7 @@ use std::{path::PathBuf, process::ExitCode};
 use anyhow::Context as _;
 use brioche::{fs_utils, sandbox::SandboxExecutionConfig};
 use clap::Parser;
+use human_repr::HumanDuration;
 use tracing::Instrument;
 
 #[derive(Debug, Parser)]
@@ -137,6 +138,15 @@ async fn build(args: BuildArgs) -> anyhow::Result<ExitCode> {
         let result = brioche::brioche::resolve::resolve(&brioche, artifact).await?;
 
         guard.shutdown_console().await;
+
+        let elapsed = reporter.elapsed().human_duration();
+        let num_jobs = reporter.num_jobs();
+        let jobs_message = match num_jobs {
+            0 => "(no new jobs)".to_string(),
+            1 => "1 job".to_string(),
+            n => format!("{n} jobs"),
+        };
+        println!("Build finished, completed {jobs_message} in {elapsed}");
 
         let result_hash = result.value.hash();
         println!("Result: {result_hash}");

--- a/crates/brioche/src/main.rs
+++ b/crates/brioche/src/main.rs
@@ -98,6 +98,7 @@ struct BuildArgs {
 
 async fn build(args: BuildArgs) -> anyhow::Result<ExitCode> {
     let (reporter, mut guard) = brioche::reporter::start_console_reporter()?;
+    reporter.set_is_evaluating(true);
 
     let brioche = brioche::brioche::BriocheBuilder::new(reporter.clone())
         .keep_temps(args.keep)
@@ -131,6 +132,8 @@ async fn build(args: BuildArgs) -> anyhow::Result<ExitCode> {
 
         let artifact =
             brioche::brioche::script::evaluate::evaluate(&brioche, &project, &args.export).await?;
+
+        reporter.set_is_evaluating(false);
         let result = brioche::brioche::resolve::resolve(&brioche, artifact).await?;
 
         guard.shutdown_console().await;

--- a/crates/brioche/src/reporter.rs
+++ b/crates/brioche/src/reporter.rs
@@ -812,11 +812,24 @@ impl superconsole::Component for JobsComponent {
             .take(num_terminal_lines);
 
         let elapsed = self.start.elapsed().human_duration();
-        let summary_line = format!(
-            "[{elapsed}] {num_complete_jobs} / {num_jobs}{or_more} job{s} complete",
-            s = if num_jobs == 1 { "" } else { "s" },
-            or_more = if is_evaluating { "+" } else { "" },
-        );
+        let summary_line = match mode {
+            superconsole::DrawMode::Normal => {
+                format!(
+                    "[{elapsed}] {num_complete_jobs} / {num_jobs}{or_more} job{s} complete",
+                    s = if num_jobs == 1 { "" } else { "s" },
+                    or_more = if is_evaluating { "+" } else { "" },
+                )
+            }
+            superconsole::DrawMode::Final => {
+                let jobs_message = match num_jobs {
+                    0 => "(no new jobs)".to_string(),
+                    1 => "1 job".to_string(),
+                    n => format!("{n} jobs"),
+                };
+                format!("Build finished, completed {jobs_message} in {elapsed}")
+            }
+        };
+
         let summary_line = superconsole::Line::from_iter([summary_line.try_into().unwrap()]);
 
         let lines = terminal_lines


### PR DESCRIPTION
This PR adds a summary line during builds, showing the total elapsed time as well as the total number of in-progress / complete jobs:

![Terminal screenshot showing the line "3.24 seconds, 80 / 100 jobs complete"](https://github.com/brioche-dev/brioche/assets/1362179/2452c2bb-0ed3-494a-b227-e63fb739ba10)

A final summary is also shown once a build completes (this will be printed even when not using the fancier SuperConsole output).