### PR TITLE
Minor improvements to using `unpack` with tarfiles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,6 +191,7 @@ version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc2d0cfb2a7388d34f590e76686704c494ed7aaceed62ee1ba35cbf363abc2a5"
 dependencies = [
+ "bzip2",
  "flate2",
  "futures-core",
  "memchr",
@@ -886,6 +887,27 @@ name = "bytes"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+
+[[package]]
+name = "bzip2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
+dependencies = [
+ "bzip2-sys",
+ "libc",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.11+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
 
 [[package]]
 name = "cast"

--- a/crates/brioche/Cargo.toml
+++ b/crates/brioche/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = { version = "1.0.75", features = ["backtrace"] }
-async-compression = { version = "0.4.5", features = ["tokio", "gzip", "xz", "zstd"] }
+async-compression = { version = "0.4.5", features = ["tokio", "bzip2", "gzip", "xz", "zstd"] }
 async-recursion = "1.0.5"
 bincode = "1.3.3"
 biome_formatter = "0.4.0"

--- a/crates/brioche/src/brioche/artifact.rs
+++ b/crates/brioche/src/brioche/artifact.rs
@@ -766,6 +766,7 @@ pub enum ArchiveFormat {
 pub enum CompressionFormat {
     #[default]
     None,
+    Bzip2,
     Gzip,
     Xz,
     Zstd,
@@ -778,6 +779,7 @@ impl CompressionFormat {
     ) -> Box<dyn tokio::io::AsyncRead + Unpin + Send> {
         match self {
             Self::None => Box::new(input),
+            Self::Bzip2 => Box::new(async_compression::tokio::bufread::BzDecoder::new(input)),
             Self::Gzip => Box::new(async_compression::tokio::bufread::GzipDecoder::new(input)),
             Self::Xz => Box::new(async_compression::tokio::bufread::XzDecoder::new(input)),
             Self::Zstd => Box::new(async_compression::tokio::bufread::ZstdDecoder::new(input)),


### PR DESCRIPTION
This PR makes two minor changes to resolving the "unpack" lazy artifact:

- Ignore `XHeader` and `XGlobalHeader` tar entires. I believe these entries both specify extra file metadata, but Brioche artifacts can't store this metadata anyway so skipping should be totally safe.
- Add support for unpacking bzip2-compressed tar archives.