### PR TITLE
Optimize locals with hardlinks

### DIFF
--- a/crates/brioche/src/brioche/output.rs
+++ b/crates/brioche/src/brioche/output.rs
@@ -8,20 +8,56 @@ use super::{
     Brioche,
 };
 
+struct LocalOutputLock(());
+
+static LOCAL_OUTPUT_MUTEX: tokio::sync::Mutex<LocalOutputLock> =
+    tokio::sync::Mutex::const_new(LocalOutputLock(()));
+
 #[derive(Debug, Clone, Copy)]
 pub struct OutputOptions<'a> {
     pub output_path: &'a Path,
     pub resources_dir: Option<&'a Path>,
     pub merge: bool,
+    pub link_locals: bool,
+}
+
+#[tracing::instrument(skip(brioche, artifact), fields(artifact_hash = %artifact.hash()), err)]
+pub async fn create_output(
+    brioche: &Brioche,
+    artifact: &CompleteArtifact,
+    options: OutputOptions<'_>,
+) -> anyhow::Result<()> {
+    let lock = if options.link_locals {
+        // If we use links into the `~/.local/share/brioche/locals` directory,
+        // lock a mutex to ensure we don't write to the same local more
+        // than once at a time
+        Some(LOCAL_OUTPUT_MUTEX.lock().await)
+    } else {
+        None
+    };
+
+    create_output_inner(brioche, artifact, options, lock.as_ref()).await?;
+    Ok(())
 }
 
 #[async_recursion::async_recursion]
-#[tracing::instrument(skip(brioche, artifact), fields(artifact_hash = %artifact.hash()), err)]
-pub async fn create_output<'a: 'async_recursion>(
+#[tracing::instrument(skip(brioche, artifact, link_lock), fields(artifact_hash = %artifact.hash()), err)]
+async fn create_output_inner<'a: 'async_recursion>(
     brioche: &Brioche,
     artifact: &CompleteArtifact,
     options: OutputOptions<'a>,
+    link_lock: Option<&'a tokio::sync::MutexGuard<'a, LocalOutputLock>>,
 ) -> anyhow::Result<()> {
+    let link_lock = match (options.link_locals, link_lock) {
+        (false, _) => None,
+        (true, Some(lock)) => Some(lock),
+        (true, None) => {
+            anyhow::bail!(
+                "tried to call `create_output_inner` with `link_locals`, but no lock was provided"
+            );
+        }
+    };
+
     match artifact {
         CompleteArtifact::File(File {
             content_blob,
@@ -33,14 +69,16 @@ pub async fn create_output<'a: 'async_recursion>(
                     anyhow::bail!("cannot output file outside of a directory, file has references");
                 };
 
-                create_output(
+                create_output_inner(
                     brioche,
                     &CompleteArtifact::Directory(resources.clone()),
                     OutputOptions {
                         output_path: resources_dir,
                         resources_dir: Some(resources_dir),
                         merge: true,
+                        link_locals: options.link_locals,
                     },
+                    link_lock,
                 )
                 .await?;
             }
@@ -108,16 +146,48 @@ pub async fn create_output<'a: 'async_recursion>(
                     }
                 };
 
-                create_output(
-                    brioche,
-                    &entry.value,
-                    OutputOptions {
-                        output_path: &entry_path,
-                        resources_dir: Some(resources_dir),
-                        merge: true,
-                    },
-                )
-                .await?;
+                match (&entry.value, link_lock) {
+                    (CompleteArtifact::File(file), Some(link_lock)) => {
+                        if !file.resources.is_empty() {
+                            create_output_inner(
+                                brioche,
+                                &CompleteArtifact::Directory(file.resources.clone()),
+                                OutputOptions {
+                                    output_path: resources_dir,
+                                    resources_dir: Some(resources_dir),
+                                    merge: true,
+                                    link_locals: options.link_locals,
+                                },
+                                Some(link_lock),
+                            )
+                            .await?;
+                        }
+
+                        // If `link_locals` is enabled, create a local output
+                        // for the file, then hardlink to it
+
+                        let local_output =
+                            create_local_output_inner(brioche, &entry.value, link_lock).await?;
+                        crate::fs_utils::try_remove(&entry_path).await?;
+                        tokio::fs::hard_link(&local_output.path, &entry_path)
+                            .await
+                            .context("failed to create hardlink into Brioche `locals` directory")?;
+                    }
+                    _ => {
+                        create_output_inner(
+                            brioche,
+                            &entry.value,
+                            OutputOptions {
+                                output_path: &entry_path,
+                                resources_dir: Some(resources_dir),
+                                merge: true,
+                                link_locals: options.link_locals,
+                            },
+                            link_lock,
+                        )
+                        .await?;
+                    }
+                }
             }
 
             set_directory_permissions(options.output_path).await?;
@@ -134,10 +204,18 @@ pub async fn create_local_output(
     // Use a mutex to ensure we don't try to create the same local output
     // simultaneously.
     // TODO: Make this function parallelizable
-    // TODO: Handle cleanup if creating a local output fails
-    static LOCAL_OUTPUT_MUTEX: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
-    let _lock = LOCAL_OUTPUT_MUTEX.lock().await;
+    let lock = LOCAL_OUTPUT_MUTEX.lock().await;
 
+    let result = create_local_output_inner(brioche, artifact, &lock).await?;
+
+    Ok(result)
+}
+
+async fn create_local_output_inner(
+    brioche: &Brioche,
+    artifact: &CompleteArtifact,
+    lock: &tokio::sync::MutexGuard<'_, LocalOutputLock>,
+) -> anyhow::Result<LocalOutput> {
     let local_dir = brioche.home.join("locals");
     tokio::fs::create_dir_all(&local_dir).await?;
 
@@ -152,14 +230,16 @@ pub async fn create_local_output(
         let local_temp_path = local_temp_dir.join(temp_id.to_string());
         let local_temp_resources_dir = local_temp_dir.join(format!("{temp_id}-pack.d"));
 
-        create_output(
+        create_output_inner(
             brioche,
             artifact,
             OutputOptions {
                 output_path: &local_temp_path,
                 resources_dir: Some(&local_temp_resources_dir),
                 merge: false,
+                link_locals: true,
             },
+            Some(lock),
         )
         .await?;
 

--- a/crates/brioche/src/brioche/resolve/process.rs
+++ b/crates/brioche/src/brioche/resolve/process.rs
@@ -639,6 +639,13 @@ impl ResolveDir {
 
     async fn remove(mut self) -> anyhow::Result<()> {
         let path = self.path.take().context("resolve dir not found")?;
+
+        // Ensure that directories are writable so we can recursively remove
+        // all files
+        crate::fs_utils::set_directory_rwx_recursive(&path)
+            .await
+            .context("failed to set permissions for temprorary resolve directory")?;
+
         tokio::fs::remove_dir_all(&path)
             .await
             .context("failed to remove temporary resolve directory")?;

--- a/crates/brioche/src/brioche/resolve/process.rs
+++ b/crates/brioche/src/brioche/resolve/process.rs
@@ -179,6 +179,7 @@ pub async fn resolve_process(
             output_path: &host_work_dir,
             merge: true,
             resources_dir: Some(&host_pack_dir),
+            link_locals: true,
         },
     )
     .await?;
@@ -560,6 +561,7 @@ async fn set_up_rootfs(
         output_path: rootfs_dir,
         merge: true,
         resources_dir: None,
+        link_locals: true,
     };
 
     let dash = LazyArtifact::Unpack(UnpackArtifact {

--- a/crates/brioche/src/main.rs
+++ b/crates/brioche/src/main.rs
@@ -166,6 +166,7 @@ async fn build(args: BuildArgs) -> anyhow::Result<ExitCode> {
                     output_path: output,
                     merge: false,
                     resources_dir: None,
+                    link_locals: false,
                 },
             )
             .await?;


### PR DESCRIPTION
This PR updates the files under `~/.local/share/brioche/locals` to use hardlinks where possible, which saves a massive amount of disk space. When building [`std`](https://github.com/brioche-dev/brioche-packages/tree/db84686c46eb364ca0f32fd46107b5a800da535d/std) with `brioche build ./std -e native`, this seems to cut the total disk usage down from ~18 GB to ~8 GB!

We use hardlinks in the following cases:

- A local read-only `File` artifact gets hardlinked to its "content blob" (from `~/.local/share/brioche/blobs`)
- A local `File` artifact that has `resources` gets hardlinked to a version without its resources
- A local `Directory` artifact will contain hardlinks to all the files contained within it

This means we greatly cut down on data duplication. Now, we should only be duplicating data if two artifacts differ by permission (e.g. two `File` artifacts have the same contents, but the `executable` field is set to true for one and false for the other). In the future, we could also improve things further on more modern filesystems by using reflinks where possible.