### PR TITLE
Update `Directory` artifacts to use blobs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -759,6 +759,7 @@ dependencies = [
  "libmount",
  "mockito",
  "nix 0.27.1",
+ "olpc-cjson",
  "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-jaeger",
@@ -2821,6 +2822,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cf5f9dd3933bd50a9e1f149ec995f39ae2c496d31fd772c1fd45ebc27e902b0"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "olpc-cjson"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d637c9c15b639ccff597da8f4fa968300651ad2f1e968aefc3b4927a6fb2027a"
+dependencies = [
+ "serde",
+ "serde_json",
+ "unicode-normalization",
 ]
 
 [[package]]

--- a/crates/brioche/Cargo.toml
+++ b/crates/brioche/Cargo.toml
@@ -30,6 +30,7 @@ human-repr = "1.1.0"
 joinery = "3.1.0"
 libmount = "0.1.15"
 nix = { version = "0.27.1", features = ["user"] }
+olpc-cjson = "0.1.3"
 opentelemetry = "0.21.0"
 opentelemetry-http = { version = "0.10.0", features = ["reqwest"] }
 opentelemetry-jaeger = "0.20.0"

--- a/crates/brioche/benches/brioche_bench/mod.rs
+++ b/crates/brioche/benches/brioche_bench/mod.rs
@@ -46,7 +46,7 @@ pub async fn blob(brioche: &Brioche, content: impl AsRef<[u8]> + std::marker::Un
 
 pub fn lazy_file(blob: BlobId, executable: bool) -> brioche::brioche::artifact::LazyArtifact {
     brioche::brioche::artifact::LazyArtifact::File {
-        data: blob,
+        content_blob: blob,
         executable,
         resources: Box::new(WithMeta::without_meta(
             brioche::brioche::artifact::LazyArtifact::Directory(Directory::default()),
@@ -56,7 +56,7 @@ pub fn lazy_file(blob: BlobId, executable: bool) -> brioche::brioche::artifact::
 
 pub fn file(blob: BlobId, executable: bool) -> brioche::brioche::artifact::CompleteArtifact {
     brioche::brioche::artifact::CompleteArtifact::File(File {
-        data: blob,
+        content_blob: blob,
         executable,
         resources: Directory::default(),
     })
@@ -68,7 +68,7 @@ pub fn file_with_resources(
     resources: brioche::brioche::artifact::Directory,
 ) -> brioche::brioche::artifact::CompleteArtifact {
     brioche::brioche::artifact::CompleteArtifact::File(File {
-        data: blob,
+        content_blob: blob,
         executable,
         resources,
     })

--- a/crates/brioche/benches/brioche_bench/mod.rs
+++ b/crates/brioche/benches/brioche_bench/mod.rs
@@ -39,8 +39,7 @@ pub async fn brioche_test() -> (Brioche, TestContext) {
 }
 
 pub async fn blob(brioche: &Brioche, content: impl AsRef<[u8]> + std::marker::Unpin) -> BlobId {
-    let mut cursor = std::io::Cursor::new(content);
-    brioche::brioche::blob::save_blob_from_reader(brioche, &mut cursor, SaveBlobOptions::default())
+    brioche::brioche::blob::save_blob(brioche, content.as_ref(), SaveBlobOptions::default())
         .await
         .unwrap()
 }

--- a/crates/brioche/benches/brioche_bench/mod.rs
+++ b/crates/brioche/benches/brioche_bench/mod.rs
@@ -40,7 +40,7 @@ pub async fn brioche_test() -> (Brioche, TestContext) {
 
 pub async fn blob(brioche: &Brioche, content: impl AsRef<[u8]> + std::marker::Unpin) -> BlobId {
     let mut cursor = std::io::Cursor::new(content);
-    brioche::brioche::blob::save_blob(brioche, &mut cursor, SaveBlobOptions::default())
+    brioche::brioche::blob::save_blob_from_reader(brioche, &mut cursor, SaveBlobOptions::default())
         .await
         .unwrap()
 }

--- a/crates/brioche/benches/brioche_bench/mod.rs
+++ b/crates/brioche/benches/brioche_bench/mod.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use brioche::brioche::{
-    artifact::{Directory, DirectoryListing, File, LazyDirectory, WithMeta},
+    artifact::{CreateDirectory, Directory, DirectoryListing, File, WithMeta},
     blob::{BlobId, SaveBlobOptions},
     Brioche, BriocheBuilder,
 };
@@ -78,7 +78,7 @@ pub fn lazy_dir<K: AsRef<[u8]>>(
     entries: impl IntoIterator<Item = (K, brioche::brioche::artifact::LazyArtifact)>,
 ) -> WithMeta<brioche::brioche::artifact::LazyArtifact> {
     WithMeta::without_meta(brioche::brioche::artifact::LazyArtifact::CreateDirectory(
-        LazyDirectory {
+        CreateDirectory {
             entries: entries
                 .into_iter()
                 .map(|(k, v)| (k.as_ref().into(), WithMeta::without_meta(v)))
@@ -116,7 +116,7 @@ pub async fn dir<K: AsRef<[u8]>>(
 }
 
 pub fn lazy_dir_empty() -> brioche::brioche::artifact::LazyArtifact {
-    brioche::brioche::artifact::LazyArtifact::CreateDirectory(LazyDirectory::default())
+    brioche::brioche::artifact::LazyArtifact::CreateDirectory(CreateDirectory::default())
 }
 
 pub fn dir_empty() -> brioche::brioche::artifact::CompleteArtifact {

--- a/crates/brioche/benches/brioche_bench/mod.rs
+++ b/crates/brioche/benches/brioche_bench/mod.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use brioche::brioche::{
-    artifact::{Directory, File, LazyDirectory, WithMeta},
+    artifact::{Directory, DirectoryListing, File, LazyDirectory, WithMeta},
     blob::{BlobId, SaveBlobOptions},
     Brioche, BriocheBuilder,
 };
@@ -49,7 +49,9 @@ pub fn lazy_file(blob: BlobId, executable: bool) -> brioche::brioche::artifact::
     brioche::brioche::artifact::LazyArtifact::File {
         data: blob,
         executable,
-        resources: LazyDirectory::default(),
+        resources: Box::new(WithMeta::without_meta(
+            brioche::brioche::artifact::LazyArtifact::Directory(Directory::default()),
+        )),
     }
 }
 
@@ -76,7 +78,7 @@ pub fn file_with_resources(
 pub fn lazy_dir<K: AsRef<[u8]>>(
     entries: impl IntoIterator<Item = (K, brioche::brioche::artifact::LazyArtifact)>,
 ) -> WithMeta<brioche::brioche::artifact::LazyArtifact> {
-    WithMeta::without_meta(brioche::brioche::artifact::LazyArtifact::Directory(
+    WithMeta::without_meta(brioche::brioche::artifact::LazyArtifact::CreateDirectory(
         LazyDirectory {
             entries: entries
                 .into_iter()
@@ -86,27 +88,36 @@ pub fn lazy_dir<K: AsRef<[u8]>>(
     ))
 }
 
-pub fn dir_value<K: AsRef<[u8]>>(
+pub fn empty_dir_value() -> brioche::brioche::artifact::Directory {
+    brioche::brioche::artifact::Directory::default()
+}
+
+pub async fn dir_value<K: AsRef<[u8]>>(
+    brioche: &Brioche,
     entries: impl IntoIterator<Item = (K, brioche::brioche::artifact::CompleteArtifact)>,
 ) -> brioche::brioche::artifact::Directory {
-    let mut directory = Directory::default();
+    let mut listing = DirectoryListing::default();
     for (k, v) in entries {
-        directory
-            .insert(k.as_ref(), WithMeta::without_meta(v))
+        listing
+            .insert(brioche, k.as_ref(), Some(WithMeta::without_meta(v)))
+            .await
             .expect("failed to insert into dir");
     }
 
-    directory
+    Directory::create(brioche, &listing)
+        .await
+        .expect("failed to create dir")
 }
 
-pub fn dir<K: AsRef<[u8]>>(
+pub async fn dir<K: AsRef<[u8]>>(
+    brioche: &Brioche,
     entries: impl IntoIterator<Item = (K, brioche::brioche::artifact::CompleteArtifact)>,
 ) -> brioche::brioche::artifact::CompleteArtifact {
-    brioche::brioche::artifact::CompleteArtifact::Directory(dir_value(entries))
+    brioche::brioche::artifact::CompleteArtifact::Directory(dir_value(brioche, entries).await)
 }
 
 pub fn lazy_dir_empty() -> brioche::brioche::artifact::LazyArtifact {
-    brioche::brioche::artifact::LazyArtifact::Directory(LazyDirectory::default())
+    brioche::brioche::artifact::LazyArtifact::CreateDirectory(LazyDirectory::default())
 }
 
 pub fn dir_empty() -> brioche::brioche::artifact::CompleteArtifact {

--- a/crates/brioche/src/brioche/artifact.rs
+++ b/crates/brioche/src/brioche/artifact.rs
@@ -667,7 +667,7 @@ impl ArtifactHash {
     /// are made to the artifact schema, this prefix will be changed to ensure
     /// that we don't accidentally match a former artifact hash that has the
     /// same binary representation.
-    const VERSION_PREFIX: &'static [u8] = b"v0              ";
+    const VERSION_PREFIX: &'static [u8] = b"v0.0.1          ";
 
     fn from_serializable<V>(value: &V) -> anyhow::Result<Self>
     where

--- a/crates/brioche/src/brioche/artifact.rs
+++ b/crates/brioche/src/brioche/artifact.rs
@@ -360,8 +360,7 @@ impl Directory {
         listing.serialize(&mut serializer)?;
 
         let tree_blob_id =
-            blob::save_blob_from_bytes(brioche, &listing_json, blob::SaveBlobOptions::default())
-                .await?;
+            blob::save_blob(brioche, &listing_json, blob::SaveBlobOptions::default()).await?;
 
         Ok(Self {
             tree: Some(tree_blob_id),

--- a/crates/brioche/src/brioche/artifact.rs
+++ b/crates/brioche/src/brioche/artifact.rs
@@ -59,7 +59,7 @@ pub enum LazyArtifact {
         resources: Box<WithMeta<LazyArtifact>>,
     },
     #[serde(rename_all = "camelCase")]
-    CreateDirectory(LazyDirectory),
+    CreateDirectory(CreateDirectory),
     #[serde(rename_all = "camelCase")]
     Cast {
         artifact: Box<WithMeta<LazyArtifact>>,
@@ -239,12 +239,12 @@ impl std::fmt::Display for StackFrame {
 #[serde_with::serde_as]
 #[derive(Debug, Clone, Default, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct LazyDirectory {
+pub struct CreateDirectory {
     #[serde_as(as = "BTreeMap<UrlEncoded, _>")]
     pub entries: BTreeMap<BString, WithMeta<LazyArtifact>>,
 }
 
-impl LazyDirectory {
+impl CreateDirectory {
     pub fn is_empty(&self) -> bool {
         self.entries.is_empty()
     }

--- a/crates/brioche/src/brioche/blob.rs
+++ b/crates/brioche/src/brioche/blob.rs
@@ -8,8 +8,88 @@ use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
 
 use super::{Brioche, Hash};
 
+#[tracing::instrument(skip(brioche, options), err)]
+pub async fn save_blob<'a>(
+    brioche: &Brioche,
+    bytes: &[u8],
+    options: SaveBlobOptions<'a>,
+) -> anyhow::Result<BlobId> {
+    let mut hasher = blake3::Hasher::new();
+    let mut validation_hashing = options
+        .expected_hash
+        .as_ref()
+        .map(|validate_hash| (validate_hash, super::Hasher::for_hash(validate_hash)));
+
+    hasher.update(bytes);
+
+    if let Some((_, validate_hasher)) = &mut validation_hashing {
+        validate_hasher.update(bytes);
+    }
+
+    let hash = hasher.finalize();
+    let id = BlobId(hash);
+    let blob_path = blob_path(brioche, id);
+
+    if let Some((expected_hash, validate_hasher)) = validation_hashing {
+        let actual_hash = validate_hasher.finish()?;
+
+        if *expected_hash != actual_hash {
+            anyhow::bail!("expected hash {} but got {}", expected_hash, actual_hash);
+        }
+
+        let expected_hash_string = expected_hash.to_string();
+        let blob_id_string = id.to_string();
+
+        let mut db_conn = brioche.db_conn.lock().await;
+        sqlx::query!(
+            r"
+                INSERT INTO blob_aliases (hash, blob_id) VALUES (?, ?)
+                ON CONFLICT (hash) DO UPDATE SET blob_id = ?
+            ",
+            expected_hash_string,
+            blob_id_string,
+            blob_id_string,
+        )
+        .execute(&mut *db_conn)
+        .await?;
+        drop(db_conn);
+    }
+
+    if let Some(parent) = blob_path.parent() {
+        tokio::fs::create_dir_all(&parent)
+            .await
+            .with_context(|| format!("failed to create directory {}", parent.display()))?;
+    }
+
+    if tokio::fs::try_exists(&blob_path).await? {
+        return Ok(id);
+    }
+
+    let temp_dir = brioche.home.join("blobs-temp");
+    tokio::fs::create_dir_all(&temp_dir).await.unwrap();
+    let temp_path = temp_dir.join(ulid::Ulid::new().to_string());
+
+    let mut temp_file = tokio::fs::File::create(&temp_path)
+        .await
+        .context("failed to open temp file")?;
+    temp_file
+        .write_all(bytes)
+        .await
+        .context("failed to write blob to temp file")?;
+    temp_file
+        .set_permissions(blob_permissions())
+        .await
+        .context("failed to set blob permissions")?;
+
+    tokio::fs::rename(&temp_path, &blob_path)
+        .await
+        .context("failed to rename blob from temp file")?;
+
+    Ok(id)
+}
+
 #[tracing::instrument(skip(brioche, input, options))]
-pub async fn save_blob<'a, R>(
+pub async fn save_blob_from_reader<'a, R>(
     brioche: &Brioche,
     mut input: R,
     mut options: SaveBlobOptions<'a>,
@@ -100,86 +180,6 @@ where
         .set_permissions(blob_permissions())
         .await
         .context("failed to set blob permissions")?;
-    tokio::fs::rename(&temp_path, &blob_path)
-        .await
-        .context("failed to rename blob from temp file")?;
-
-    Ok(id)
-}
-
-#[tracing::instrument(skip(brioche, options), err)]
-pub async fn save_blob_from_bytes<'a>(
-    brioche: &Brioche,
-    bytes: &[u8],
-    options: SaveBlobOptions<'a>,
-) -> anyhow::Result<BlobId> {
-    let mut hasher = blake3::Hasher::new();
-    let mut validation_hashing = options
-        .expected_hash
-        .as_ref()
-        .map(|validate_hash| (validate_hash, super::Hasher::for_hash(validate_hash)));
-
-    hasher.update(bytes);
-
-    if let Some((_, validate_hasher)) = &mut validation_hashing {
-        validate_hasher.update(bytes);
-    }
-
-    let hash = hasher.finalize();
-    let id = BlobId(hash);
-    let blob_path = blob_path(brioche, id);
-
-    if let Some((expected_hash, validate_hasher)) = validation_hashing {
-        let actual_hash = validate_hasher.finish()?;
-
-        if *expected_hash != actual_hash {
-            anyhow::bail!("expected hash {} but got {}", expected_hash, actual_hash);
-        }
-
-        let expected_hash_string = expected_hash.to_string();
-        let blob_id_string = id.to_string();
-
-        let mut db_conn = brioche.db_conn.lock().await;
-        sqlx::query!(
-            r"
-                INSERT INTO blob_aliases (hash, blob_id) VALUES (?, ?)
-                ON CONFLICT (hash) DO UPDATE SET blob_id = ?
-            ",
-            expected_hash_string,
-            blob_id_string,
-            blob_id_string,
-        )
-        .execute(&mut *db_conn)
-        .await?;
-        drop(db_conn);
-    }
-
-    if let Some(parent) = blob_path.parent() {
-        tokio::fs::create_dir_all(&parent)
-            .await
-            .with_context(|| format!("failed to create directory {}", parent.display()))?;
-    }
-
-    if tokio::fs::try_exists(&blob_path).await? {
-        return Ok(id);
-    }
-
-    let temp_dir = brioche.home.join("blobs-temp");
-    tokio::fs::create_dir_all(&temp_dir).await.unwrap();
-    let temp_path = temp_dir.join(ulid::Ulid::new().to_string());
-
-    let mut temp_file = tokio::fs::File::create(&temp_path)
-        .await
-        .context("failed to open temp file")?;
-    temp_file
-        .write_all(bytes)
-        .await
-        .context("failed to write blob to temp file")?;
-    temp_file
-        .set_permissions(blob_permissions())
-        .await
-        .context("failed to set blob permissions")?;
-
     tokio::fs::rename(&temp_path, &blob_path)
         .await
         .context("failed to rename blob from temp file")?;

--- a/crates/brioche/src/brioche/input.rs
+++ b/crates/brioche/src/brioche/input.rs
@@ -154,7 +154,7 @@ pub async fn create_input(
 
         Ok(WithMeta::new(
             CompleteArtifact::File(File {
-                data: blob_id,
+                content_blob: blob_id,
                 executable,
                 resources,
             }),

--- a/crates/brioche/src/brioche/input.rs
+++ b/crates/brioche/src/brioche/input.rs
@@ -4,7 +4,7 @@ use anyhow::Context as _;
 use bstr::{ByteSlice as _, ByteVec as _};
 
 use super::{
-    artifact::{CompleteArtifact, Directory, File, Meta, WithMeta},
+    artifact::{CompleteArtifact, Directory, DirectoryListing, File, Meta, WithMeta},
     Brioche,
 };
 
@@ -50,7 +50,7 @@ pub async fn create_input(
                 let pack_paths = pack.iter().flat_map(|pack| pack.paths());
 
                 let mut pack_paths: Vec<_> = pack_paths.collect();
-                let mut resources = Directory::default();
+                let mut resources = DirectoryListing::default();
                 while let Some(pack_path) = pack_paths.pop() {
                     let path = pack_path.to_path().context("invalid resource path")?;
                     let resource_path = resources_dir.join(path);
@@ -75,7 +75,9 @@ pub async fn create_input(
                         .await?;
 
                         tracing::debug!(resource = %resource_path.display(), "found resource");
-                        resources.insert(&pack_path, resource)?;
+                        resources
+                            .insert(brioche, &pack_path, Some(resource))
+                            .await?;
 
                         // Add the symlink's target to the resources dir as well
                         if resource_metadata.is_symlink() {
@@ -137,8 +139,9 @@ pub async fn create_input(
 
                 resources
             }
-            None => Directory::default(),
+            None => DirectoryListing::default(),
         };
+        let resources = Directory::create(brioche, &resources).await?;
 
         let blob_id = super::blob::save_blob_from_file(
             brioche,
@@ -164,7 +167,7 @@ pub async fn create_input(
                 format!("failed to read directory {}", options.input_path.display())
             })?;
 
-        let mut result_dir = Directory::default();
+        let mut result_dir = DirectoryListing::default();
 
         while let Some(entry) = dir.next_entry().await? {
             let entry_name = <Vec<u8> as bstr::ByteVec>::from_os_string(entry.file_name())
@@ -200,6 +203,7 @@ pub async fn create_input(
                 })?;
         }
 
+        let result_dir = Directory::create(brioche, &result_dir).await?;
         Ok(WithMeta::new(
             CompleteArtifact::Directory(result_dir),
             options.meta.clone(),

--- a/crates/brioche/src/brioche/output.rs
+++ b/crates/brioche/src/brioche/output.rs
@@ -24,7 +24,7 @@ pub async fn create_output<'a: 'async_recursion>(
 ) -> anyhow::Result<()> {
     match artifact {
         CompleteArtifact::File(File {
-            data,
+            content_blob,
             executable,
             resources,
         }) => {
@@ -45,7 +45,7 @@ pub async fn create_output<'a: 'async_recursion>(
                 .await?;
             }
 
-            let blob_path = super::blob::blob_path(brioche, *data);
+            let blob_path = super::blob::blob_path(brioche, *content_blob);
             tokio::fs::copy(&blob_path, options.output_path)
                 .await
                 .with_context(|| {

--- a/crates/brioche/src/brioche/output.rs
+++ b/crates/brioche/src/brioche/output.rs
@@ -4,7 +4,7 @@ use anyhow::Context as _;
 use bstr::ByteSlice;
 
 use super::{
-    artifact::{CompleteArtifact, Directory, File},
+    artifact::{CompleteArtifact, File},
     Brioche,
 };
 
@@ -77,7 +77,7 @@ pub async fn create_output<'a: 'async_recursion>(
                     )
                 })?;
         }
-        CompleteArtifact::Directory(Directory { entries }) => {
+        CompleteArtifact::Directory(directory) => {
             let result = tokio::fs::create_dir(options.output_path).await;
 
             match result {
@@ -94,7 +94,9 @@ pub async fn create_output<'a: 'async_recursion>(
                 }
             }
 
-            for (path, entry) in entries {
+            let listing = directory.listing(brioche).await?;
+
+            for (path, entry) in listing.entries {
                 let path = bytes_to_path_component(path.as_bstr())?;
                 let entry_path = options.output_path.join(path);
                 let resources_dir_buf;

--- a/crates/brioche/src/brioche/resolve.rs
+++ b/crates/brioche/src/brioche/resolve.rs
@@ -9,8 +9,8 @@ use tracing::Instrument as _;
 
 use super::{
     artifact::{
-        ArtifactHash, CompleteArtifact, CompleteArtifactDiscriminants, Directory, DirectoryListing,
-        File, LazyArtifact, LazyDirectory, Meta, WithMeta,
+        ArtifactHash, CompleteArtifact, CompleteArtifactDiscriminants, CreateDirectory, Directory,
+        DirectoryListing, File, LazyArtifact, Meta, WithMeta,
     },
     Brioche,
 };
@@ -249,7 +249,7 @@ async fn resolve_inner(
                 resources,
             }))
         }
-        LazyArtifact::CreateDirectory(LazyDirectory { entries }) => {
+        LazyArtifact::CreateDirectory(CreateDirectory { entries }) => {
             let entries = entries
                 .into_iter()
                 .map(|(path, entry)| {

--- a/crates/brioche/src/brioche/resolve.rs
+++ b/crates/brioche/src/brioche/resolve.rs
@@ -234,12 +234,9 @@ async fn resolve_inner(
             executable,
             resources,
         } => {
-            let blob_id = super::blob::save_blob_from_reader(
-                brioche,
-                &**data,
-                super::blob::SaveBlobOptions::default(),
-            )
-            .await?;
+            let blob_id =
+                super::blob::save_blob(brioche, &data, super::blob::SaveBlobOptions::default())
+                    .await?;
 
             let resources = resolve(brioche, *resources).await?;
             let CompleteArtifact::Directory(resources) = resources.value else {

--- a/crates/brioche/src/brioche/resolve.rs
+++ b/crates/brioche/src/brioche/resolve.rs
@@ -189,7 +189,7 @@ async fn resolve_inner(
 ) -> anyhow::Result<CompleteArtifact> {
     match artifact {
         LazyArtifact::File {
-            data,
+            content_blob,
             executable,
             resources,
         } => {
@@ -198,7 +198,7 @@ async fn resolve_inner(
                 anyhow::bail!("file resources resolved to non-directory value");
             };
             Ok(CompleteArtifact::File(File {
-                data,
+                content_blob,
                 executable,
                 resources,
             }))
@@ -230,12 +230,12 @@ async fn resolve_inner(
             Ok(result)
         }
         LazyArtifact::CreateFile {
-            data,
+            content,
             executable,
             resources,
         } => {
             let blob_id =
-                super::blob::save_blob(brioche, &data, super::blob::SaveBlobOptions::default())
+                super::blob::save_blob(brioche, &content, super::blob::SaveBlobOptions::default())
                     .await?;
 
             let resources = resolve(brioche, *resources).await?;
@@ -244,7 +244,7 @@ async fn resolve_inner(
             };
 
             Ok(CompleteArtifact::File(File {
-                data: blob_id,
+                content_blob: blob_id,
                 executable,
                 resources,
             }))

--- a/crates/brioche/src/brioche/resolve.rs
+++ b/crates/brioche/src/brioche/resolve.rs
@@ -234,9 +234,12 @@ async fn resolve_inner(
             executable,
             resources,
         } => {
-            let blob_id =
-                super::blob::save_blob(brioche, &**data, super::blob::SaveBlobOptions::default())
-                    .await?;
+            let blob_id = super::blob::save_blob_from_reader(
+                brioche,
+                &**data,
+                super::blob::SaveBlobOptions::default(),
+            )
+            .await?;
 
             let resources = resolve(brioche, *resources).await?;
             let CompleteArtifact::Directory(resources) = resources.value else {

--- a/crates/brioche/src/brioche/resolve/download.rs
+++ b/crates/brioche/src/brioche/resolve/download.rs
@@ -72,7 +72,7 @@ pub async fn resolve_download(
     );
 
     Ok(File {
-        data: blob_id,
+        content_blob: blob_id,
         executable: false,
         resources: Directory::default(),
     })

--- a/crates/brioche/src/brioche/resolve/download.rs
+++ b/crates/brioche/src/brioche/resolve/download.rs
@@ -59,9 +59,10 @@ pub async fn resolve_download(
             Ok(())
         });
 
-    let blob_id = crate::brioche::blob::save_blob(brioche, download_stream, save_blob_options)
-        .await
-        .context("failed to save blob")?;
+    let blob_id =
+        crate::brioche::blob::save_blob_from_reader(brioche, download_stream, save_blob_options)
+            .await
+            .context("failed to save blob")?;
 
     brioche.reporter.update_job(
         job_id,

--- a/crates/brioche/src/brioche/resolve/unpack.rs
+++ b/crates/brioche/src/brioche/resolve/unpack.rs
@@ -19,7 +19,11 @@ pub async fn resolve_unpack(
     unpack: UnpackArtifact,
 ) -> anyhow::Result<Directory> {
     let file = super::resolve(brioche, *unpack.file).await?;
-    let CompleteArtifact::File(File { data: blob_id, .. }) = file.value else {
+    let CompleteArtifact::File(File {
+        content_blob: blob_id,
+        ..
+    }) = file.value
+    else {
         anyhow::bail!("expected archive to be a file");
     };
 
@@ -62,7 +66,7 @@ pub async fn resolve_unpack(
                     let executable = entry_mode & 0o100 != 0;
 
                     CompleteArtifact::File(File {
-                        data: entry_blob_id,
+                        content_blob: entry_blob_id,
                         executable,
                         resources: Directory::default(),
                     })

--- a/crates/brioche/src/brioche/resolve/unpack.rs
+++ b/crates/brioche/src/brioche/resolve/unpack.rs
@@ -53,7 +53,7 @@ pub async fn resolve_unpack(
 
             let entry_artifact = match archive_entry.header().entry_type() {
                 tokio_tar::EntryType::Regular => {
-                    let entry_blob_id = crate::brioche::blob::save_blob(
+                    let entry_blob_id = crate::brioche::blob::save_blob_from_reader(
                         brioche,
                         archive_entry,
                         crate::brioche::blob::SaveBlobOptions::new(),

--- a/crates/brioche/tests/artifact_hash_stable.rs
+++ b/crates/brioche/tests/artifact_hash_stable.rs
@@ -24,31 +24,31 @@ async fn test_artifact_hash_stable_file() -> anyhow::Result<()> {
 
     asserts.push((
         brioche_test::file(hello_blob, false).hash().to_string(),
-        "a6b7080d0b8c52c608680ba9c86cbaf8ddb2fa68782ca56a5e6bb640add8220f",
+        "bf8f872243626c7c0f504f238692b0ef5d24fc0fe1ab0158f1ba98791f510f06",
     ));
     asserts.push((
         brioche_test::lazy_file(hello_blob, false)
             .hash()
             .to_string(),
-        "2b49864e5a614c122da7aca0503c47df6410608b0874e4730e9229b3faa908b7",
+        "f4d1681d0ef3bb2283c7353849580fc2557972e2f77ae5c62a7aa7b0bd55e419",
     ));
 
     asserts.push((
         brioche_test::file(hi_blob, false).hash().to_string(),
-        "a325a432160ad49a11697bd2f18157b5124ed48376453bc851f627b8cef58eac",
+        "92e0405a0e9d24c11ee17d7b83de03be05b798d42db078aa6be4a1df55a27d28",
     ));
     asserts.push((
         brioche_test::lazy_file(hi_blob, false).hash().to_string(),
-        "81a8bfd7a02285a6eae9fab40ffaccd649711e21cf0bca5f192f52062192b86f",
+        "937cef462f78e7050dcf9b8f0e94064bc5d82872ad6b14373a750d8811ec38da",
     ));
 
     asserts.push((
         brioche_test::file(hello_blob, true).hash().to_string(),
-        "20ed0a264da3b8fb5c27fca2d70778590a764129de7157070aa25fbcf31ac7ea",
+        "567dcb7dd0f4e646db07611e0a2a4b7e98cab91ea3f1ba6b6285a09cfee9687f",
     ));
     asserts.push((
         brioche_test::lazy_file(hello_blob, true).hash().to_string(),
-        "b176eb8dea170f247a2eafe1a4e35e1598818ce077e13b7783b56c3c9db7af91",
+        "c60ae6cd5b1c5ec18cf9b452c08ca912527786e76460fdc5e4e794b1e4093f7c",
     ));
 
     asserts.push((
@@ -63,7 +63,7 @@ async fn test_artifact_hash_stable_file() -> anyhow::Result<()> {
         )
         .hash()
         .to_string(),
-        "47bb5f180d0206135e843e3aa81f12106124851e8f48f0143e7d6a35053c6f6e",
+        "19573f5e0dda1d7f794d24d29706ad01cfa1b66b12d832b46b0fc1c3f9a496b2",
     ));
     asserts.push((
         brioche_test::lazy_file_with_resources(
@@ -79,7 +79,7 @@ async fn test_artifact_hash_stable_file() -> anyhow::Result<()> {
         )
         .hash()
         .to_string(),
-        "3ded790822fdddc49a48fef5ec466d4cfa5b36629799e732be561dad7cad1cef",
+        "403aec4f2551b4092d2c225972ac568d4d2dbb941b7c7f35e615dec968a83de9",
     ));
 
     let left: Vec<_> = asserts.iter().map(|(left, _)| left).collect();
@@ -101,13 +101,13 @@ async fn test_artifact_hash_stable_directory() -> anyhow::Result<()> {
 
     asserts.push((
         brioche_test::dir_empty().hash().to_string(),
-        "2f51f105073a1b8b7644b23c3992439a3f82e6b54c0d06b10ed65575a6283135",
+        "2a370e3e0f3bfd8421d72a594a93a947fb4c133c480e3a898f6f65102a415302",
     ));
     asserts.push((
         LazyArtifact::from(brioche_test::dir_empty())
             .hash()
             .to_string(),
-        "2f51f105073a1b8b7644b23c3992439a3f82e6b54c0d06b10ed65575a6283135",
+        "2a370e3e0f3bfd8421d72a594a93a947fb4c133c480e3a898f6f65102a415302",
     ));
 
     asserts.push((
@@ -118,7 +118,7 @@ async fn test_artifact_hash_stable_directory() -> anyhow::Result<()> {
         .await
         .hash()
         .to_string(),
-        "773e23ae9256d18dbea707c79f6d2d2c018b910a992b6c75e71ef26dd7a32233",
+        "2f4c5a79a756b60c20de6849a7d2b86cc5b4ea0535e7a90647bd9b6d6797eb75",
     ));
     asserts.push((
         LazyArtifact::from(
@@ -130,7 +130,7 @@ async fn test_artifact_hash_stable_directory() -> anyhow::Result<()> {
         )
         .hash()
         .to_string(),
-        "773e23ae9256d18dbea707c79f6d2d2c018b910a992b6c75e71ef26dd7a32233",
+        "2f4c5a79a756b60c20de6849a7d2b86cc5b4ea0535e7a90647bd9b6d6797eb75",
     ));
 
     asserts.push((
@@ -148,7 +148,7 @@ async fn test_artifact_hash_stable_directory() -> anyhow::Result<()> {
         .await
         .hash()
         .to_string(),
-        "04155278894583935b64b9fe655e6d865ac3aff93fa790bcff4bbe9710ebe08b",
+        "1b971999cc4b2686e865b3c5184eacecbc5bba10649092d47d7fc23c729f7ce4",
     ));
     asserts.push((
         LazyArtifact::from(
@@ -170,7 +170,7 @@ async fn test_artifact_hash_stable_directory() -> anyhow::Result<()> {
         )
         .hash()
         .to_string(),
-        "04155278894583935b64b9fe655e6d865ac3aff93fa790bcff4bbe9710ebe08b",
+        "1b971999cc4b2686e865b3c5184eacecbc5bba10649092d47d7fc23c729f7ce4",
     ));
 
     asserts.push((
@@ -185,7 +185,7 @@ async fn test_artifact_hash_stable_directory() -> anyhow::Result<()> {
         )])
         .hash()
         .to_string(),
-        "59c5921cc57e0ee5f7b2206cdb64c1f874b8043d1aca6d93d5d079740704879a",
+        "9847f1a30047cda80890cb81762c56d7000699039b9c0ac54317d6a628fa5f73",
     ));
 
     let left: Vec<_> = asserts.iter().map(|(left, _)| left).collect();
@@ -204,20 +204,20 @@ async fn test_artifact_hash_stable_symlink() -> anyhow::Result<()> {
 
     asserts.push((
         brioche_test::lazy_symlink(b"foo").hash().to_string(),
-        "5beab9f7b650a3804bf79f30355309421e61a3978087a79d1baa299ddc8fac7c",
+        "7d2cc695d170b1f0f842c09f083336f646bcd44d329a100b949a7baec28c0755",
     ));
     asserts.push((
         brioche_test::symlink(b"foo").hash().to_string(),
-        "5beab9f7b650a3804bf79f30355309421e61a3978087a79d1baa299ddc8fac7c",
+        "7d2cc695d170b1f0f842c09f083336f646bcd44d329a100b949a7baec28c0755",
     ));
 
     asserts.push((
         brioche_test::lazy_symlink(b"/foo").hash().to_string(),
-        "f815995c6f75a4a37a05b2ce2c9c8605a1f6c194f6a4671bc4cf76ace03e2860",
+        "9d1f6c07805817d5e6608bae751fe65e7e9c0f90435140c33934de8250fe4be1",
     ));
     asserts.push((
         brioche_test::symlink(b"/foo").hash().to_string(),
-        "f815995c6f75a4a37a05b2ce2c9c8605a1f6c194f6a4671bc4cf76ace03e2860",
+        "9d1f6c07805817d5e6608bae751fe65e7e9c0f90435140c33934de8250fe4be1",
     ));
 
     let left: Vec<_> = asserts.iter().map(|(left, _)| left).collect();
@@ -241,7 +241,7 @@ async fn test_artifact_hash_stable_download() -> anyhow::Result<()> {
         })
         .hash()
         .to_string(),
-        "9a6643fe132824d8cfb0a2949a7d0e6ae0b84cc73cb7bdf833dd0ab1d65b0937",
+        "a5a538836efdfbe31cdffe8ba2838f3e03bb872a870a9eb52dec979e5410897e",
     ));
 
     asserts.push((
@@ -251,7 +251,7 @@ async fn test_artifact_hash_stable_download() -> anyhow::Result<()> {
         })
         .hash()
         .to_string(),
-        "0abe03ac1f459602aec0f3ddacbe025d7e318541290287c6357aa284446279b1",
+        "747cd20070228a01dabeb531be9d8cc68c02d8c12ac4bf572d4a16234c3b8758",
     ));
 
     let left: Vec<_> = asserts.iter().map(|(left, _)| left).collect();
@@ -278,7 +278,7 @@ async fn test_artifact_hash_stable_process() -> anyhow::Result<()> {
         })
         .hash()
         .to_string(),
-        "bcd2e9a337eed8ffa23c200779874689a47b99e695c2e9b78fbf40f341b67ea8",
+        "ae9c054dbaef92aa11c733dc46990b1b52eb539378a074517d0032a014722b3e",
     ));
 
     asserts.push((
@@ -295,7 +295,7 @@ async fn test_artifact_hash_stable_process() -> anyhow::Result<()> {
         })
         .hash()
         .to_string(),
-        "6fd9e60413f06f081ca8fb4848fc64bd43b56bacbc5754b8b4a7b8998c93c5ed",
+        "024e1e606bdbbfafbc6be05b0e60186a023500ca446a534a2637ef48a11563c8",
     ));
 
     asserts.push((
@@ -314,7 +314,7 @@ async fn test_artifact_hash_stable_process() -> anyhow::Result<()> {
         })
         .hash()
         .to_string(),
-        "5d79fba94bcfa6a7f059c2d7f672a0a76d00aaf60ab41fd3871b2ce48f8889c3",
+        "357d2e036720b2fd5b872f5d3b746d49a40e6a293a18ce05f56fa50986049a53",
     ));
 
     asserts.push((
@@ -340,7 +340,7 @@ async fn test_artifact_hash_stable_process() -> anyhow::Result<()> {
         })
         .hash()
         .to_string(),
-        "7504517f95f4aa3de6af11f7cc5e6b9eba2f67037c2df425756c09a6b87bc98a",
+        "323435cce7936a9bb68834908a2e37c80e5e1bd8223100103081d1f4d6808544",
     ));
 
     asserts.push((
@@ -371,7 +371,7 @@ async fn test_artifact_hash_stable_process() -> anyhow::Result<()> {
         })
         .hash()
         .to_string(),
-        "bfda06bcc63fb6fb88cb2d3be3a8bd3ba6a549c22c7b6f2be0009d311d8f398b",
+        "256263f7acbeb184b90eed36a27784d171816944315948399b62837a44d1ca0c",
     ));
 
     let left: Vec<_> = asserts.iter().map(|(left, _)| left).collect();

--- a/crates/brioche/tests/artifact_hash_stable.rs
+++ b/crates/brioche/tests/artifact_hash_stable.rs
@@ -63,7 +63,7 @@ async fn test_artifact_hash_stable_file() -> anyhow::Result<()> {
         )
         .hash()
         .to_string(),
-        "4ffde3f046dfb46f4d7e7c794799dfe81b452683fd90bc18659dccd792c4a400",
+        "47bb5f180d0206135e843e3aa81f12106124851e8f48f0143e7d6a35053c6f6e",
     ));
     asserts.push((
         brioche_test::lazy_file_with_resources(
@@ -79,7 +79,7 @@ async fn test_artifact_hash_stable_file() -> anyhow::Result<()> {
         )
         .hash()
         .to_string(),
-        "551c9204afe0b6fe0438b84b889df3c76d19368e2c3ed0a4c13ebde8fadf6dfe",
+        "3ded790822fdddc49a48fef5ec466d4cfa5b36629799e732be561dad7cad1cef",
     ));
 
     let left: Vec<_> = asserts.iter().map(|(left, _)| left).collect();
@@ -118,7 +118,7 @@ async fn test_artifact_hash_stable_directory() -> anyhow::Result<()> {
         .await
         .hash()
         .to_string(),
-        "e741c7f33e7845f3f659c0484bb889645daf338677d2a3209a472e4406eae404",
+        "773e23ae9256d18dbea707c79f6d2d2c018b910a992b6c75e71ef26dd7a32233",
     ));
     asserts.push((
         LazyArtifact::from(
@@ -130,7 +130,7 @@ async fn test_artifact_hash_stable_directory() -> anyhow::Result<()> {
         )
         .hash()
         .to_string(),
-        "e741c7f33e7845f3f659c0484bb889645daf338677d2a3209a472e4406eae404",
+        "773e23ae9256d18dbea707c79f6d2d2c018b910a992b6c75e71ef26dd7a32233",
     ));
 
     asserts.push((
@@ -148,7 +148,7 @@ async fn test_artifact_hash_stable_directory() -> anyhow::Result<()> {
         .await
         .hash()
         .to_string(),
-        "02360a3026e4c5623a29b0437b5f7ca21fc23810befdc20c3ce5915dce96ba17",
+        "04155278894583935b64b9fe655e6d865ac3aff93fa790bcff4bbe9710ebe08b",
     ));
     asserts.push((
         LazyArtifact::from(
@@ -170,7 +170,7 @@ async fn test_artifact_hash_stable_directory() -> anyhow::Result<()> {
         )
         .hash()
         .to_string(),
-        "02360a3026e4c5623a29b0437b5f7ca21fc23810befdc20c3ce5915dce96ba17",
+        "04155278894583935b64b9fe655e6d865ac3aff93fa790bcff4bbe9710ebe08b",
     ));
 
     asserts.push((

--- a/crates/brioche/tests/artifact_hash_stable.rs
+++ b/crates/brioche/tests/artifact_hash_stable.rs
@@ -23,53 +23,63 @@ async fn test_artifact_hash_stable_file() -> anyhow::Result<()> {
     let mut asserts = vec![];
 
     asserts.push((
-        brioche_test::lazy_file(hello_blob, false)
-            .hash()
-            .to_string(),
-        "a6b7080d0b8c52c608680ba9c86cbaf8ddb2fa68782ca56a5e6bb640add8220f",
-    ));
-    asserts.push((
         brioche_test::file(hello_blob, false).hash().to_string(),
         "a6b7080d0b8c52c608680ba9c86cbaf8ddb2fa68782ca56a5e6bb640add8220f",
     ));
-
     asserts.push((
-        brioche_test::lazy_file(hi_blob, false).hash().to_string(),
-        "a325a432160ad49a11697bd2f18157b5124ed48376453bc851f627b8cef58eac",
+        brioche_test::lazy_file(hello_blob, false)
+            .hash()
+            .to_string(),
+        "2b49864e5a614c122da7aca0503c47df6410608b0874e4730e9229b3faa908b7",
     ));
+
     asserts.push((
         brioche_test::file(hi_blob, false).hash().to_string(),
         "a325a432160ad49a11697bd2f18157b5124ed48376453bc851f627b8cef58eac",
     ));
-
     asserts.push((
-        brioche_test::lazy_file(hello_blob, true).hash().to_string(),
-        "20ed0a264da3b8fb5c27fca2d70778590a764129de7157070aa25fbcf31ac7ea",
+        brioche_test::lazy_file(hi_blob, false).hash().to_string(),
+        "81a8bfd7a02285a6eae9fab40ffaccd649711e21cf0bca5f192f52062192b86f",
     ));
+
     asserts.push((
         brioche_test::file(hello_blob, true).hash().to_string(),
         "20ed0a264da3b8fb5c27fca2d70778590a764129de7157070aa25fbcf31ac7ea",
     ));
-
     asserts.push((
-        brioche_test::lazy_file_with_resources(
-            hello_blob,
-            false,
-            brioche_test::lazy_dir_value([("foo.txt", brioche_test::lazy_file(hello_blob, false))]),
-        )
-        .hash()
-        .to_string(),
-        "27c41efc8d056e2d571f781032416d95714cd77da82afc40135ce21c0453f4a6",
+        brioche_test::lazy_file(hello_blob, true).hash().to_string(),
+        "b176eb8dea170f247a2eafe1a4e35e1598818ce077e13b7783b56c3c9db7af91",
     ));
+
     asserts.push((
         brioche_test::file_with_resources(
             hello_blob,
             false,
-            brioche_test::dir_value([("foo.txt", brioche_test::file(hello_blob, false))]),
+            brioche_test::dir_value(
+                &brioche,
+                [("foo.txt", brioche_test::file(hello_blob, false))],
+            )
+            .await,
         )
         .hash()
         .to_string(),
-        "27c41efc8d056e2d571f781032416d95714cd77da82afc40135ce21c0453f4a6",
+        "4ffde3f046dfb46f4d7e7c794799dfe81b452683fd90bc18659dccd792c4a400",
+    ));
+    asserts.push((
+        brioche_test::lazy_file_with_resources(
+            hello_blob,
+            false,
+            LazyArtifact::from(
+                brioche_test::dir(
+                    &brioche,
+                    [("foo.txt", brioche_test::file(hello_blob, false))],
+                )
+                .await,
+            ),
+        )
+        .hash()
+        .to_string(),
+        "551c9204afe0b6fe0438b84b889df3c76d19368e2c3ed0a4c13ebde8fadf6dfe",
     ));
 
     let left: Vec<_> = asserts.iter().map(|(left, _)| left).collect();
@@ -90,50 +100,77 @@ async fn test_artifact_hash_stable_directory() -> anyhow::Result<()> {
     let mut asserts = vec![];
 
     asserts.push((
-        brioche_test::lazy_dir_empty().hash().to_string(),
-        "2f51f105073a1b8b7644b23c3992439a3f82e6b54c0d06b10ed65575a6283135",
-    ));
-    asserts.push((
         brioche_test::dir_empty().hash().to_string(),
         "2f51f105073a1b8b7644b23c3992439a3f82e6b54c0d06b10ed65575a6283135",
     ));
-
     asserts.push((
-        brioche_test::lazy_dir([("foo.txt", brioche_test::lazy_file(hello_blob, false))])
+        LazyArtifact::from(brioche_test::dir_empty())
             .hash()
             .to_string(),
-        "939a1c5b18900279593cea01e1a78e6ea0604eebd080f845011353c476b64a2c",
-    ));
-    asserts.push((
-        brioche_test::dir([("foo.txt", brioche_test::file(hello_blob, false))])
-            .hash()
-            .to_string(),
-        "939a1c5b18900279593cea01e1a78e6ea0604eebd080f845011353c476b64a2c",
+        "2f51f105073a1b8b7644b23c3992439a3f82e6b54c0d06b10ed65575a6283135",
     ));
 
     asserts.push((
-        brioche_test::lazy_dir([
-            ("foo.txt", brioche_test::lazy_file(hello_blob, false)),
-            (
-                "bar",
-                brioche_test::lazy_dir([("hi.txt", brioche_test::lazy_file(hi_blob, false))]),
-            ),
-        ])
+        brioche_test::dir(
+            &brioche,
+            [("foo.txt", brioche_test::file(hello_blob, false))],
+        )
+        .await
         .hash()
         .to_string(),
-        "9a381be2fd8619d55273d037c1ceb6068ddb3fdfaffff85cec0c9fdd78a7bf93",
+        "e741c7f33e7845f3f659c0484bb889645daf338677d2a3209a472e4406eae404",
     ));
     asserts.push((
-        brioche_test::dir([
-            ("foo.txt", brioche_test::file(hello_blob, false)),
-            (
-                "bar",
-                brioche_test::dir([("hi.txt", brioche_test::file(hi_blob, false))]),
-            ),
-        ])
+        LazyArtifact::from(
+            brioche_test::dir(
+                &brioche,
+                [("foo.txt", brioche_test::file(hello_blob, false))],
+            )
+            .await,
+        )
         .hash()
         .to_string(),
-        "9a381be2fd8619d55273d037c1ceb6068ddb3fdfaffff85cec0c9fdd78a7bf93",
+        "e741c7f33e7845f3f659c0484bb889645daf338677d2a3209a472e4406eae404",
+    ));
+
+    asserts.push((
+        brioche_test::dir(
+            &brioche,
+            [
+                ("foo.txt", brioche_test::file(hello_blob, false)),
+                (
+                    "bar",
+                    brioche_test::dir(&brioche, [("hi.txt", brioche_test::file(hi_blob, false))])
+                        .await,
+                ),
+            ],
+        )
+        .await
+        .hash()
+        .to_string(),
+        "02360a3026e4c5623a29b0437b5f7ca21fc23810befdc20c3ce5915dce96ba17",
+    ));
+    asserts.push((
+        LazyArtifact::from(
+            brioche_test::dir(
+                &brioche,
+                [
+                    ("foo.txt", brioche_test::file(hello_blob, false)),
+                    (
+                        "bar",
+                        brioche_test::dir(
+                            &brioche,
+                            [("hi.txt", brioche_test::file(hi_blob, false))],
+                        )
+                        .await,
+                    ),
+                ],
+            )
+            .await,
+        )
+        .hash()
+        .to_string(),
+        "02360a3026e4c5623a29b0437b5f7ca21fc23810befdc20c3ce5915dce96ba17",
     ));
 
     asserts.push((
@@ -148,7 +185,7 @@ async fn test_artifact_hash_stable_directory() -> anyhow::Result<()> {
         )])
         .hash()
         .to_string(),
-        "e68087284af6d54595c2235c97630ac5d2fcdeba87f27e91af278b6c3ab576c4",
+        "59c5921cc57e0ee5f7b2206cdb64c1f874b8043d1aca6d93d5d079740704879a",
     ));
 
     let left: Vec<_> = asserts.iter().map(|(left, _)| left).collect();
@@ -241,7 +278,7 @@ async fn test_artifact_hash_stable_process() -> anyhow::Result<()> {
         })
         .hash()
         .to_string(),
-        "d9df4f961f526c9124fb19b2a9e9696a83f1d2cdd3f390660e78c465b93f79a8",
+        "bcd2e9a337eed8ffa23c200779874689a47b99e695c2e9b78fbf40f341b67ea8",
     ));
 
     asserts.push((
@@ -258,7 +295,7 @@ async fn test_artifact_hash_stable_process() -> anyhow::Result<()> {
         })
         .hash()
         .to_string(),
-        "8eaec0e082b66e6344d0ad10e493f4f7d0ca0f47515a2011a5c851d1eaf3419b",
+        "6fd9e60413f06f081ca8fb4848fc64bd43b56bacbc5754b8b4a7b8998c93c5ed",
     ));
 
     asserts.push((
@@ -277,7 +314,7 @@ async fn test_artifact_hash_stable_process() -> anyhow::Result<()> {
         })
         .hash()
         .to_string(),
-        "d94023b82816a1b8cb316cfe175a1ab8dcd9c0029cd35065a098474910f9cdab",
+        "5d79fba94bcfa6a7f059c2d7f672a0a76d00aaf60ab41fd3871b2ce48f8889c3",
     ));
 
     asserts.push((
@@ -303,7 +340,7 @@ async fn test_artifact_hash_stable_process() -> anyhow::Result<()> {
         })
         .hash()
         .to_string(),
-        "caf4553cb77d7527cd01d0dc954bf8d083d1f313bdffde2496e9859c1b1f38c1",
+        "7504517f95f4aa3de6af11f7cc5e6b9eba2f67037c2df425756c09a6b87bc98a",
     ));
 
     asserts.push((
@@ -334,7 +371,7 @@ async fn test_artifact_hash_stable_process() -> anyhow::Result<()> {
         })
         .hash()
         .to_string(),
-        "b065cc3f66e108550f62cbbf6202ac2dd9ca423b01ee7ca6d7352782e675601f",
+        "bfda06bcc63fb6fb88cb2d3be3a8bd3ba6a549c22c7b6f2be0009d311d8f398b",
     ));
 
     let left: Vec<_> = asserts.iter().map(|(left, _)| left).collect();

--- a/crates/brioche/tests/brioche_test/mod.rs
+++ b/crates/brioche/tests/brioche_test/mod.rs
@@ -47,10 +47,13 @@ pub async fn resolve_without_meta(
 }
 
 pub async fn blob(brioche: &Brioche, content: impl AsRef<[u8]> + std::marker::Unpin) -> BlobId {
-    let mut cursor = std::io::Cursor::new(content);
-    brioche::brioche::blob::save_blob_from_reader(brioche, &mut cursor, SaveBlobOptions::default())
-        .await
-        .unwrap()
+    brioche::brioche::blob::save_blob_from_reader(
+        brioche,
+        content.as_ref(),
+        SaveBlobOptions::default(),
+    )
+    .await
+    .unwrap()
 }
 
 pub fn lazy_file(blob: BlobId, executable: bool) -> brioche::brioche::artifact::LazyArtifact {

--- a/crates/brioche/tests/brioche_test/mod.rs
+++ b/crates/brioche/tests/brioche_test/mod.rs
@@ -58,7 +58,7 @@ pub async fn blob(brioche: &Brioche, content: impl AsRef<[u8]> + std::marker::Un
 
 pub fn lazy_file(blob: BlobId, executable: bool) -> brioche::brioche::artifact::LazyArtifact {
     brioche::brioche::artifact::LazyArtifact::File {
-        data: blob,
+        content_blob: blob,
         executable,
         resources: Box::new(WithMeta::without_meta(
             brioche::brioche::artifact::LazyArtifact::Directory(Directory::default()),
@@ -72,7 +72,7 @@ pub fn lazy_file_with_resources(
     resources: brioche::brioche::artifact::LazyArtifact,
 ) -> brioche::brioche::artifact::LazyArtifact {
     brioche::brioche::artifact::LazyArtifact::File {
-        data: blob,
+        content_blob: blob,
         executable,
         resources: Box::new(WithMeta::without_meta(resources)),
     }
@@ -80,7 +80,7 @@ pub fn lazy_file_with_resources(
 
 pub fn file(blob: BlobId, executable: bool) -> brioche::brioche::artifact::CompleteArtifact {
     brioche::brioche::artifact::CompleteArtifact::File(File {
-        data: blob,
+        content_blob: blob,
         executable,
         resources: Directory::default(),
     })
@@ -92,7 +92,7 @@ pub fn file_with_resources(
     resources: brioche::brioche::artifact::Directory,
 ) -> brioche::brioche::artifact::CompleteArtifact {
     brioche::brioche::artifact::CompleteArtifact::File(File {
-        data: blob,
+        content_blob: blob,
         executable,
         resources,
     })

--- a/crates/brioche/tests/brioche_test/mod.rs
+++ b/crates/brioche/tests/brioche_test/mod.rs
@@ -48,7 +48,7 @@ pub async fn resolve_without_meta(
 
 pub async fn blob(brioche: &Brioche, content: impl AsRef<[u8]> + std::marker::Unpin) -> BlobId {
     let mut cursor = std::io::Cursor::new(content);
-    brioche::brioche::blob::save_blob(brioche, &mut cursor, SaveBlobOptions::default())
+    brioche::brioche::blob::save_blob_from_reader(brioche, &mut cursor, SaveBlobOptions::default())
         .await
         .unwrap()
 }

--- a/crates/brioche/tests/brioche_test/mod.rs
+++ b/crates/brioche/tests/brioche_test/mod.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use brioche::brioche::{
-    artifact::{Directory, DirectoryListing, File, LazyDirectory, WithMeta},
+    artifact::{CreateDirectory, Directory, DirectoryListing, File, WithMeta},
     blob::{BlobId, SaveBlobOptions},
     Brioche, BriocheBuilder,
 };
@@ -100,8 +100,8 @@ pub fn file_with_resources(
 
 pub fn lazy_dir_value<K: AsRef<[u8]>>(
     entries: impl IntoIterator<Item = (K, brioche::brioche::artifact::LazyArtifact)>,
-) -> brioche::brioche::artifact::LazyDirectory {
-    LazyDirectory {
+) -> brioche::brioche::artifact::CreateDirectory {
+    CreateDirectory {
         entries: entries
             .into_iter()
             .map(|(k, v)| (k.as_ref().into(), without_meta(v)))
@@ -112,7 +112,7 @@ pub fn lazy_dir_value<K: AsRef<[u8]>>(
 pub fn lazy_dir<K: AsRef<[u8]>>(
     entries: impl IntoIterator<Item = (K, brioche::brioche::artifact::LazyArtifact)>,
 ) -> brioche::brioche::artifact::LazyArtifact {
-    brioche::brioche::artifact::LazyArtifact::CreateDirectory(LazyDirectory {
+    brioche::brioche::artifact::LazyArtifact::CreateDirectory(CreateDirectory {
         entries: entries
             .into_iter()
             .map(|(k, v)| (k.as_ref().into(), WithMeta::without_meta(v)))
@@ -149,7 +149,7 @@ pub async fn dir<K: AsRef<[u8]>>(
 }
 
 pub fn lazy_dir_empty() -> brioche::brioche::artifact::LazyArtifact {
-    brioche::brioche::artifact::LazyArtifact::CreateDirectory(LazyDirectory::default())
+    brioche::brioche::artifact::LazyArtifact::CreateDirectory(CreateDirectory::default())
 }
 
 pub fn dir_empty() -> brioche::brioche::artifact::CompleteArtifact {

--- a/crates/brioche/tests/input.rs
+++ b/crates/brioche/tests/input.rs
@@ -129,17 +129,25 @@ async fn test_input_dir() -> anyhow::Result<()> {
 
     assert_eq!(
         artifact,
-        brioche_test::dir([
-            (
-                "hello",
-                brioche_test::dir([(
-                    "hi.txt",
-                    brioche_test::file(brioche_test::blob(&brioche, b"hello").await, false)
-                ),])
-            ),
-            ("empty", brioche_test::dir_empty()),
-            ("link", brioche_test::symlink("hello/hi.txt"))
-        ])
+        brioche_test::dir(
+            &brioche,
+            [
+                (
+                    "hello",
+                    brioche_test::dir(
+                        &brioche,
+                        [(
+                            "hi.txt",
+                            brioche_test::file(brioche_test::blob(&brioche, b"hello").await, false)
+                        ),]
+                    )
+                    .await
+                ),
+                ("empty", brioche_test::dir_empty()),
+                ("link", brioche_test::symlink("hello/hi.txt"))
+            ]
+        )
+        .await
     );
     assert!(dir_path.is_dir());
 
@@ -159,17 +167,25 @@ async fn test_input_remove_original() -> anyhow::Result<()> {
 
     assert_eq!(
         artifact,
-        brioche_test::dir([
-            (
-                "hello",
-                brioche_test::dir([(
-                    "hi.txt",
-                    brioche_test::file(brioche_test::blob(&brioche, b"hello").await, false)
-                ),])
-            ),
-            ("empty", brioche_test::dir_empty()),
-            ("link", brioche_test::symlink("hello/hi.txt"))
-        ])
+        brioche_test::dir(
+            &brioche,
+            [
+                (
+                    "hello",
+                    brioche_test::dir(
+                        &brioche,
+                        [(
+                            "hi.txt",
+                            brioche_test::file(brioche_test::blob(&brioche, b"hello").await, false)
+                        ),]
+                    )
+                    .await
+                ),
+                ("empty", brioche_test::dir_empty()),
+                ("link", brioche_test::symlink("hello/hi.txt"))
+            ]
+        )
+        .await
     );
     assert!(!dir_path.is_dir());
 
@@ -200,19 +216,27 @@ async fn test_input_dir_treat_pack_normally() -> anyhow::Result<()> {
 
     assert_eq!(
         artifact,
-        brioche_test::dir([
-            (
-                "hi",
-                brioche_test::file(brioche_test::blob(&brioche, &packed_file).await, false)
-            ),
-            (
-                "brioche-pack.d",
-                brioche_test::dir([(
-                    "test",
-                    brioche_test::file(brioche_test::blob(&brioche, b"test").await, false)
-                ),])
-            ),
-        ])
+        brioche_test::dir(
+            &brioche,
+            [
+                (
+                    "hi",
+                    brioche_test::file(brioche_test::blob(&brioche, &packed_file).await, false)
+                ),
+                (
+                    "brioche-pack.d",
+                    brioche_test::dir(
+                        &brioche,
+                        [(
+                            "test",
+                            brioche_test::file(brioche_test::blob(&brioche, b"test").await, false)
+                        ),]
+                    )
+                    .await
+                ),
+            ]
+        )
+        .await
     );
     assert!(dir_path.is_dir());
 
@@ -242,17 +266,25 @@ async fn test_input_dir_use_resource_dir() -> anyhow::Result<()> {
 
     assert_eq!(
         artifact,
-        brioche_test::dir([(
-            "hi",
-            brioche_test::file_with_resources(
-                brioche_test::blob(&brioche, &packed_file).await,
-                false,
-                brioche_test::dir_value([(
-                    "test",
-                    brioche_test::file(brioche_test::blob(&brioche, b"test").await, false),
-                )]),
-            )
-        ),])
+        brioche_test::dir(
+            &brioche,
+            [(
+                "hi",
+                brioche_test::file_with_resources(
+                    brioche_test::blob(&brioche, &packed_file).await,
+                    false,
+                    brioche_test::dir_value(
+                        &brioche,
+                        [(
+                            "test",
+                            brioche_test::file(brioche_test::blob(&brioche, b"test").await, false),
+                        )]
+                    )
+                    .await,
+                )
+            ),]
+        )
+        .await
     );
     assert!(dir_path.is_dir());
 
@@ -283,20 +315,31 @@ async fn test_input_dir_with_symlink_resources() -> anyhow::Result<()> {
 
     assert_eq!(
         artifact,
-        brioche_test::dir([(
-            "hi",
-            brioche_test::file_with_resources(
-                brioche_test::blob(&brioche, &packed_file).await,
-                false,
-                brioche_test::dir_value([
-                    ("test", brioche_test::symlink(b"test_target")),
-                    (
-                        "test_target",
-                        brioche_test::file(brioche_test::blob(&brioche, b"test").await, false)
-                    ),
-                ]),
-            )
-        ),])
+        brioche_test::dir(
+            &brioche,
+            [(
+                "hi",
+                brioche_test::file_with_resources(
+                    brioche_test::blob(&brioche, &packed_file).await,
+                    false,
+                    brioche_test::dir_value(
+                        &brioche,
+                        [
+                            ("test", brioche_test::symlink(b"test_target")),
+                            (
+                                "test_target",
+                                brioche_test::file(
+                                    brioche_test::blob(&brioche, b"test").await,
+                                    false
+                                )
+                            ),
+                        ]
+                    )
+                    .await,
+                )
+            ),]
+        )
+        .await
     );
     assert!(dir_path.is_dir());
 
@@ -326,14 +369,22 @@ async fn test_input_dir_broken_symlink() -> anyhow::Result<()> {
 
     assert_eq!(
         artifact,
-        brioche_test::dir([(
-            "hi",
-            brioche_test::file_with_resources(
-                brioche_test::blob(&brioche, &packed_file).await,
-                false,
-                brioche_test::dir_value([("test", brioche_test::symlink(b"test_target"))]),
-            )
-        ),])
+        brioche_test::dir(
+            &brioche,
+            [(
+                "hi",
+                brioche_test::file_with_resources(
+                    brioche_test::blob(&brioche, &packed_file).await,
+                    false,
+                    brioche_test::dir_value(
+                        &brioche,
+                        [("test", brioche_test::symlink(b"test_target"))]
+                    )
+                    .await,
+                )
+            ),]
+        )
+        .await
     );
     assert!(dir_path.is_dir());
 
@@ -367,32 +418,47 @@ async fn test_input_dir_with_dir_resources() -> anyhow::Result<()> {
 
     assert_eq!(
         artifact,
-        brioche_test::dir([(
-            "hi",
-            brioche_test::file_with_resources(
-                brioche_test::blob(&brioche, &packed_file).await,
-                false,
-                brioche_test::dir_value([
-                    (
-                        "test",
-                        brioche_test::dir([
+        brioche_test::dir(
+            &brioche,
+            [(
+                "hi",
+                brioche_test::file_with_resources(
+                    brioche_test::blob(&brioche, &packed_file).await,
+                    false,
+                    brioche_test::dir_value(
+                        &brioche,
+                        [
                             (
-                                "hi",
+                                "test",
+                                brioche_test::dir(
+                                    &brioche,
+                                    [
+                                        (
+                                            "hi",
+                                            brioche_test::file(
+                                                brioche_test::blob(&brioche, b"test").await,
+                                                false
+                                            )
+                                        ),
+                                        ("target", brioche_test::symlink(b"../test_target")),
+                                    ]
+                                )
+                                .await
+                            ),
+                            (
+                                "test_target",
                                 brioche_test::file(
                                     brioche_test::blob(&brioche, b"test").await,
                                     false
                                 )
                             ),
-                            ("target", brioche_test::symlink(b"../test_target")),
-                        ])
-                    ),
-                    (
-                        "test_target",
-                        brioche_test::file(brioche_test::blob(&brioche, b"test").await, false)
-                    ),
-                ]),
-            )
-        ),])
+                        ]
+                    )
+                    .await,
+                )
+            ),]
+        )
+        .await
     );
     assert!(dir_path.is_dir());
 
@@ -425,17 +491,25 @@ async fn test_input_dir_omits_unused_resources() -> anyhow::Result<()> {
 
     assert_eq!(
         artifact,
-        brioche_test::dir([(
-            "hi",
-            brioche_test::file_with_resources(
-                brioche_test::blob(&brioche, &packed_file).await,
-                false,
-                brioche_test::dir_value([(
-                    "test",
-                    brioche_test::file(brioche_test::blob(&brioche, b"hello").await, false),
-                )]),
-            )
-        ),])
+        brioche_test::dir(
+            &brioche,
+            [(
+                "hi",
+                brioche_test::file_with_resources(
+                    brioche_test::blob(&brioche, &packed_file).await,
+                    false,
+                    brioche_test::dir_value(
+                        &brioche,
+                        [(
+                            "test",
+                            brioche_test::file(brioche_test::blob(&brioche, b"hello").await, false),
+                        )]
+                    )
+                    .await,
+                )
+            ),]
+        )
+        .await
     );
     assert!(dir_path.is_dir());
 

--- a/crates/brioche/tests/output.rs
+++ b/crates/brioche/tests/output.rs
@@ -128,17 +128,25 @@ async fn test_output_empty_dir() -> anyhow::Result<()> {
 async fn test_output_dir() -> anyhow::Result<()> {
     let (brioche, context) = brioche_test::brioche_test().await;
 
-    let artifact = brioche_test::dir([
-        (
-            "hello",
-            brioche_test::dir([(
-                "hi.txt",
-                brioche_test::file(brioche_test::blob(&brioche, b"hello").await, false),
-            )]),
-        ),
-        ("empty", brioche_test::dir_empty()),
-        ("link", brioche_test::symlink("hello/hi.txt")),
-    ]);
+    let artifact = brioche_test::dir(
+        &brioche,
+        [
+            (
+                "hello",
+                brioche_test::dir(
+                    &brioche,
+                    [(
+                        "hi.txt",
+                        brioche_test::file(brioche_test::blob(&brioche, b"hello").await, false),
+                    )],
+                )
+                .await,
+            ),
+            ("empty", brioche_test::dir_empty()),
+            ("link", brioche_test::symlink("hello/hi.txt")),
+        ],
+    )
+    .await;
 
     create_output(&brioche, &context.path("output"), &artifact, false).await?;
 
@@ -163,17 +171,25 @@ async fn test_output_dir() -> anyhow::Result<()> {
 async fn test_output_merge() -> anyhow::Result<()> {
     let (brioche, context) = brioche_test::brioche_test().await;
 
-    let artifact = brioche_test::dir([
-        (
-            "hello",
-            brioche_test::dir([(
-                "hi.txt",
-                brioche_test::file(brioche_test::blob(&brioche, b"hello").await, false),
-            )]),
-        ),
-        ("empty", brioche_test::dir_empty()),
-        ("link", brioche_test::symlink("hello/hi.txt")),
-    ]);
+    let artifact = brioche_test::dir(
+        &brioche,
+        [
+            (
+                "hello",
+                brioche_test::dir(
+                    &brioche,
+                    [(
+                        "hi.txt",
+                        brioche_test::file(brioche_test::blob(&brioche, b"hello").await, false),
+                    )],
+                )
+                .await,
+            ),
+            ("empty", brioche_test::dir_empty()),
+            ("link", brioche_test::symlink("hello/hi.txt")),
+        ],
+    )
+    .await;
 
     context.write_file("output/foo.txt", "foo").await;
 
@@ -202,13 +218,17 @@ async fn test_output_merge() -> anyhow::Result<()> {
 async fn test_output_merge_replace() -> anyhow::Result<()> {
     let (brioche, context) = brioche_test::brioche_test().await;
 
-    let artifact = brioche_test::dir([
-        (
-            "test.txt",
-            brioche_test::file(brioche_test::blob(&brioche, "new content").await, false),
-        ),
-        ("link", brioche_test::symlink("test.txt")),
-    ]);
+    let artifact = brioche_test::dir(
+        &brioche,
+        [
+            (
+                "test.txt",
+                brioche_test::file(brioche_test::blob(&brioche, "new content").await, false),
+            ),
+            ("link", brioche_test::symlink("test.txt")),
+        ],
+    )
+    .await;
 
     context.write_file("output/test.txt", "old content").await;
     context.write_file("output/test2.txt", "unchanged").await;
@@ -238,17 +258,25 @@ async fn test_output_merge_replace() -> anyhow::Result<()> {
 async fn test_output_conflict_no_merge() -> anyhow::Result<()> {
     let (brioche, context) = brioche_test::brioche_test().await;
 
-    let artifact = brioche_test::dir([
-        (
-            "hello",
-            brioche_test::dir([(
-                "hi.txt",
-                brioche_test::file(brioche_test::blob(&brioche, b"hello").await, false),
-            )]),
-        ),
-        ("empty", brioche_test::dir_empty()),
-        ("link", brioche_test::symlink("hello/hi.txt")),
-    ]);
+    let artifact = brioche_test::dir(
+        &brioche,
+        [
+            (
+                "hello",
+                brioche_test::dir(
+                    &brioche,
+                    [(
+                        "hi.txt",
+                        brioche_test::file(brioche_test::blob(&brioche, b"hello").await, false),
+                    )],
+                )
+                .await,
+            ),
+            ("empty", brioche_test::dir_empty()),
+            ("link", brioche_test::symlink("hello/hi.txt")),
+        ],
+    )
+    .await;
 
     context.write_file("output1", "foo").await;
     context.write_symlink("/foo", "output2").await;
@@ -275,17 +303,25 @@ async fn test_output_conflict_no_merge() -> anyhow::Result<()> {
 async fn test_output_conflict_merge() -> anyhow::Result<()> {
     let (brioche, context) = brioche_test::brioche_test().await;
 
-    let artifact = brioche_test::dir([
-        (
-            "hello",
-            brioche_test::dir([(
-                "hi.txt",
-                brioche_test::file(brioche_test::blob(&brioche, b"hello").await, false),
-            )]),
-        ),
-        ("empty", brioche_test::dir_empty()),
-        ("link", brioche_test::symlink("hello/hi.txt")),
-    ]);
+    let artifact = brioche_test::dir(
+        &brioche,
+        [
+            (
+                "hello",
+                brioche_test::dir(
+                    &brioche,
+                    [(
+                        "hi.txt",
+                        brioche_test::file(brioche_test::blob(&brioche, b"hello").await, false),
+                    )],
+                )
+                .await,
+            ),
+            ("empty", brioche_test::dir_empty()),
+            ("link", brioche_test::symlink("hello/hi.txt")),
+        ],
+    )
+    .await;
 
     context.write_file("output1", "foo").await;
     context.write_symlink("/foo", "output2").await;
@@ -308,39 +344,62 @@ async fn test_output_conflict_merge() -> anyhow::Result<()> {
 async fn test_output_dir_with_resources() -> anyhow::Result<()> {
     let (brioche, context) = brioche_test::brioche_test().await;
 
-    let artifact = brioche_test::dir([(
-        "hello",
-        brioche_test::dir([
-            (
-                "hi.txt",
-                brioche_test::file_with_resources(
-                    brioche_test::blob(&brioche, b"hello").await,
-                    false,
-                    brioche_test::dir_value([(
-                        "hi_ref.txt",
-                        brioche_test::file(
-                            brioche_test::blob(&brioche, b"reference data").await,
+    let artifact = brioche_test::dir(
+        &brioche,
+        [(
+            "hello",
+            brioche_test::dir(
+                &brioche,
+                [
+                    (
+                        "hi.txt",
+                        brioche_test::file_with_resources(
+                            brioche_test::blob(&brioche, b"hello").await,
                             false,
+                            brioche_test::dir_value(
+                                &brioche,
+                                [(
+                                    "hi_ref.txt",
+                                    brioche_test::file(
+                                        brioche_test::blob(&brioche, b"reference data").await,
+                                        false,
+                                    ),
+                                )],
+                            )
+                            .await,
                         ),
-                    )]),
-                ),
-            ),
-            (
-                "second.txt",
-                brioche_test::file_with_resources(
-                    brioche_test::blob(&brioche, b"2").await,
-                    false,
-                    brioche_test::dir_value([(
-                        "second_refs",
-                        brioche_test::dir([(
-                            "second_ref.txt",
-                            brioche_test::file(brioche_test::blob(&brioche, b"T W O").await, false),
-                        )]),
-                    )]),
-                ),
-            ),
-        ]),
-    )]);
+                    ),
+                    (
+                        "second.txt",
+                        brioche_test::file_with_resources(
+                            brioche_test::blob(&brioche, b"2").await,
+                            false,
+                            brioche_test::dir_value(
+                                &brioche,
+                                [(
+                                    "second_refs",
+                                    brioche_test::dir(
+                                        &brioche,
+                                        [(
+                                            "second_ref.txt",
+                                            brioche_test::file(
+                                                brioche_test::blob(&brioche, b"T W O").await,
+                                                false,
+                                            ),
+                                        )],
+                                    )
+                                    .await,
+                                )],
+                            )
+                            .await,
+                        ),
+                    ),
+                ],
+            )
+            .await,
+        )],
+    )
+    .await;
 
     create_output(&brioche, &context.path("output"), &artifact, false).await?;
 
@@ -372,29 +431,41 @@ async fn test_output_dir_with_resources() -> anyhow::Result<()> {
 async fn test_output_dir_with_resources_and_pack_dir() -> anyhow::Result<()> {
     let (brioche, context) = brioche_test::brioche_test().await;
 
-    let artifact = brioche_test::dir([
-        (
-            "hi.txt",
-            brioche_test::file_with_resources(
-                brioche_test::blob(&brioche, b"hello").await,
-                false,
-                brioche_test::dir_value([(
-                    "hi_ref.txt",
-                    brioche_test::file(
-                        brioche_test::blob(&brioche, b"reference data").await,
-                        false,
-                    ),
-                )]),
+    let artifact = brioche_test::dir(
+        &brioche,
+        [
+            (
+                "hi.txt",
+                brioche_test::file_with_resources(
+                    brioche_test::blob(&brioche, b"hello").await,
+                    false,
+                    brioche_test::dir_value(
+                        &brioche,
+                        [(
+                            "hi_ref.txt",
+                            brioche_test::file(
+                                brioche_test::blob(&brioche, b"reference data").await,
+                                false,
+                            ),
+                        )],
+                    )
+                    .await,
+                ),
             ),
-        ),
-        (
-            "brioche-pack.d",
-            brioche_test::dir([(
-                "test.txt",
-                brioche_test::file(brioche_test::blob(&brioche, b"test").await, false),
-            )]),
-        ),
-    ]);
+            (
+                "brioche-pack.d",
+                brioche_test::dir(
+                    &brioche,
+                    [(
+                        "test.txt",
+                        brioche_test::file(brioche_test::blob(&brioche, b"test").await, false),
+                    )],
+                )
+                .await,
+            ),
+        ],
+    )
+    .await;
 
     create_output(&brioche, &context.path("output"), &artifact, false).await?;
 
@@ -420,30 +491,50 @@ async fn test_output_dir_with_resources_and_pack_dir() -> anyhow::Result<()> {
 async fn test_output_dir_with_nested_resources() -> anyhow::Result<()> {
     let (brioche, context) = brioche_test::brioche_test().await;
 
-    let artifact = brioche_test::dir([(
-        "hello",
-        brioche_test::dir([(
-            "hi.txt",
-            brioche_test::file_with_resources(
-                brioche_test::blob(&brioche, b"hello").await,
-                false,
-                brioche_test::dir_value([(
-                    "hi_ref.txt",
+    let artifact = brioche_test::dir(
+        &brioche,
+        [(
+            "hello",
+            brioche_test::dir(
+                &brioche,
+                [(
+                    "hi.txt",
                     brioche_test::file_with_resources(
-                        brioche_test::blob(&brioche, b"reference data").await,
+                        brioche_test::blob(&brioche, b"hello").await,
                         false,
-                        brioche_test::dir_value([(
-                            "hi_ref_ref.txt",
-                            brioche_test::file(
-                                brioche_test::blob(&brioche, b"reference reference data").await,
-                                false,
-                            ),
-                        )]),
+                        brioche_test::dir_value(
+                            &brioche,
+                            [(
+                                "hi_ref.txt",
+                                brioche_test::file_with_resources(
+                                    brioche_test::blob(&brioche, b"reference data").await,
+                                    false,
+                                    brioche_test::dir_value(
+                                        &brioche,
+                                        [(
+                                            "hi_ref_ref.txt",
+                                            brioche_test::file(
+                                                brioche_test::blob(
+                                                    &brioche,
+                                                    b"reference reference data",
+                                                )
+                                                .await,
+                                                false,
+                                            ),
+                                        )],
+                                    )
+                                    .await,
+                                ),
+                            )],
+                        )
+                        .await,
                     ),
-                )]),
-            ),
-        )]),
-    )]);
+                )],
+            )
+            .await,
+        )],
+    )
+    .await;
 
     create_output(&brioche, &context.path("output"), &artifact, false).await?;
 
@@ -470,33 +561,55 @@ async fn test_output_dir_with_nested_resources() -> anyhow::Result<()> {
 async fn test_output_dir_with_equal_resources() -> anyhow::Result<()> {
     let (brioche, context) = brioche_test::brioche_test().await;
 
-    let artifact = brioche_test::dir([(
-        "hello",
-        brioche_test::dir([
-            (
-                "hi.txt",
-                brioche_test::file_with_resources(
-                    brioche_test::blob(&brioche, b"hello").await,
-                    false,
-                    brioche_test::dir_value([(
-                        "same.txt",
-                        brioche_test::file(brioche_test::blob(&brioche, b"a").await, false),
-                    )]),
-                ),
-            ),
-            (
-                "second.txt",
-                brioche_test::file_with_resources(
-                    brioche_test::blob(&brioche, b"2").await,
-                    false,
-                    brioche_test::dir_value([(
-                        "same.txt",
-                        brioche_test::file(brioche_test::blob(&brioche, b"a").await, false),
-                    )]),
-                ),
-            ),
-        ]),
-    )]);
+    let artifact = brioche_test::dir(
+        &brioche,
+        [(
+            "hello",
+            brioche_test::dir(
+                &brioche,
+                [
+                    (
+                        "hi.txt",
+                        brioche_test::file_with_resources(
+                            brioche_test::blob(&brioche, b"hello").await,
+                            false,
+                            brioche_test::dir_value(
+                                &brioche,
+                                [(
+                                    "same.txt",
+                                    brioche_test::file(
+                                        brioche_test::blob(&brioche, b"a").await,
+                                        false,
+                                    ),
+                                )],
+                            )
+                            .await,
+                        ),
+                    ),
+                    (
+                        "second.txt",
+                        brioche_test::file_with_resources(
+                            brioche_test::blob(&brioche, b"2").await,
+                            false,
+                            brioche_test::dir_value(
+                                &brioche,
+                                [(
+                                    "same.txt",
+                                    brioche_test::file(
+                                        brioche_test::blob(&brioche, b"a").await,
+                                        false,
+                                    ),
+                                )],
+                            )
+                            .await,
+                        ),
+                    ),
+                ],
+            )
+            .await,
+        )],
+    )
+    .await;
 
     create_output(&brioche, &context.path("output"), &artifact, false).await?;
 
@@ -524,10 +637,14 @@ async fn test_output_top_level_file_with_resources_fails() -> anyhow::Result<()>
     let artifact = brioche_test::file_with_resources(
         brioche_test::blob(&brioche, b"hello").await,
         false,
-        brioche_test::dir_value([(
-            "same.txt",
-            brioche_test::file(brioche_test::blob(&brioche, b"a").await, false),
-        )]),
+        brioche_test::dir_value(
+            &brioche,
+            [(
+                "same.txt",
+                brioche_test::file(brioche_test::blob(&brioche, b"a").await, false),
+            )],
+        )
+        .await,
     );
 
     let result = create_output(&brioche, &context.path("output"), &artifact, false).await;
@@ -545,10 +662,14 @@ async fn test_output_top_level_file_with_parallel_resources() -> anyhow::Result<
     let artifact = brioche_test::file_with_resources(
         brioche_test::blob(&brioche, b"hello").await,
         false,
-        brioche_test::dir_value([(
-            "resource.txt",
-            brioche_test::file(brioche_test::blob(&brioche, b"a").await, false),
-        )]),
+        brioche_test::dir_value(
+            &brioche,
+            [(
+                "resource.txt",
+                brioche_test::file(brioche_test::blob(&brioche, b"a").await, false),
+            )],
+        )
+        .await,
     );
 
     create_output_with_resources(

--- a/crates/brioche/tests/resolve_basic.rs
+++ b/crates/brioche/tests/resolve_basic.rs
@@ -14,27 +14,65 @@ async fn test_resolve_basic() -> anyhow::Result<()> {
     let blob_hello = brioche_test::blob(&brioche, b"hello").await;
     let file_hello = brioche_test::lazy_file(blob_hello, false);
 
-    let empty_dir = brioche_test::lazy_dir_empty();
+    let lazy_empty_dir = brioche_test::lazy_dir_empty();
+    let empty_dir = brioche_test::dir_empty();
 
-    let hello_dir = brioche_test::lazy_dir([
+    let lazy_hello_dir = brioche_test::lazy_dir([
         ("hello.txt", file_hello.clone()),
         ("hi.txt", file_hello.clone()),
     ]);
+    let hello_dir = brioche_test::dir(
+        &brioche,
+        [
+            ("hello.txt", brioche_test::file(blob_hello, false)),
+            ("hi.txt", brioche_test::file(blob_hello, false)),
+        ],
+    )
+    .await;
 
-    let complex_dir = brioche_test::lazy_dir([
+    let lazy_complex_dir = brioche_test::lazy_dir([
         ("hello.txt", file_hello.clone()),
-        ("hello", hello_dir.clone()),
-        ("empty", empty_dir.clone()),
+        ("hello", lazy_hello_dir.clone()),
+        ("empty", lazy_empty_dir.clone()),
         ("link", brioche_test::lazy_symlink("hello.txt")),
     ]);
+    let complex_dir = brioche_test::dir(
+        &brioche,
+        [
+            ("hello.txt", brioche_test::file(blob_hello, false)),
+            (
+                "hello",
+                brioche_test::dir(
+                    &brioche,
+                    [
+                        ("hello.txt", brioche_test::file(blob_hello, false)),
+                        ("hi.txt", brioche_test::file(blob_hello, false)),
+                    ],
+                )
+                .await,
+            ),
+            ("empty", empty_dir.clone()),
+            ("link", brioche_test::symlink("hello.txt")),
+        ],
+    )
+    .await;
 
     assert_eq!(resolve_to_lazy(&brioche, &file_hello).await, file_hello);
 
-    assert_eq!(resolve_to_lazy(&brioche, &empty_dir).await, empty_dir);
+    assert_eq!(
+        resolve_to_lazy(&brioche, &lazy_empty_dir).await,
+        empty_dir.into()
+    );
 
-    assert_eq!(resolve_to_lazy(&brioche, &hello_dir).await, hello_dir);
+    assert_eq!(
+        resolve_to_lazy(&brioche, &lazy_hello_dir).await,
+        hello_dir.into()
+    );
 
-    assert_eq!(resolve_to_lazy(&brioche, &complex_dir).await, complex_dir);
+    assert_eq!(
+        resolve_to_lazy(&brioche, &lazy_complex_dir).await,
+        complex_dir.into()
+    );
 
     Ok(())
 }

--- a/crates/brioche/tests/resolve_cache.rs
+++ b/crates/brioche/tests/resolve_cache.rs
@@ -34,7 +34,11 @@ async fn test_resolve_cache_nested() -> anyhow::Result<()> {
     // The cache from hello_download should be re-used
     assert_eq!(
         resolve_without_meta(&brioche, hello_nested_download).await?,
-        brioche_test::dir([("file.txt", brioche_test::file(hello_blob, false))]),
+        brioche_test::dir(
+            &brioche,
+            [("file.txt", brioche_test::file(hello_blob, false))]
+        )
+        .await,
     );
 
     hello_endpoint.assert();
@@ -67,7 +71,11 @@ async fn test_resolve_cache_unnested() -> anyhow::Result<()> {
 
     assert_eq!(
         resolve_without_meta(&brioche, hello_nested_download).await?,
-        brioche_test::dir([("file.txt", brioche_test::file(hello_blob, false))]),
+        brioche_test::dir(
+            &brioche,
+            [("file.txt", brioche_test::file(hello_blob, false))]
+        )
+        .await,
     );
 
     // The cache from hello_nested_download should be re-used

--- a/crates/brioche/tests/resolve_proxy.rs
+++ b/crates/brioche/tests/resolve_proxy.rs
@@ -28,7 +28,7 @@ async fn test_resolve_proxy() -> anyhow::Result<()> {
     let merge_proxy_result = resolve_without_meta(&brioche, merge_proxy).await?;
     assert_eq!(
         merge_proxy_result,
-        brioche_test::dir([("hello", brioche_test::file(hello_blob, false))])
+        brioche_test::dir(&brioche, [("hello", brioche_test::file(hello_blob, false))]).await,
     );
 
     Ok(())

--- a/crates/brioche/tests/script_eval.rs
+++ b/crates/brioche/tests/script_eval.rs
@@ -18,7 +18,7 @@ async fn test_eval_basic() -> anyhow::Result<()> {
                         briocheSerialize: () => {
                             return {
                                 type: "directory",
-                                entries: {},
+                                tree: null,
                             }
                         },
                     };
@@ -31,7 +31,7 @@ async fn test_eval_basic() -> anyhow::Result<()> {
 
     let resolved = evaluate(&brioche, &project, "default").await?.value;
 
-    assert_eq!(resolved, brioche_test::lazy_dir_empty());
+    assert_eq!(resolved, brioche_test::dir_empty().into());
 
     Ok(())
 }
@@ -52,7 +52,7 @@ async fn test_eval_custom_export() -> anyhow::Result<()> {
                         briocheSerialize: () => {
                             return {
                                 type: "directory",
-                                entries: {},
+                                tree: null,
                             }
                         },
                     };
@@ -65,7 +65,7 @@ async fn test_eval_custom_export() -> anyhow::Result<()> {
 
     let resolved = evaluate(&brioche, &project, "custom").await?.value;
 
-    assert_eq!(resolved, brioche_test::lazy_dir_empty());
+    assert_eq!(resolved, brioche_test::dir_empty().into());
 
     Ok(())
 }
@@ -86,7 +86,7 @@ async fn test_eval_async() -> anyhow::Result<()> {
                         briocheSerialize: () => {
                             return {
                                 type: "directory",
-                                entries: {},
+                                tree: null,
                             }
                         },
                     };
@@ -99,7 +99,7 @@ async fn test_eval_async() -> anyhow::Result<()> {
 
     let resolved = evaluate(&brioche, &project, "default").await?.value;
 
-    assert_eq!(resolved, brioche_test::lazy_dir_empty());
+    assert_eq!(resolved, brioche_test::dir_empty().into());
 
     Ok(())
 }
@@ -120,7 +120,7 @@ async fn test_eval_serialize_async() -> anyhow::Result<()> {
                         briocheSerialize: async () => {
                             return {
                                 type: "directory",
-                                entries: {},
+                                tree: null,
                             }
                         },
                     };
@@ -133,7 +133,7 @@ async fn test_eval_serialize_async() -> anyhow::Result<()> {
 
     let resolved = evaluate(&brioche, &project, "default").await?.value;
 
-    assert_eq!(resolved, brioche_test::lazy_dir_empty());
+    assert_eq!(resolved, brioche_test::dir_empty().into());
 
     Ok(())
 }
@@ -153,7 +153,7 @@ async fn test_eval_import_local() -> anyhow::Result<()> {
                         briocheSerialize: () => {
                             return {
                                 type: "directory",
-                                entries: {},
+                                tree: null,
                             }
                         },
                     };
@@ -179,7 +179,7 @@ async fn test_eval_import_local() -> anyhow::Result<()> {
 
     let resolved = evaluate(&brioche, &project, "default").await?.value;
 
-    assert_eq!(resolved, brioche_test::lazy_dir_empty());
+    assert_eq!(resolved, brioche_test::dir_empty().into());
 
     Ok(())
 }
@@ -217,7 +217,7 @@ async fn test_eval_import_dep() -> anyhow::Result<()> {
                         briocheSerialize: () => {
                             return {
                                 type: "directory",
-                                entries: {},
+                                tree: null,
                             }
                         },
                     };
@@ -230,7 +230,7 @@ async fn test_eval_import_dep() -> anyhow::Result<()> {
 
     let resolved = evaluate(&brioche, &project, "default").await?.value;
 
-    assert_eq!(resolved, brioche_test::lazy_dir_empty());
+    assert_eq!(resolved, brioche_test::dir_empty().into());
 
     Ok(())
 }

--- a/crates/brioche/tests/script_eval.rs
+++ b/crates/brioche/tests/script_eval.rs
@@ -18,7 +18,7 @@ async fn test_eval_basic() -> anyhow::Result<()> {
                         briocheSerialize: () => {
                             return {
                                 type: "directory",
-                                tree: null,
+                                listingBlob: null,
                             }
                         },
                     };
@@ -52,7 +52,7 @@ async fn test_eval_custom_export() -> anyhow::Result<()> {
                         briocheSerialize: () => {
                             return {
                                 type: "directory",
-                                tree: null,
+                                listingBlob: null,
                             }
                         },
                     };
@@ -86,7 +86,7 @@ async fn test_eval_async() -> anyhow::Result<()> {
                         briocheSerialize: () => {
                             return {
                                 type: "directory",
-                                tree: null,
+                                listingBlob: null,
                             }
                         },
                     };
@@ -120,7 +120,7 @@ async fn test_eval_serialize_async() -> anyhow::Result<()> {
                         briocheSerialize: async () => {
                             return {
                                 type: "directory",
-                                tree: null,
+                                listingBlob: null,
                             }
                         },
                     };
@@ -153,7 +153,7 @@ async fn test_eval_import_local() -> anyhow::Result<()> {
                         briocheSerialize: () => {
                             return {
                                 type: "directory",
-                                tree: null,
+                                listingBlob: null,
                             }
                         },
                     };
@@ -217,7 +217,7 @@ async fn test_eval_import_dep() -> anyhow::Result<()> {
                         briocheSerialize: () => {
                             return {
                                 type: "directory",
-                                tree: null,
+                                listingBlob: null,
                             }
                         },
                     };


### PR DESCRIPTION
This PR updates how `Directory` artifacts are represented: rather than storing a map of file/entry names, it now stores a blob ID (much like a file artifact does). The blob referred to by this ID will then contain a (canonicalized) JSON payload that can be deserialized into a `DirectoryListing` structure (which in turn, contains a map of file/entry names).

This new representation was inspired by Git's representation of directories, which internally use "directory tree objects", or plain text files listing the other objects making up the directory's entries (I found the ["inside .git"](https://wizardzines.com/comics/inside-git/) zine especially helpful for understanding this!)

I was hoping this new implementation would be noticeably faster. While testing did show some improvements in some areas, it was only on a scale of 10-100ms or so. The main reason I pressed forward with this implementation anyways was because I felt like introducing this layer of indirection was a bit cleaner, and could make some future work easier (hopefully, anyway!)