### PR TITLE
Use "tick encoding" for encoding binary data in JSON

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,7 +209,7 @@ checksum = "5fd55a5ba1179988837d24ab4c7cc8ed6efdeff578ede0416b4225a5fca35bd0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -231,7 +231,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -242,7 +242,7 @@ checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -723,7 +723,7 @@ checksum = "efeab2975f8102de445dcf898856a638332403c50216144653a89aec22fd79e0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -783,6 +783,7 @@ dependencies = [
  "tempdir",
  "termwiz 0.20.0",
  "thiserror",
+ "tick-encoding",
  "tokio",
  "tokio-tar",
  "tokio-util",
@@ -794,7 +795,6 @@ dependencies = [
  "ulid",
  "unshare",
  "url",
- "urlencoding",
 ]
 
 [[package]]
@@ -986,7 +986,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1277,7 +1277,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1288,7 +1288,7 @@ checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1346,7 +1346,7 @@ checksum = "3c65c2ffdafc1564565200967edc4851c7b55422d3913466688907efd05ea26f"
 dependencies = [
  "deno-proc-macro-rules-macros",
  "proc-macro2",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1358,7 +1358,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1451,7 +1451,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "syn 1.0.109",
- "syn 2.0.41",
+ "syn 2.0.48",
  "thiserror",
 ]
 
@@ -1829,7 +1829,7 @@ checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -3110,7 +3110,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -3199,7 +3199,7 @@ dependencies = [
  "phf_shared 0.11.2",
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -3237,7 +3237,7 @@ checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -3332,7 +3332,7 @@ checksum = "52a40bc70c2c58040d2d8b167ba9a5ff59fc9dab7ad44771cfde3dcfde7a09c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -3405,9 +3405,9 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.70"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39278fbbf5fb4f646ce651690877f89d1c5811a3d4acb27700c1cb3cdb78fd3b"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
  "unicode-ident",
 ]
@@ -3455,7 +3455,7 @@ dependencies = [
  "itertools 0.11.0",
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -3484,9 +3484,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -3822,7 +3822,7 @@ dependencies = [
  "quote",
  "rust-embed-utils",
  "shellexpand",
- "syn 2.0.41",
+ "syn 2.0.48",
  "walkdir",
 ]
 
@@ -4015,7 +4015,7 @@ checksum = "1db149f81d46d2deba7cd3c50772474707729550221e69588478ebf9ada425ae"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -4026,7 +4026,7 @@ checksum = "7f81c2fde025af7e69b1d1420531c8a8811ca898919db177141a85313b1cb932"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -4127,7 +4127,7 @@ checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -4161,7 +4161,7 @@ checksum = "3081f5ffbb02284dda55132aa26daecedd7372a42417bbbab6f14ab7d6bb9145"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -4227,7 +4227,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -4757,7 +4757,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -5136,9 +5136,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.41"
+version = "2.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c8b28c477cc3bf0e7966561e3460130e1255f7a1cf71931075f1c5e7a7e269"
+checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5329,22 +5329,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.51"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f11c217e1416d6f036b870f14e0413d480dbf28edbee1f877abaf0206af43bb7"
+checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.51"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01742297787513b79cf8e29d1056ede1313e2420b7b3b15d0a768b4921f549df"
+checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -5377,6 +5377,15 @@ dependencies = [
  "log",
  "ordered-float 2.10.1",
  "threadpool",
+]
+
+[[package]]
+name = "tick-encoding"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0159bb977d6d6cdf04ebf88a23aa0f158df4ce737a13ae40528f488e5f9efcf"
+dependencies = [
+ "thiserror",
 ]
 
 [[package]]
@@ -5471,7 +5480,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -5689,7 +5698,7 @@ checksum = "84fd902d4e0b9a4b27f2f440108dc034e1758628a9b702f8ec61ad66355422fa"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -5718,7 +5727,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -6046,7 +6055,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
  "wasm-bindgen-shared",
 ]
 
@@ -6080,7 +6089,7 @@ checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -6443,7 +6452,7 @@ checksum = "b3c129550b3e6de3fd0ba67ba5c81818f9805e58b8d7fee80a3a59d2c9fc601a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -821,8 +821,8 @@ dependencies = [
  "serde_json",
  "serde_with",
  "thiserror",
+ "tick-encoding",
  "ulid",
- "urlencoding",
 ]
 
 [[package]]

--- a/crates/brioche-pack/Cargo.toml
+++ b/crates/brioche-pack/Cargo.toml
@@ -14,5 +14,5 @@ serde = { version = "1.0.193", features = ["derive"] }
 serde_with = { version = "3.4.0" }
 serde_json = { version = "1.0.108" }
 thiserror = "1.0.51"
+tick-encoding = "0.1.2"
 ulid = "1.1.0"
-urlencoding = "2.1.3"

--- a/crates/brioche-pack/src/encoding.rs
+++ b/crates/brioche-pack/src/encoding.rs
@@ -2,9 +2,9 @@ use std::{borrow::Cow, path::PathBuf};
 
 use bstr::{ByteSlice, ByteVec as _};
 
-pub enum UrlEncoded {}
+pub enum TickEncoded {}
 
-impl<T> serde_with::SerializeAs<T> for UrlEncoded
+impl<T> serde_with::SerializeAs<T> for TickEncoded
 where
     T: AsRef<[u8]>,
 {
@@ -12,12 +12,12 @@ where
     where
         S: serde::Serializer,
     {
-        let encoded = urlencoding::encode_binary(source.as_ref());
+        let encoded = tick_encoding::encode(source.as_ref());
         serializer.serialize_str(encoded.as_ref())
     }
 }
 
-impl<'de, T> serde_with::DeserializeAs<'de, T> for UrlEncoded
+impl<'de, T> serde_with::DeserializeAs<'de, T> for TickEncoded
 where
     T: TryFrom<Vec<u8>>,
     T::Error: std::fmt::Display,
@@ -27,7 +27,8 @@ where
         D: serde::Deserializer<'de>,
     {
         let encoded: Cow<'de, str> = serde::de::Deserialize::deserialize(deserializer)?;
-        let decoded = urlencoding::decode_binary(encoded.as_bytes());
+        let decoded =
+            tick_encoding::decode(encoded.as_bytes()).map_err(serde::de::Error::custom)?;
         let deserialized = T::try_from(decoded.into_owned()).map_err(serde::de::Error::custom)?;
         Ok(deserialized)
     }

--- a/crates/brioche-pack/src/lib.rs
+++ b/crates/brioche-pack/src/lib.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use encoding::UrlEncoded;
+use encoding::TickEncoded;
 
 pub mod autowrap;
 mod encoding;
@@ -17,7 +17,7 @@ type LengthInt = u32;
 #[derive(Debug, bincode::Encode, bincode::Decode, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Pack {
-    #[serde_as(as = "UrlEncoded")]
+    #[serde_as(as = "TickEncoded")]
     pub program: Vec<u8>,
     pub interpreter: Option<Interpreter>,
 }
@@ -55,9 +55,9 @@ impl Pack {
 pub enum Interpreter {
     #[serde(rename_all = "camelCase")]
     LdLinux {
-        #[serde_as(as = "UrlEncoded")]
+        #[serde_as(as = "TickEncoded")]
         path: Vec<u8>,
-        #[serde_as(as = "Vec<UrlEncoded>")]
+        #[serde_as(as = "Vec<TickEncoded>")]
         library_paths: Vec<Vec<u8>>,
     },
 }

--- a/crates/brioche/Cargo.toml
+++ b/crates/brioche/Cargo.toml
@@ -52,6 +52,7 @@ strum = { version = "0.25.0", features = ["derive"] }
 superconsole = "0.2.0"
 termwiz = "0.20.0"
 thiserror = "1.0.51"
+tick-encoding = "0.1.2"
 tokio = { version = "1.35.0", features = ["full", "tracing"] }
 tokio-tar = "0.3.1"
 tokio-util = { version = "0.7.10", features = ["compat", "full"] }
@@ -63,7 +64,6 @@ tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json", "tr
 ulid = "1.1.0"
 unshare = { git = "https://github.com/brioche-dev/unshare.git" }
 url = { version = "2.5.0", features = ["serde"] }
-urlencoding = "2.1.3"
 
 [dev-dependencies]
 assert_matches = "1.5.0"

--- a/crates/brioche/src/brioche/artifact.rs
+++ b/crates/brioche/src/brioche/artifact.rs
@@ -7,7 +7,7 @@ use std::{
 use bstr::{BStr, BString};
 use serde::Serialize;
 
-use crate::encoding::UrlEncoded;
+use crate::encoding::TickEncoded;
 
 use super::{
     blob::{self, BlobId},
@@ -42,7 +42,7 @@ pub enum LazyArtifact {
     Directory(Directory),
     #[serde(rename_all = "camelCase")]
     Symlink {
-        #[serde_as(as = "UrlEncoded")]
+        #[serde_as(as = "TickEncoded")]
         target: BString,
     },
     #[serde(rename_all = "camelCase")]
@@ -53,7 +53,7 @@ pub enum LazyArtifact {
     CompleteProcess(CompleteProcessArtifact),
     #[serde(rename_all = "camelCase")]
     CreateFile {
-        #[serde_as(as = "UrlEncoded")]
+        #[serde_as(as = "TickEncoded")]
         content: BString,
         executable: bool,
         resources: Box<WithMeta<LazyArtifact>>,
@@ -77,13 +77,13 @@ pub enum LazyArtifact {
     #[serde(rename_all = "camelCase")]
     Get {
         directory: Box<WithMeta<LazyArtifact>>,
-        #[serde_as(as = "UrlEncoded")]
+        #[serde_as(as = "TickEncoded")]
         path: BString,
     },
     #[serde(rename_all = "camelCase")]
     Insert {
         directory: Box<WithMeta<LazyArtifact>>,
-        #[serde_as(as = "UrlEncoded")]
+        #[serde_as(as = "TickEncoded")]
         path: BString,
         artifact: Option<Box<WithMeta<LazyArtifact>>>,
     },
@@ -240,7 +240,7 @@ impl std::fmt::Display for StackFrame {
 #[derive(Debug, Clone, Default, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CreateDirectory {
-    #[serde_as(as = "BTreeMap<UrlEncoded, _>")]
+    #[serde_as(as = "BTreeMap<TickEncoded, _>")]
     pub entries: BTreeMap<BString, WithMeta<LazyArtifact>>,
 }
 
@@ -272,7 +272,7 @@ pub struct UnpackArtifact {
 pub struct ProcessArtifact {
     pub command: ProcessTemplate,
     pub args: Vec<ProcessTemplate>,
-    #[serde_as(as = "BTreeMap<UrlEncoded, _>")]
+    #[serde_as(as = "BTreeMap<TickEncoded, _>")]
     pub env: BTreeMap<BString, ProcessTemplate>,
     pub work_dir: Box<WithMeta<LazyArtifact>>,
     pub platform: Platform,
@@ -284,7 +284,7 @@ pub struct ProcessArtifact {
 pub struct CompleteProcessArtifact {
     pub command: CompleteProcessTemplate,
     pub args: Vec<CompleteProcessTemplate>,
-    #[serde_as(as = "BTreeMap<UrlEncoded, _>")]
+    #[serde_as(as = "BTreeMap<TickEncoded, _>")]
     pub env: BTreeMap<BString, CompleteProcessTemplate>,
     pub work_dir: Directory,
     pub platform: Platform,
@@ -311,7 +311,7 @@ pub enum CompleteArtifact {
     File(File),
     #[serde(rename_all = "camelCase")]
     Symlink {
-        #[serde_as(as = "UrlEncoded")]
+        #[serde_as(as = "TickEncoded")]
         target: BString,
     },
     #[serde(rename_all = "camelCase")]
@@ -388,7 +388,7 @@ impl Directory {
 #[derive(Debug, Default, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DirectoryListing {
-    #[serde_as(as = "BTreeMap<UrlEncoded, _>")]
+    #[serde_as(as = "BTreeMap<TickEncoded, _>")]
     pub entries: BTreeMap<BString, WithMeta<CompleteArtifact>>,
 }
 
@@ -711,7 +711,7 @@ pub struct ProcessTemplate {
 #[serde(rename_all = "snake_case")]
 pub enum ProcessTemplateComponent {
     Literal {
-        #[serde_as(as = "UrlEncoded")]
+        #[serde_as(as = "TickEncoded")]
         value: BString,
     },
     Input {
@@ -736,7 +736,7 @@ pub struct CompleteProcessTemplate {
 #[serde(rename_all = "snake_case")]
 pub enum CompleteProcessTemplateComponent {
     Literal {
-        #[serde_as(as = "UrlEncoded")]
+        #[serde_as(as = "TickEncoded")]
         value: BString,
     },
     Input {

--- a/crates/brioche/src/brioche/script.rs
+++ b/crates/brioche/src/brioche/script.rs
@@ -192,12 +192,12 @@ pub async fn op_brioche_create_proxy(
     Ok(result)
 }
 
-// TODO: Return a Uint8Array instead of URL-encoding
+// TODO: Return a Uint8Array instead of tick-encoding
 #[deno_core::op]
 pub async fn op_brioche_read_blob(
     state: Rc<RefCell<OpState>>,
     blob_id: BlobId,
-) -> anyhow::Result<crate::encoding::UrlEncode<Vec<u8>>> {
+) -> anyhow::Result<crate::encoding::TickEncode<Vec<u8>>> {
     let brioche = {
         let state = state.try_borrow()?;
         state
@@ -211,5 +211,5 @@ pub async fn op_brioche_read_blob(
         .await
         .with_context(|| format!("failed to read blob {blob_id}"))?;
 
-    Ok(crate::encoding::UrlEncode(bytes))
+    Ok(crate::encoding::TickEncode(bytes))
 }

--- a/crates/brioche/src/brioche/script/js.rs
+++ b/crates/brioche/src/brioche/script/js.rs
@@ -10,8 +10,8 @@ deno_core::extension!(
         op_brioche_stack_frames_from_exception,
         op_brioche_utf8_encode,
         op_brioche_utf8_decode,
-        op_brioche_url_encode,
-        op_brioche_url_decode,
+        op_brioche_tick_encode,
+        op_brioche_tick_decode,
     ],
 );
 
@@ -80,17 +80,17 @@ fn op_brioche_utf8_decode(bytes: v8::Local<v8::Uint8Array>) -> anyhow::Result<St
 
 #[deno_core::op2]
 #[string]
-fn op_brioche_url_encode(bytes: v8::Local<v8::Uint8Array>) -> anyhow::Result<String> {
+fn op_brioche_tick_encode(bytes: v8::Local<v8::Uint8Array>) -> anyhow::Result<String> {
     let byte_length = bytes.byte_length();
     let mut buffer = vec![0; byte_length];
     let copied_length = bytes.copy_contents(&mut buffer);
     anyhow::ensure!(copied_length == byte_length, "mismatch in copied bytes");
-    let encoded = urlencoding::encode_binary(&buffer).into_owned();
+    let encoded = tick_encoding::encode(&buffer).into_owned();
     Ok(encoded)
 }
 
 #[deno_core::op2]
-fn op_brioche_url_decode<'a>(
+fn op_brioche_tick_decode<'a>(
     scope: &'a mut v8::HandleScope,
     bytes: v8::Local<'a, v8::Uint8Array>,
 ) -> anyhow::Result<v8::Local<'a, v8::Uint8Array>> {
@@ -99,7 +99,7 @@ fn op_brioche_url_decode<'a>(
     let copied_length = bytes.copy_contents(&mut buffer);
     anyhow::ensure!(copied_length == byte_length, "mismatch in copied bytes");
 
-    let encoded = urlencoding::decode_binary(&buffer).into_owned();
+    let encoded = tick_encoding::decode(&buffer)?.into_owned();
 
     let backing_store = v8::ArrayBuffer::new_backing_store_from_vec(encoded);
     let encoded_buffer = v8::ArrayBuffer::with_backing_store(scope, &backing_store.make_shared());

--- a/crates/brioche/src/sandbox.rs
+++ b/crates/brioche/src/sandbox.rs
@@ -2,19 +2,19 @@ use std::{collections::HashMap, ffi::OsString, path::PathBuf};
 
 use bstr::ByteSlice as _;
 
-use crate::encoding::{AsPath, UrlEncoded};
+use crate::encoding::{AsPath, TickEncoded};
 
 #[serde_with::serde_as]
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SandboxExecutionConfig {
-    #[serde_as(as = "AsPath<UrlEncoded>")]
+    #[serde_as(as = "AsPath<TickEncoded>")]
     pub sandbox_root: PathBuf,
-    #[serde_as(as = "HashMap<AsPath<UrlEncoded>, _>")]
+    #[serde_as(as = "HashMap<AsPath<TickEncoded>, _>")]
     pub include_host_paths: HashMap<PathBuf, SandboxPathOptions>,
     pub command: SandboxTemplate,
     pub args: Vec<SandboxTemplate>,
-    #[serde_as(as = "HashMap<UrlEncoded, _>")]
+    #[serde_as(as = "HashMap<TickEncoded, _>")]
     pub env: HashMap<bstr::BString, SandboxTemplate>,
     pub current_dir: SandboxPath,
     pub uid_hint: u32,
@@ -25,7 +25,7 @@ pub struct SandboxExecutionConfig {
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SandboxPath {
-    #[serde_as(as = "AsPath<UrlEncoded>")]
+    #[serde_as(as = "AsPath<TickEncoded>")]
     pub host_path: PathBuf,
     #[serde(flatten)]
     pub options: SandboxPathOptions,
@@ -36,7 +36,7 @@ pub struct SandboxPath {
 #[serde(rename_all = "camelCase")]
 pub struct SandboxPathOptions {
     pub mode: HostPathMode,
-    #[serde_as(as = "UrlEncoded")]
+    #[serde_as(as = "TickEncoded")]
     pub guest_path_hint: bstr::BString,
 }
 
@@ -52,7 +52,7 @@ pub struct SandboxTemplate {
 #[serde(rename_all = "camelCase")]
 pub enum SandboxTemplateComponent {
     Literal {
-        #[serde_as(as = "UrlEncoded")]
+        #[serde_as(as = "TickEncoded")]
         value: bstr::BString,
     },
     Path(SandboxPath),

--- a/crates/brioche/tests/artifact_hash_stable.rs
+++ b/crates/brioche/tests/artifact_hash_stable.rs
@@ -213,11 +213,11 @@ async fn test_artifact_hash_stable_symlink() -> anyhow::Result<()> {
 
     asserts.push((
         brioche_test::lazy_symlink(b"/foo").hash().to_string(),
-        "9d1f6c07805817d5e6608bae751fe65e7e9c0f90435140c33934de8250fe4be1",
+        "c8c223c202dff16e2c257dd1f5e764c2ab919bb6ae4e019e1c6eee1aa66a6393",
     ));
     asserts.push((
         brioche_test::symlink(b"/foo").hash().to_string(),
-        "9d1f6c07805817d5e6608bae751fe65e7e9c0f90435140c33934de8250fe4be1",
+        "c8c223c202dff16e2c257dd1f5e764c2ab919bb6ae4e019e1c6eee1aa66a6393",
     ));
 
     let left: Vec<_> = asserts.iter().map(|(left, _)| left).collect();
@@ -295,7 +295,7 @@ async fn test_artifact_hash_stable_process() -> anyhow::Result<()> {
         })
         .hash()
         .to_string(),
-        "024e1e606bdbbfafbc6be05b0e60186a023500ca446a534a2637ef48a11563c8",
+        "66900de43c1d7425a3613aed799e3728bc87e004843c019e56f619c52ef903cd",
     ));
 
     asserts.push((
@@ -314,7 +314,7 @@ async fn test_artifact_hash_stable_process() -> anyhow::Result<()> {
         })
         .hash()
         .to_string(),
-        "357d2e036720b2fd5b872f5d3b746d49a40e6a293a18ce05f56fa50986049a53",
+        "636ada2393c79fb91afb11b3a536daa6bd6f92e66be3ebe2e521efe7644da4c1",
     ));
 
     asserts.push((
@@ -340,7 +340,7 @@ async fn test_artifact_hash_stable_process() -> anyhow::Result<()> {
         })
         .hash()
         .to_string(),
-        "323435cce7936a9bb68834908a2e37c80e5e1bd8223100103081d1f4d6808544",
+        "bd926c17a17897022fdae3d6e899eeb770b0994caf34366c0b6ed0acc8e2648f",
     ));
 
     asserts.push((
@@ -371,7 +371,7 @@ async fn test_artifact_hash_stable_process() -> anyhow::Result<()> {
         })
         .hash()
         .to_string(),
-        "256263f7acbeb184b90eed36a27784d171816944315948399b62837a44d1ca0c",
+        "2fa878536d82f6be721ae00b8b404f3aef20b67d301fa9535ad867ca4ea4bf0c",
     ));
 
     let left: Vec<_> = asserts.iter().map(|(left, _)| left).collect();


### PR DESCRIPTION
This PR replaces all uses of URL encoding in Brioche (a.k.a percent encoding) with [`tick-encoding`](https://crates.io/crates/tick-encoding) (a small crate I wrote over the weekend). While URL encoding has worked well, it has some undesirable properties in the context of Brioche:

- No unambiguous canonical encoding (e.g. `encodeURI` vs `encodeURIComponents` both being valid URL encodings). This is bad in the context of hashing artifacts, where it's better to ideally have one unambiguous serialized representation of an artifact
- More wasteful than it has to be. Since we're not bound by the limitations of URLs, we end up needing to escape some characters that absolutely do not need to be escaped in JSON. As such, we just end up wasting a bit of space.
- Kinda ugly. Trying to read a URL-encoded Bash script is... unpleasant (obviously not something an end-user would ever need to deal with but still!)

Tick Encoding is a small binary ↔ ASCII string encoding scheme I wrote, which is very similar to URL encoding but meant to work better for Brioche's use-case. To summarize, it doesn't require escaping ASCII tabs, spaces, newlines, or printable ASCII characters (except "\`"); backtick ("\`") is escaped as "\`\`"; any other bytes are escaped as backtick followed by uppercase hex (`0xFF` is encoded as "\`FF").