### PR TITLE
Store proxy artifacts as blobs

### DIFF
--- a/crates/brioche/src/brioche/artifact.rs
+++ b/crates/brioche/src/brioche/artifact.rs
@@ -92,7 +92,7 @@ pub enum LazyArtifact {
     },
     #[serde(rename_all = "camelCase")]
     Proxy {
-        hash: ArtifactHash,
+        blob: BlobId,
     },
 }
 

--- a/crates/brioche/src/brioche/script.rs
+++ b/crates/brioche/src/brioche/script.rs
@@ -188,7 +188,7 @@ pub async fn op_brioche_create_proxy(
             .clone()
     };
 
-    let result = super::resolve::create_proxy(&brioche, artifact).await;
+    let result = super::resolve::create_proxy(&brioche, artifact).await?;
     Ok(result)
 }
 

--- a/crates/brioche/tests/resolve_process.rs
+++ b/crates/brioche/tests/resolve_process.rs
@@ -464,9 +464,9 @@ async fn test_resolve_process_cached_equivalent_inputs_parallel() -> anyhow::Res
     });
 
     let process_random_1_proxy =
-        brioche::brioche::resolve::create_proxy(&brioche, process_random_1.clone()).await;
+        brioche::brioche::resolve::create_proxy(&brioche, process_random_1.clone()).await?;
     let process_random_2_proxy =
-        brioche::brioche::resolve::create_proxy(&brioche, process_random_2.clone()).await;
+        brioche::brioche::resolve::create_proxy(&brioche, process_random_2.clone()).await?;
     let processes_dir = brioche_test::lazy_dir([
         ("process1.txt", process_random_1.clone()),
         ("process2.txt", process_random_2.clone()),

--- a/crates/brioche/tests/resolve_proxy.rs
+++ b/crates/brioche/tests/resolve_proxy.rs
@@ -19,7 +19,7 @@ async fn test_resolve_proxy() -> anyhow::Result<()> {
         ],
     };
 
-    let merge_proxy = create_proxy(&brioche, merge.clone()).await;
+    let merge_proxy = create_proxy(&brioche, merge.clone()).await?;
 
     // The hash of the proxy artifact should be different from the hash of the
     // lazy artifact it wraps


### PR DESCRIPTION
This PR updates how `Proxy` artifacts work. Previously, they were always stored only as in-memory values, meaning that it wasn't easy to get the data that a proxy was wrapping. Now, they are just represented as normal blob values, meaning there's an easy and consistent way to look them up. I believe this will help simplify work with persisting / syncing artifacts over the network in the future.

One disadvantage is that this PR hurts performance: running `brioche build ./std -e native` in the [`brioche-packages`](https://github.com/brioche-dev/brioche-packages/tree/db84686c46eb364ca0f32fd46107b5a800da535d) repo went up from 400ms to 500ms for a fully-cached build. I believe we'll be able to win back some of this performance in the future.