### PR TITLE
Switch to using Canonical JSON encoding for artifact hashes

### DIFF
--- a/crates/brioche/benches/brioche_bench/mod.rs
+++ b/crates/brioche/benches/brioche_bench/mod.rs
@@ -58,7 +58,9 @@ pub fn file(blob: BlobId, executable: bool) -> brioche::brioche::artifact::Compl
     brioche::brioche::artifact::CompleteArtifact::File(File {
         content_blob: blob,
         executable,
-        resources: Directory::default(),
+        resources: Box::new(brioche::brioche::artifact::CompleteArtifact::Directory(
+            Directory::default(),
+        )),
     })
 }
 
@@ -70,7 +72,9 @@ pub fn file_with_resources(
     brioche::brioche::artifact::CompleteArtifact::File(File {
         content_blob: blob,
         executable,
-        resources,
+        resources: Box::new(brioche::brioche::artifact::CompleteArtifact::Directory(
+            resources,
+        )),
     })
 }
 

--- a/crates/brioche/src/brioche/artifact.rs
+++ b/crates/brioche/src/brioche/artifact.rs
@@ -320,7 +320,7 @@ impl CompleteArtifact {
 pub struct File {
     pub content_blob: BlobId,
     pub executable: bool,
-    pub resources: Directory,
+    pub resources: Box<CompleteArtifact>,
 }
 
 #[serde_with::serde_as]
@@ -571,7 +571,7 @@ impl TryFrom<LazyArtifact> for CompleteArtifact {
                 Ok(CompleteArtifact::File(File {
                     content_blob: data,
                     executable,
-                    resources,
+                    resources: Box::new(CompleteArtifact::Directory(resources)),
                 }))
             }
             LazyArtifact::Symlink { target } => Ok(CompleteArtifact::Symlink { target }),
@@ -606,7 +606,7 @@ impl From<CompleteArtifact> for LazyArtifact {
             }) => Self::File {
                 content_blob: data,
                 executable,
-                resources: Box::new(WithMeta::without_meta(LazyArtifact::Directory(resources))),
+                resources: Box::new(WithMeta::without_meta(LazyArtifact::from(*resources))),
             },
             CompleteArtifact::Symlink { target } => Self::Symlink { target },
             CompleteArtifact::Directory(directory) => Self::Directory(directory),

--- a/crates/brioche/src/brioche/input.rs
+++ b/crates/brioche/src/brioche/input.rs
@@ -156,7 +156,7 @@ pub async fn create_input(
             CompleteArtifact::File(File {
                 content_blob: blob_id,
                 executable,
-                resources,
+                resources: Box::new(CompleteArtifact::Directory(resources)),
             }),
             options.meta.clone(),
         ))

--- a/crates/brioche/src/brioche/output.rs
+++ b/crates/brioche/src/brioche/output.rs
@@ -28,6 +28,10 @@ pub async fn create_output<'a: 'async_recursion>(
             executable,
             resources,
         }) => {
+            let CompleteArtifact::Directory(resources) = &**resources else {
+                anyhow::bail!("expected file resources to be a directory");
+            };
+
             if !resources.is_empty() {
                 let Some(resources_dir) = options.resources_dir else {
                     anyhow::bail!("cannot output file outside of a directory, file has references");

--- a/crates/brioche/src/brioche/resolve.rs
+++ b/crates/brioche/src/brioche/resolve.rs
@@ -200,7 +200,7 @@ async fn resolve_inner(
             Ok(CompleteArtifact::File(File {
                 content_blob,
                 executable,
-                resources,
+                resources: Box::new(CompleteArtifact::Directory(resources)),
             }))
         }
         LazyArtifact::Directory(directory) => Ok(CompleteArtifact::Directory(directory)),
@@ -246,7 +246,7 @@ async fn resolve_inner(
             Ok(CompleteArtifact::File(File {
                 content_blob: blob_id,
                 executable,
-                resources,
+                resources: Box::new(CompleteArtifact::Directory(resources)),
             }))
         }
         LazyArtifact::CreateDirectory(CreateDirectory { entries }) => {

--- a/crates/brioche/src/brioche/resolve/download.rs
+++ b/crates/brioche/src/brioche/resolve/download.rs
@@ -3,7 +3,7 @@ use futures::TryStreamExt as _;
 use tokio_util::compat::FuturesAsyncReadCompatExt as _;
 
 use crate::brioche::{
-    artifact::{Directory, DownloadArtifact, File},
+    artifact::{CompleteArtifact, Directory, DownloadArtifact, File},
     Brioche,
 };
 
@@ -74,6 +74,6 @@ pub async fn resolve_download(
     Ok(File {
         content_blob: blob_id,
         executable: false,
-        resources: Directory::default(),
+        resources: Box::new(CompleteArtifact::Directory(Directory::default())),
     })
 }

--- a/crates/brioche/src/brioche/resolve/unpack.rs
+++ b/crates/brioche/src/brioche/resolve/unpack.rs
@@ -68,7 +68,7 @@ pub async fn resolve_unpack(
                     CompleteArtifact::File(File {
                         content_blob: entry_blob_id,
                         executable,
-                        resources: Directory::default(),
+                        resources: Box::new(CompleteArtifact::Directory(Directory::default())),
                     })
                 }
                 tokio_tar::EntryType::Symlink => {

--- a/crates/brioche/tests/artifact_hash_stable.rs
+++ b/crates/brioche/tests/artifact_hash_stable.rs
@@ -24,7 +24,7 @@ async fn test_artifact_hash_stable_file() -> anyhow::Result<()> {
 
     asserts.push((
         brioche_test::file(hello_blob, false).hash().to_string(),
-        "6fb4535c83b1589958a5a77cf7eb108d26950eaced48e97af0a2af813049cc71",
+        "d227def794e3645dde5eaec99c66b593b6f3c2bcc0769104c3fb69c2058ae186",
     ));
     asserts.push((
         brioche_test::lazy_file(hello_blob, false)
@@ -35,7 +35,7 @@ async fn test_artifact_hash_stable_file() -> anyhow::Result<()> {
 
     asserts.push((
         brioche_test::file(hi_blob, false).hash().to_string(),
-        "523d859354928e55293c31408448f1612e2462bc0767677984be7914fb1d7c2b",
+        "97908c17864a649c59ad0e2fece3ea6769e473e4b8472fe1c010e2b307713f05",
     ));
     asserts.push((
         brioche_test::lazy_file(hi_blob, false).hash().to_string(),
@@ -44,7 +44,7 @@ async fn test_artifact_hash_stable_file() -> anyhow::Result<()> {
 
     asserts.push((
         brioche_test::file(hello_blob, true).hash().to_string(),
-        "0a2becce28ad606df34ce295d3fd3a32367faf74308da44edaccb27fc9379d6b",
+        "3648fb32ff94b7e51853e70b220a1012bfa38e33d4e88f5dfa6d1b1b0a231a4e",
     ));
     asserts.push((
         brioche_test::lazy_file(hello_blob, true).hash().to_string(),
@@ -63,7 +63,7 @@ async fn test_artifact_hash_stable_file() -> anyhow::Result<()> {
         )
         .hash()
         .to_string(),
-        "a14ca3b495a29622f02c985360446dbd0542fe1c568e9d321022467868143012",
+        "6b8e393b935024be81b311363e87e5ec04ee0c708325f1d2caee89986ebf1e2a",
     ));
     asserts.push((
         brioche_test::lazy_file_with_resources(
@@ -79,7 +79,7 @@ async fn test_artifact_hash_stable_file() -> anyhow::Result<()> {
         )
         .hash()
         .to_string(),
-        "27c51c86970f3ec17b0284a75cefd4a0693e392c5dc7402bde43ea012d7c11ce",
+        "6b8e393b935024be81b311363e87e5ec04ee0c708325f1d2caee89986ebf1e2a",
     ));
 
     let left: Vec<_> = asserts.iter().map(|(left, _)| left).collect();
@@ -118,7 +118,7 @@ async fn test_artifact_hash_stable_directory() -> anyhow::Result<()> {
         .await
         .hash()
         .to_string(),
-        "4e3f2610ff359d0675591f85ad87494907f16bb7089a16443a79c0506dbfbd52",
+        "b09749fe2c801b5dae89cf6a98475a9c5a4a99740cccf8b89aa0459f709d71c2",
     ));
     asserts.push((
         LazyArtifact::from(
@@ -130,7 +130,7 @@ async fn test_artifact_hash_stable_directory() -> anyhow::Result<()> {
         )
         .hash()
         .to_string(),
-        "4e3f2610ff359d0675591f85ad87494907f16bb7089a16443a79c0506dbfbd52",
+        "b09749fe2c801b5dae89cf6a98475a9c5a4a99740cccf8b89aa0459f709d71c2",
     ));
 
     asserts.push((
@@ -148,7 +148,7 @@ async fn test_artifact_hash_stable_directory() -> anyhow::Result<()> {
         .await
         .hash()
         .to_string(),
-        "9aa768d5c3ccf65c5cf7fdb7494d029106790189bc0422319368651c88434b6e",
+        "3416a6ebc40bdf233c4747db9af2d227e7a368948e23dabca8f54de072f567ce",
     ));
     asserts.push((
         LazyArtifact::from(
@@ -170,7 +170,7 @@ async fn test_artifact_hash_stable_directory() -> anyhow::Result<()> {
         )
         .hash()
         .to_string(),
-        "9aa768d5c3ccf65c5cf7fdb7494d029106790189bc0422319368651c88434b6e",
+        "3416a6ebc40bdf233c4747db9af2d227e7a368948e23dabca8f54de072f567ce",
     ));
 
     asserts.push((

--- a/crates/brioche/tests/brioche_test/mod.rs
+++ b/crates/brioche/tests/brioche_test/mod.rs
@@ -82,7 +82,9 @@ pub fn file(blob: BlobId, executable: bool) -> brioche::brioche::artifact::Compl
     brioche::brioche::artifact::CompleteArtifact::File(File {
         content_blob: blob,
         executable,
-        resources: Directory::default(),
+        resources: Box::new(brioche::brioche::artifact::CompleteArtifact::Directory(
+            Directory::default(),
+        )),
     })
 }
 
@@ -94,7 +96,9 @@ pub fn file_with_resources(
     brioche::brioche::artifact::CompleteArtifact::File(File {
         content_blob: blob,
         executable,
-        resources,
+        resources: Box::new(brioche::brioche::artifact::CompleteArtifact::Directory(
+            resources,
+        )),
     })
 }
 

--- a/crates/brioche/tests/resolve_process.rs
+++ b/crates/brioche/tests/resolve_process.rs
@@ -807,8 +807,8 @@ async fn test_resolve_process_output_with_resources() -> anyhow::Result<()> {
     };
 
     assert_eq!(
-        *resources,
-        brioche_test::dir_value(
+        **resources,
+        brioche_test::dir(
             &brioche,
             [
                 (


### PR DESCRIPTION
An "artifact hash" is the stable identifier used for caching resolves. Currently, Brioche serializes an artifact with [Bincode](https://github.com/bincode-org/bincode) then hashes it with BLAKE3 to generate an artifact hash.

Given the same data structure and serialization options, Bincode's format is stable. However, Bincode is explicitly not designed for handling versioning of data formats, and I believe even adding a new optional field will be a breaking change to a data format.

JSON is much better in this regard, especially when paired with Serde: it's relatively easy to add new fields, and even ensure that adding a new optional field doesn't change the serialized representation. JSON itself isn't suitable for cryptographic hashing, but luckily there are standards for that. This PR uses the [`olpc-cjson`](https://crates.io/crates/olpc-cjson) crate, which in turn implements [this Canonical JSON spec](https://wiki.laptop.org/go/Canonical_JSON) (the same spec used by [The Update Framework](https://theupdateframework.io/)).

---

One other minor change introduced by this PR is that it makes it so the `LazyArtifact::File(_)` and `CompleteArtifact::File(_)` enum variants get mapped to the same artifact hash. Previously, they differed because the `resources` field from `CompleteArtifact::File` omitted the `type` field (since the only valid type was `"directory"`).