### PR TITLE
Set file modified times for locals and blobs

### DIFF
--- a/crates/brioche/src/brioche/blob.rs
+++ b/crates/brioche/src/brioche/blob.rs
@@ -294,9 +294,13 @@ pub async fn save_blob_from_file<'a>(
         // change its permissions and move it into place. We need to check
         // for exclusivity, because we would otherwise ruin the permission
         // of other hard links to the same file.
+
         tokio::fs::set_permissions(input_path, permissions)
             .await
             .context("failed to set blob permissions")?;
+        crate::fs_utils::set_mtime_to_epoch(input_path)
+            .await
+            .context("failed to set blob modified time")?;
         let move_type = crate::fs_utils::move_file(input_path, &blob_path)
             .await
             .with_context(|| {
@@ -320,6 +324,9 @@ pub async fn save_blob_from_file<'a>(
         tokio::fs::set_permissions(&blob_path, permissions)
             .await
             .context("failed to set blob permissions")?;
+        crate::fs_utils::set_mtime_to_epoch(input_path)
+            .await
+            .context("failed to set blob modified time")?;
         tracing::debug!(input_path = %input_path.display(), blob_id = %id, "saved blob by copying file");
 
         if options.remove_input {

--- a/crates/brioche/src/brioche/blob.rs
+++ b/crates/brioche/src/brioche/blob.rs
@@ -82,7 +82,7 @@ pub async fn save_blob<'a>(
         .context("failed to set blob permissions")?;
     let temp_file = temp_file.into_std().await;
     tokio::task::spawn_blocking(move || {
-        temp_file.set_modified(std::time::UNIX_EPOCH)?;
+        temp_file.set_modified(crate::fs_utils::brioche_epoch())?;
         anyhow::Ok(())
     })
     .await??;
@@ -188,7 +188,7 @@ where
         .context("failed to set blob permissions")?;
     let temp_file = temp_file.into_std().await;
     tokio::task::spawn_blocking(move || {
-        temp_file.set_modified(std::time::UNIX_EPOCH)?;
+        temp_file.set_modified(crate::fs_utils::brioche_epoch())?;
         anyhow::Ok(())
     })
     .await??;
@@ -304,7 +304,7 @@ pub async fn save_blob_from_file<'a>(
             .context("failed to set blob permissions")?;
         let existing_blob_file = existing_blob_file.into_std().await;
         tokio::task::spawn_blocking(move || {
-            existing_blob_file.set_modified(std::time::UNIX_EPOCH)?;
+            existing_blob_file.set_modified(crate::fs_utils::brioche_epoch())?;
             anyhow::Ok(())
         })
         .await??;
@@ -317,7 +317,7 @@ pub async fn save_blob_from_file<'a>(
         tokio::fs::set_permissions(input_path, permissions)
             .await
             .context("failed to set blob permissions")?;
-        crate::fs_utils::set_mtime_to_epoch(input_path)
+        crate::fs_utils::set_mtime_to_brioche_epoch(input_path)
             .await
             .context("failed to set blob modified time")?;
         let move_type = crate::fs_utils::move_file(input_path, &blob_path)
@@ -343,7 +343,7 @@ pub async fn save_blob_from_file<'a>(
         tokio::fs::set_permissions(&blob_path, permissions)
             .await
             .context("failed to set blob permissions")?;
-        crate::fs_utils::set_mtime_to_epoch(input_path)
+        crate::fs_utils::set_mtime_to_brioche_epoch(input_path)
             .await
             .context("failed to set blob modified time")?;
         tracing::debug!(input_path = %input_path.display(), blob_id = %id, "saved blob by copying file");

--- a/crates/brioche/src/brioche/output.rs
+++ b/crates/brioche/src/brioche/output.rs
@@ -110,7 +110,7 @@ async fn create_output_inner<'a: 'async_recursion>(
                             .await
                             .context("failed to set output file modified time")?;
                     } else if options.link_locals {
-                        crate::fs_utils::set_mtime_to_epoch(options.output_path)
+                        crate::fs_utils::set_mtime_to_brioche_epoch(options.output_path)
                             .await
                             .context("failed to set output file modified time")?;
                     }
@@ -341,7 +341,7 @@ async fn create_local_output_inner(
                 )
                 .await
                 .context("failed to set permissions for local file")?;
-                crate::fs_utils::set_mtime_to_epoch(&local_path)
+                crate::fs_utils::set_mtime_to_brioche_epoch(&local_path)
                     .await
                     .context("failed to set modified time for local file")?;
             }
@@ -408,13 +408,13 @@ async fn try_exists_and_ensure_local_meta(path: &Path) -> anyhow::Result<bool> {
 
     let mtime = metadata
         .modified()
-        .context("failed to get fil modified time")?;
+        .context("failed to get file modified time")?;
     let is_mtime_at_epoch = mtime
-        .duration_since(std::time::UNIX_EPOCH)
+        .duration_since(crate::fs_utils::brioche_epoch())
         .is_ok_and(|duration| duration.is_zero());
 
     if metadata.is_file() && !is_mtime_at_epoch {
-        crate::fs_utils::set_mtime_to_epoch(path).await?;
+        crate::fs_utils::set_mtime_to_brioche_epoch(path).await?;
     }
 
     Ok(true)

--- a/crates/brioche/src/brioche/resolve/process.rs
+++ b/crates/brioche/src/brioche/resolve/process.rs
@@ -189,7 +189,7 @@ pub async fn resolve_process(
                 output_path: &host_work_dir,
                 merge: true,
                 resources_dir: Some(&host_pack_dir),
-                mtime: Some(std::time::SystemTime::UNIX_EPOCH),
+                mtime: Some(crate::fs_utils::brioche_epoch()),
                 link_locals: false,
             },
         )
@@ -204,7 +204,7 @@ pub async fn resolve_process(
                     output_path: &output_path,
                     merge: false,
                     resources_dir: Some(&host_pack_dir),
-                    mtime: Some(std::time::SystemTime::UNIX_EPOCH),
+                    mtime: Some(crate::fs_utils::brioche_epoch()),
                     link_locals: false,
                 },
             )

--- a/crates/brioche/src/brioche/resolve/process.rs
+++ b/crates/brioche/src/brioche/resolve/process.rs
@@ -189,7 +189,7 @@ pub async fn resolve_process(
                 output_path: &host_work_dir,
                 merge: true,
                 resources_dir: Some(&host_pack_dir),
-                mtime: None,
+                mtime: Some(std::time::SystemTime::UNIX_EPOCH),
                 link_locals: false,
             },
         )
@@ -204,7 +204,7 @@ pub async fn resolve_process(
                     output_path: &output_path,
                     merge: false,
                     resources_dir: Some(&host_pack_dir),
-                    mtime: None,
+                    mtime: Some(std::time::SystemTime::UNIX_EPOCH),
                     link_locals: false,
                 },
             )

--- a/crates/brioche/src/brioche/resolve/process.rs
+++ b/crates/brioche/src/brioche/resolve/process.rs
@@ -189,6 +189,7 @@ pub async fn resolve_process(
                 output_path: &host_work_dir,
                 merge: true,
                 resources_dir: Some(&host_pack_dir),
+                mtime: None,
                 link_locals: false,
             },
         )
@@ -203,6 +204,7 @@ pub async fn resolve_process(
                     output_path: &output_path,
                     merge: false,
                     resources_dir: Some(&host_pack_dir),
+                    mtime: None,
                     link_locals: false,
                 },
             )
@@ -590,6 +592,7 @@ async fn set_up_rootfs(
         output_path: rootfs_dir,
         merge: true,
         resources_dir: None,
+        mtime: None,
         link_locals: true,
     };
 

--- a/crates/brioche/src/fs_utils.rs
+++ b/crates/brioche/src/fs_utils.rs
@@ -128,6 +128,11 @@ pub async fn set_directory_rwx_recursive(path: &Path) -> anyhow::Result<()> {
     Ok(())
 }
 
+pub async fn set_mtime_to_epoch(path: &Path) -> anyhow::Result<()> {
+    set_mtime(path, std::time::UNIX_EPOCH).await?;
+    Ok(())
+}
+
 cfg_if::cfg_if! {
     if #[cfg(unix)] {
         pub fn is_executable(permissions: &std::fs::Permissions) -> bool {
@@ -143,11 +148,11 @@ cfg_if::cfg_if! {
             permissions.set_mode(new_mode);
         }
 
-        pub async fn set_mtime_to_epoch(path: &Path) -> anyhow::Result<()> {
+        pub async fn set_mtime(path: &Path, mtime: std::time::SystemTime) -> anyhow::Result<()> {
             let path = path.to_owned();
             tokio::task::spawn_blocking(move || {
                 let file = std::fs::File::open(path)?;
-                file.set_modified(std::time::UNIX_EPOCH)?;
+                file.set_modified(mtime)?;
                 anyhow::Ok(())
             }).await??;
 

--- a/crates/brioche/src/fs_utils.rs
+++ b/crates/brioche/src/fs_utils.rs
@@ -128,8 +128,19 @@ pub async fn set_directory_rwx_recursive(path: &Path) -> anyhow::Result<()> {
     Ok(())
 }
 
-pub async fn set_mtime_to_epoch(path: &Path) -> anyhow::Result<()> {
-    set_mtime(path, std::time::UNIX_EPOCH).await?;
+/// A timestamp used for as the modified time for files during Brioche builds.
+/// Defined as 2000-01-01 00:00:00 UTC, or 946,684,800 seconds after the Unix
+/// epoch.
+///
+/// The main motivation for not using the Unix epoch is that ZIP files don't
+/// support dates eariler than 1980, which is inconvenient. The chosen timestamp
+/// beyond that is arbitrary.
+pub fn brioche_epoch() -> std::time::SystemTime {
+    std::time::UNIX_EPOCH + std::time::Duration::from_secs(946_684_800)
+}
+
+pub async fn set_mtime_to_brioche_epoch(path: &Path) -> anyhow::Result<()> {
+    set_mtime(path, brioche_epoch()).await?;
     Ok(())
 }
 

--- a/crates/brioche/src/fs_utils.rs
+++ b/crates/brioche/src/fs_utils.rs
@@ -142,6 +142,17 @@ cfg_if::cfg_if! {
             let new_mode = permissions.mode() | 0o700;
             permissions.set_mode(new_mode);
         }
+
+        pub async fn set_mtime_to_epoch(path: &Path) -> anyhow::Result<()> {
+            let path = path.to_owned();
+            tokio::task::spawn_blocking(move || {
+                let file = std::fs::File::open(path)?;
+                file.set_modified(std::time::UNIX_EPOCH)?;
+                anyhow::Ok(())
+            }).await??;
+
+            Ok(())
+        }
     }
 }
 

--- a/crates/brioche/src/main.rs
+++ b/crates/brioche/src/main.rs
@@ -166,6 +166,7 @@ async fn build(args: BuildArgs) -> anyhow::Result<ExitCode> {
                     output_path: output,
                     merge: false,
                     resources_dir: None,
+                    mtime: Some(std::time::SystemTime::now()),
                     link_locals: false,
                 },
             )

--- a/crates/brioche/tests/output.rs
+++ b/crates/brioche/tests/output.rs
@@ -25,6 +25,7 @@ async fn create_output(
             output_path,
             merge,
             resources_dir: None,
+            mtime: None,
             link_locals: false,
         },
     )
@@ -45,6 +46,7 @@ async fn create_output_with_resources(
             output_path,
             merge,
             resources_dir: Some(resources_dir),
+            mtime: None,
             link_locals: false,
         },
     )
@@ -64,6 +66,7 @@ async fn create_output_with_links(
             output_path,
             merge,
             resources_dir: None,
+            mtime: None,
             link_locals: true,
         },
     )

--- a/crates/brioche/tests/output.rs
+++ b/crates/brioche/tests/output.rs
@@ -943,7 +943,30 @@ async fn test_output_with_links() -> anyhow::Result<()> {
     )
     .await;
 
+    assert_mtime_epoch(context.path("output/hello.txt")).await;
+    assert_mtime_epoch(context.path("output/hello2.txt")).await;
+    assert_mtime_epoch(context.path("output/hello_res.txt")).await;
+    assert_mtime_epoch(context.path("output/hello_res2.txt")).await;
+    assert_mtime_epoch(context.path("output/hello_exe")).await;
+    assert_mtime_epoch(context.path("output/hello_exe2")).await;
+    assert_mtime_epoch(context.path("output/hello_exe_res")).await;
+    assert_mtime_epoch(context.path("output/hello_exe_res2")).await;
+
     Ok(())
+}
+
+async fn assert_mtime_epoch(path: impl AsRef<Path>) {
+    let path = path.as_ref();
+    let metadata = tokio::fs::metadata(path)
+        .await
+        .expect("failed to get metadata");
+    let mtime = metadata.modified().expect("failed to get mtime");
+    assert_eq!(
+        mtime
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("mtime is before epoch"),
+        std::time::Duration::ZERO,
+    );
 }
 
 struct Mode {

--- a/crates/brioche/tests/output.rs
+++ b/crates/brioche/tests/output.rs
@@ -946,19 +946,19 @@ async fn test_output_with_links() -> anyhow::Result<()> {
     )
     .await;
 
-    assert_mtime_epoch(context.path("output/hello.txt")).await;
-    assert_mtime_epoch(context.path("output/hello2.txt")).await;
-    assert_mtime_epoch(context.path("output/hello_res.txt")).await;
-    assert_mtime_epoch(context.path("output/hello_res2.txt")).await;
-    assert_mtime_epoch(context.path("output/hello_exe")).await;
-    assert_mtime_epoch(context.path("output/hello_exe2")).await;
-    assert_mtime_epoch(context.path("output/hello_exe_res")).await;
-    assert_mtime_epoch(context.path("output/hello_exe_res2")).await;
+    assert_mtime_is_brioche_epoch(context.path("output/hello.txt")).await;
+    assert_mtime_is_brioche_epoch(context.path("output/hello2.txt")).await;
+    assert_mtime_is_brioche_epoch(context.path("output/hello_res.txt")).await;
+    assert_mtime_is_brioche_epoch(context.path("output/hello_res2.txt")).await;
+    assert_mtime_is_brioche_epoch(context.path("output/hello_exe")).await;
+    assert_mtime_is_brioche_epoch(context.path("output/hello_exe2")).await;
+    assert_mtime_is_brioche_epoch(context.path("output/hello_exe_res")).await;
+    assert_mtime_is_brioche_epoch(context.path("output/hello_exe_res2")).await;
 
     Ok(())
 }
 
-async fn assert_mtime_epoch(path: impl AsRef<Path>) {
+async fn assert_mtime_is_brioche_epoch(path: impl AsRef<Path>) {
     let path = path.as_ref();
     let metadata = tokio::fs::metadata(path)
         .await
@@ -966,7 +966,7 @@ async fn assert_mtime_epoch(path: impl AsRef<Path>) {
     let mtime = metadata.modified().expect("failed to get mtime");
     assert_eq!(
         mtime
-            .duration_since(std::time::UNIX_EPOCH)
+            .duration_since(brioche::fs_utils::brioche_epoch())
             .expect("mtime is before epoch"),
         std::time::Duration::ZERO,
     );


### PR DESCRIPTION
This PR makes it so files written to `~/.local/share/brioche/locals` and `~/.local/share/brioche/blobs` have their modified time (mtime) set to the timestamp 2000-01-01 00:00:00 UTC.

Nix uses the timestamp 1970-01-01 00:00:00 UTC instead (the Unix epoch), but I chose to use a more recent timestamp, as at least ZIP files have problems with timestamps before 1980. The choice of the year 2000 is arbitrary, but I wanted to avoid issues with ZIP files at least.