### PR TITLE
Add `Process.outputScaffold`

### DIFF
--- a/crates/brioche/src/brioche/artifact.rs
+++ b/crates/brioche/src/brioche/artifact.rs
@@ -262,6 +262,9 @@ pub struct ProcessArtifact {
 
     pub work_dir: Box<WithMeta<LazyArtifact>>,
 
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub output_scaffold: Option<Box<WithMeta<LazyArtifact>>>,
+
     pub platform: Platform,
 }
 
@@ -278,6 +281,9 @@ pub struct CompleteProcessArtifact {
 
     #[serde_as(as = "serde_with::TryFromInto<LazyArtifact>")]
     pub work_dir: Directory,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub output_scaffold: Option<Box<CompleteArtifact>>,
 
     pub platform: Platform,
 }

--- a/crates/brioche/src/brioche/artifact.rs
+++ b/crates/brioche/src/brioche/artifact.rs
@@ -254,10 +254,14 @@ pub struct UnpackArtifact {
 #[serde(rename_all = "camelCase")]
 pub struct ProcessArtifact {
     pub command: ProcessTemplate,
+
     pub args: Vec<ProcessTemplate>,
+
     #[serde_as(as = "BTreeMap<TickEncoded, _>")]
     pub env: BTreeMap<BString, ProcessTemplate>,
+
     pub work_dir: Box<WithMeta<LazyArtifact>>,
+
     pub platform: Platform,
 }
 
@@ -266,10 +270,15 @@ pub struct ProcessArtifact {
 #[serde(rename_all = "camelCase")]
 pub struct CompleteProcessArtifact {
     pub command: CompleteProcessTemplate,
+
     pub args: Vec<CompleteProcessTemplate>,
+
     #[serde_as(as = "BTreeMap<TickEncoded, _>")]
     pub env: BTreeMap<BString, CompleteProcessTemplate>,
+
+    #[serde_as(as = "serde_with::TryFromInto<LazyArtifact>")]
     pub work_dir: Directory,
+
     pub platform: Platform,
 }
 

--- a/crates/brioche/tests/artifact_hash_stable.rs
+++ b/crates/brioche/tests/artifact_hash_stable.rs
@@ -274,6 +274,7 @@ async fn test_artifact_hash_stable_process() -> anyhow::Result<()> {
             args: vec![],
             env: BTreeMap::default(),
             work_dir: Box::new(brioche_test::without_meta(brioche_test::lazy_dir_empty())),
+            output_scaffold: None,
             platform: Platform::X86_64Linux,
         })
         .hash()
@@ -291,6 +292,7 @@ async fn test_artifact_hash_stable_process() -> anyhow::Result<()> {
             args: vec![],
             env: BTreeMap::default(),
             work_dir: Box::new(brioche_test::without_meta(brioche_test::lazy_dir_empty())),
+            output_scaffold: None,
             platform: Platform::X86_64Linux,
         })
         .hash()
@@ -310,6 +312,7 @@ async fn test_artifact_hash_stable_process() -> anyhow::Result<()> {
             }],
             env: BTreeMap::default(),
             work_dir: Box::new(brioche_test::without_meta(brioche_test::lazy_dir_empty())),
+            output_scaffold: None,
             platform: Platform::X86_64Linux,
         })
         .hash()
@@ -336,6 +339,7 @@ async fn test_artifact_hash_stable_process() -> anyhow::Result<()> {
                 },
             )]),
             work_dir: Box::new(brioche_test::without_meta(brioche_test::lazy_dir_empty())),
+            output_scaffold: None,
             platform: Platform::X86_64Linux,
         })
         .hash()
@@ -367,6 +371,7 @@ async fn test_artifact_hash_stable_process() -> anyhow::Result<()> {
                 },
             )]),
             work_dir: Box::new(brioche_test::without_meta(brioche_test::lazy_dir_empty())),
+            output_scaffold: None,
             platform: Platform::X86_64Linux,
         })
         .hash()

--- a/crates/brioche/tests/resolve_process.rs
+++ b/crates/brioche/tests/resolve_process.rs
@@ -351,6 +351,7 @@ async fn test_resolve_process_with_readonly_contents() -> anyhow::Result<()> {
             ),
         ]),
         work_dir: Box::new(brioche_test::without_meta(brioche_test::lazy_dir_empty())),
+        output_scaffold: None,
         platform: current_platform(),
     });
 


### PR DESCRIPTION
This PR adds a new `outputScaffold` field to the `Process` artifact, which is optional and can be set to any type of `LazyArtifact` value. When set, the process will start with `$BRIOCHE_OUTPUT` (the output path) pre-populated with the specified artifact.

In the simplest case, this is a minor convenience improvement: rather than copying an artifact into `$BRIOCHE_OUTPUT` to modify it, or having to do something like `mkdir -p "$BRIOCHE_OUTPUT/bin"` or similar, the process can now be set to the existing artifact to copy in, or you can set it to a basic directory structure like this:

```typescript
std.process({
  // ...

  // Create the folder "$BRIOCHE_OUTPUT/bin" when the process starts
  outputScaffold: std.directory({
    bin: std.directory()
  }),
});
```

A better use-case is that this makes it possible to use a command (say, `sed`) to edit a file directly, rather than needing to go through a shell first. Or, you could use a command like `gcc` directly to output a binary into a directory alongside auxiliary files like external debug symbols.

From a runtime perspective, this also gives us the option to optimize things. In the future, we could switch to using an overlay filesystem to avoid copying files altogether.