### PR TITLE
Swap `olpc-cjson` with `json-canon`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -756,10 +756,10 @@ dependencies = [
  "hex",
  "human-repr",
  "joinery",
+ "json-canon",
  "libmount",
  "mockito",
  "nix 0.27.1",
- "olpc-cjson",
  "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-jaeger",
@@ -2312,6 +2312,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "json-canon"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "447ae153a2bd47d61acc0d131295408e32ef87ed9785825a6f4ecef85afc0edb"
+dependencies = [
+ "ryu-js",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "lab"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2822,17 +2833,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cf5f9dd3933bd50a9e1f149ec995f39ae2c496d31fd772c1fd45ebc27e902b0"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "olpc-cjson"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d637c9c15b639ccff597da8f4fa968300651ad2f1e968aefc3b4927a6fb2027a"
-dependencies = [
- "serde",
- "serde_json",
- "unicode-normalization",
 ]
 
 [[package]]
@@ -3934,6 +3934,12 @@ name = "ryu"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
+
+[[package]]
+name = "ryu-js"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6518fc26bced4d53678a22d6e423e9d8716377def84545fe328236e3af070e7f"
 
 [[package]]
 name = "same-file"

--- a/crates/brioche/Cargo.toml
+++ b/crates/brioche/Cargo.toml
@@ -28,9 +28,9 @@ futures = "0.3.29"
 hex = "0.4.3"
 human-repr = "1.1.0"
 joinery = "3.1.0"
+json-canon = "0.1.3"
 libmount = "0.1.15"
 nix = { version = "0.27.1", features = ["user"] }
-olpc-cjson = "0.1.3"
 opentelemetry = "0.21.0"
 opentelemetry-http = { version = "0.10.0", features = ["reqwest"] }
 opentelemetry-jaeger = "0.20.0"


### PR DESCRIPTION
This PR builds on #9, but replaces the [`olpc-cjson`](https://crates.io/crates/olpc-cjson) crate (which implements the [OLPC Canonical JSON spec](https://wiki.laptop.org/go/Canonical_JSON)) with the [`json-canon`](https://crates.io/crates/json-canon) crate (which implements the [IETF JSON Canonicalization Scheme](https://datatracker.ietf.org/doc/html/rfc8785) (JCS)).

The reason for the switch is that the OLPC Canonical JSON representation is _not_ a valid subset of JSON in many cases. JCS is on the other hand, so after serializing JSON as JCS, you can then deserialize it with a normal JSON parser.