### PR TITLE
Refactor module resolution with new `Projects` and `Vfs` types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3687,6 +3687,9 @@ name = "relative-path"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c707298afce11da2efef2f600116fa93ffa7a032b5d7b628aa17711ec81383ca"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "remove_dir_all"

--- a/crates/brioche/Cargo.toml
+++ b/crates/brioche/Cargo.toml
@@ -37,7 +37,7 @@ opentelemetry-jaeger = "0.20.0"
 opentelemetry-otlp = { version = "0.14.0", features = ["http-proto", "reqwest", "tls-roots", "grpc-tonic"] }
 pathdiff = "0.2.1"
 regex = "1.10.2"
-relative-path = "1.9.0"
+relative-path = { version = "1.9.0", features = ["serde"] }
 reqwest = { version = "0.11.22", default-features = false, features = ["rustls-tls", "stream"] }
 reqwest-middleware = "0.2.4"
 reqwest-retry = "0.3.0"

--- a/crates/brioche/src/brioche.rs
+++ b/crates/brioche/src/brioche.rs
@@ -16,6 +16,7 @@ pub mod platform;
 pub mod project;
 pub mod resolve;
 pub mod script;
+pub mod vfs;
 
 const MAX_CONCURRENT_PROCESSES: usize = 20;
 const MAX_CONCURRENT_DOWNLOADS: usize = 20;
@@ -23,6 +24,7 @@ const MAX_CONCURRENT_DOWNLOADS: usize = 20;
 #[derive(Clone)]
 pub struct Brioche {
     reporter: Reporter,
+    pub vfs: vfs::Vfs,
     db_conn: Arc<Mutex<sqlx::SqliteConnection>>,
     pub repo_dir: PathBuf,
     /// The directory where all of Brioche's data is stored. Usually configured
@@ -146,6 +148,7 @@ impl BriocheBuilder {
 
         Ok(Brioche {
             reporter: self.reporter,
+            vfs: vfs::Vfs::default(),
             db_conn: Arc::new(Mutex::new(db_conn)),
             home: brioche_home,
             repo_dir,

--- a/crates/brioche/src/brioche.rs
+++ b/crates/brioche/src/brioche.rs
@@ -49,6 +49,7 @@ pub struct Brioche {
 
 pub struct BriocheBuilder {
     reporter: Reporter,
+    vfs: vfs::Vfs,
     home: Option<PathBuf>,
     repo_dir: Option<PathBuf>,
     self_exec_processes: bool,
@@ -59,6 +60,7 @@ impl BriocheBuilder {
     pub fn new(reporter: Reporter) -> Self {
         Self {
             reporter,
+            vfs: vfs::Vfs::immutable(),
             home: None,
             repo_dir: None,
             self_exec_processes: true,
@@ -83,6 +85,11 @@ impl BriocheBuilder {
 
     pub fn keep_temps(mut self, keep_temps: bool) -> Self {
         self.keep_temps = keep_temps;
+        self
+    }
+
+    pub fn vfs(mut self, vfs: vfs::Vfs) -> Self {
+        self.vfs = vfs;
         self
     }
 
@@ -148,7 +155,7 @@ impl BriocheBuilder {
 
         Ok(Brioche {
             reporter: self.reporter,
-            vfs: vfs::Vfs::default(),
+            vfs: self.vfs,
             db_conn: Arc::new(Mutex::new(db_conn)),
             home: brioche_home,
             repo_dir,

--- a/crates/brioche/src/brioche/project.rs
+++ b/crates/brioche/src/brioche/project.rs
@@ -1,27 +1,311 @@
 use std::{
-    collections::HashMap,
+    collections::{BTreeSet, HashMap},
     path::{Path, PathBuf},
+    sync::Arc,
 };
 
 use anyhow::Context as _;
+use relative_path::{RelativePath, RelativePathBuf};
 
-use crate::fs_utils::is_dir;
-
-use super::Brioche;
+use super::{vfs::FileId, Brioche};
 
 pub mod analyze;
 
-pub async fn resolve_project(brioche: &Brioche, path: &Path) -> anyhow::Result<Project> {
-    // Limit the maximum recursion when searching dependencies
-    resolve_project_depth(brioche, path, 100).await
+#[derive(Clone, Default)]
+pub struct Projects {
+    inner: Arc<std::sync::RwLock<ProjectsInner>>,
 }
 
-#[async_recursion::async_recursion]
-pub async fn resolve_project_depth(
+impl Projects {
+    pub async fn load(&self, brioche: &Brioche, path: &Path) -> anyhow::Result<ProjectHash> {
+        {
+            let projects = self
+                .inner
+                .read()
+                .map_err(|_| anyhow::anyhow!("failed to acquire 'projects' lock"))?;
+            if let Some(project_hash) = projects.paths_to_projects.get(path) {
+                return Ok(*project_hash);
+            }
+        }
+
+        load_project(self.clone(), brioche.clone(), path.to_owned(), 100).await
+    }
+
+    pub async fn load_from_module_path(
+        &self,
+        brioche: &Brioche,
+        path: &Path,
+    ) -> anyhow::Result<ProjectHash> {
+        {
+            let projects = self
+                .inner
+                .read()
+                .map_err(|_| anyhow::anyhow!("failed to acquire 'projects' lock"))?;
+            if let Some(project_hash) = projects.find_containing_project(path) {
+                return Ok(project_hash);
+            }
+        }
+
+        for ancestor in path.ancestors() {
+            if tokio::fs::try_exists(ancestor.join("project.bri")).await? {
+                return self.load(brioche, ancestor).await;
+            }
+        }
+
+        anyhow::bail!("could not find project root for path {}", path.display());
+    }
+
+    pub fn project_root(&self, project_hash: ProjectHash) -> anyhow::Result<PathBuf> {
+        let projects = self
+            .inner
+            .read()
+            .map_err(|_| anyhow::anyhow!("failed to acquire 'projects' lock"))?;
+        let project_root = projects
+            .projects_to_paths
+            .get(&project_hash)
+            .and_then(|paths| paths.iter().next())
+            .with_context(|| format!("project root not found for hash {}", project_hash))?;
+        Ok(project_root.clone())
+    }
+
+    pub fn project_root_module_path(&self, project_hash: ProjectHash) -> anyhow::Result<PathBuf> {
+        let projects = self
+            .inner
+            .read()
+            .map_err(|_| anyhow::anyhow!("failed to acquire 'projects' lock"))?;
+        projects.project_root_module_path(project_hash)
+    }
+
+    pub fn project_root_module_specifier(
+        &self,
+        project_hash: ProjectHash,
+    ) -> anyhow::Result<super::script::specifier::BriocheModuleSpecifier> {
+        let projects = self
+            .inner
+            .read()
+            .map_err(|_| anyhow::anyhow!("failed to acquire 'projects' lock"))?;
+        projects.project_root_module_specifier(project_hash)
+    }
+
+    pub fn project_module_paths(&self, project_hash: ProjectHash) -> anyhow::Result<Vec<PathBuf>> {
+        let projects = self
+            .inner
+            .read()
+            .map_err(|_| anyhow::anyhow!("failed to acquire 'projects' lock"))?;
+        let module_paths = projects.project_module_paths(project_hash)?;
+        Ok(module_paths.collect())
+    }
+
+    pub fn project_module_specifiers(
+        &self,
+        project_hash: ProjectHash,
+    ) -> anyhow::Result<Vec<super::script::specifier::BriocheModuleSpecifier>> {
+        let projects = self
+            .inner
+            .read()
+            .map_err(|_| anyhow::anyhow!("failed to acquire 'projects' lock"))?;
+        let module_specifiers = projects.project_module_specifiers(project_hash)?;
+        Ok(module_specifiers.collect())
+    }
+
+    pub fn find_containing_project(&self, path: &Path) -> anyhow::Result<Option<ProjectHash>> {
+        let projects = self
+            .inner
+            .read()
+            .map_err(|_| anyhow::anyhow!("failed to acquire 'projects' lock"))?;
+        Ok(projects.find_containing_project(path))
+    }
+
+    pub fn find_containing_project_root(
+        &self,
+        path: &Path,
+        project_hash: ProjectHash,
+    ) -> anyhow::Result<PathBuf> {
+        let projects = self
+            .inner
+            .read()
+            .map_err(|_| anyhow::anyhow!("failed to acquire 'projects' lock"))?;
+        let path = projects.find_containing_project_root(path, project_hash)?;
+        Ok(path.to_owned())
+    }
+
+    pub fn project(&self, project_hash: ProjectHash) -> anyhow::Result<Arc<Project>> {
+        let projects = self
+            .inner
+            .read()
+            .map_err(|_| anyhow::anyhow!("failed to acquire 'projects' lock"))?;
+        projects
+            .project(project_hash)
+            .map(|project| project.clone())
+    }
+
+    pub fn local_paths(&self, project_hash: ProjectHash) -> anyhow::Result<BTreeSet<PathBuf>> {
+        let projects = self
+            .inner
+            .read()
+            .map_err(|_| anyhow::anyhow!("failed to acquire 'projects' lock"))?;
+        let local_paths = projects
+            .local_paths(project_hash)
+            .with_context(|| format!("project not found for hash {project_hash}"))?;
+        Ok(local_paths.map(|path| path.to_owned()).collect())
+    }
+}
+
+#[derive(Default, Clone)]
+struct ProjectsInner {
+    projects: HashMap<ProjectHash, Arc<Project>>,
+    paths_to_projects: HashMap<PathBuf, ProjectHash>,
+    projects_to_paths: HashMap<ProjectHash, BTreeSet<PathBuf>>,
+}
+
+impl ProjectsInner {
+    fn project(&self, project_hash: ProjectHash) -> anyhow::Result<&Arc<Project>> {
+        self.projects
+            .get(&project_hash)
+            .with_context(|| format!("project not found for hash {}", project_hash))
+    }
+
+    fn local_paths(&self, project_hash: ProjectHash) -> Option<impl Iterator<Item = &Path> + '_> {
+        let paths = self.projects_to_paths.get(&project_hash)?;
+        Some(paths.iter().map(|path| &**path))
+    }
+
+    fn find_containing_project(&self, path: &Path) -> Option<ProjectHash> {
+        // TODO: Keep a map directly between submodules and project roots
+
+        path.ancestors()
+            .find_map(|path| self.paths_to_projects.get(path).copied())
+    }
+
+    fn find_containing_project_root(
+        &self,
+        path: &Path,
+        project_hash: ProjectHash,
+    ) -> anyhow::Result<&Path> {
+        let project_root = self
+            .projects_to_paths
+            .get(&project_hash)
+            .and_then(|paths| {
+                paths
+                    .iter()
+                    .find(|project_root| path.starts_with(project_root))
+            })
+            .with_context(|| {
+                format!(
+                    "matching project root not found for path {}",
+                    path.display()
+                )
+            })?;
+        Ok(project_root)
+    }
+
+    fn project_root_module_path(&self, project_hash: ProjectHash) -> anyhow::Result<PathBuf> {
+        let project = self
+            .projects
+            .get(&project_hash)
+            .with_context(|| format!("project not found for hash {}", project_hash))?;
+        let project_root = self
+            .projects_to_paths
+            .get(&project_hash)
+            .and_then(|paths| paths.first())
+            .with_context(|| format!("project root not found for hash {}", project_hash))?;
+
+        let root_relative_path = RelativePath::new("project.bri");
+        anyhow::ensure!(
+            project.modules.contains_key(root_relative_path),
+            "root module not found for project {}",
+            project_root.display()
+        );
+
+        let root_path = root_relative_path.to_logical_path(project_root);
+        assert!(
+            root_path.starts_with(project_root),
+            "module path {} escapes project root {}",
+            root_path.display(),
+            project_root.display()
+        );
+        Ok(root_path)
+    }
+
+    pub fn project_root_module_specifier(
+        &self,
+        project_hash: ProjectHash,
+    ) -> anyhow::Result<super::script::specifier::BriocheModuleSpecifier> {
+        let path = self.project_root_module_path(project_hash)?;
+        Ok(super::script::specifier::BriocheModuleSpecifier::File { path })
+    }
+
+    pub fn project_module_paths(
+        &self,
+        project_hash: ProjectHash,
+    ) -> anyhow::Result<impl Iterator<Item = PathBuf> + '_> {
+        let project = self
+            .projects
+            .get(&project_hash)
+            .with_context(|| format!("project not found for hash {}", project_hash))?;
+        let project_root = self
+            .projects_to_paths
+            .get(&project_hash)
+            .and_then(|paths| paths.first())
+            .with_context(|| format!("project root not found for hash {}", project_hash))?;
+
+        let paths = project.modules.keys().map(move |module_path| {
+            let path = module_path.to_logical_path(project_root);
+            assert!(
+                path.starts_with(project_root),
+                "module path {} escapes project root {}",
+                module_path,
+                project_root.display()
+            );
+            path
+        });
+        Ok(paths)
+    }
+
+    pub fn project_module_specifiers(
+        &self,
+        project_hash: ProjectHash,
+    ) -> anyhow::Result<impl Iterator<Item = super::script::specifier::BriocheModuleSpecifier> + '_>
+    {
+        let module_paths = self.project_module_paths(project_hash)?;
+        let module_specifiers = module_paths
+            .map(|path| super::script::specifier::BriocheModuleSpecifier::File { path });
+        Ok(module_specifiers)
+    }
+}
+
+async fn load_project(
+    projects: Projects,
+    brioche: Brioche,
+    path: PathBuf,
+    depth: usize,
+) -> anyhow::Result<ProjectHash> {
+    let rt = tokio::runtime::Handle::current();
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    std::thread::spawn(move || {
+        let local_set = tokio::task::LocalSet::new();
+
+        local_set.spawn_local(async move {
+            let result = load_project_inner(&projects, &brioche, &path, depth).await;
+            let _ = tx.send(result).inspect_err(|err| {
+                tracing::warn!("failed to send project load result: {err:?}");
+            });
+        });
+
+        rt.block_on(local_set);
+    });
+
+    let (project_hash, _) = rx.await.context("failed to get project load result")??;
+    Ok(project_hash)
+}
+
+#[async_recursion::async_recursion(?Send)]
+async fn load_project_inner(
+    projects: &Projects,
     brioche: &Brioche,
     path: &Path,
     depth: usize,
-) -> anyhow::Result<Project> {
+) -> anyhow::Result<(ProjectHash, Arc<Project>)> {
     tracing::debug!(path = %path.display(), "resolving project");
 
     let path = tokio::fs::canonicalize(path)
@@ -29,7 +313,8 @@ pub async fn resolve_project_depth(
         .with_context(|| format!("failed to canonicalize path {}", path.display()))?;
     let repo = &brioche.repo_dir;
 
-    let project_analysis = analyze::analyze_project(&path)?;
+    let project_analysis = analyze::analyze_project(&brioche.vfs, &path).await?;
+
     let mut dependencies = HashMap::new();
     for (name, dependency_def) in &project_analysis.definition.dependencies {
         static NAME_REGEX: std::sync::OnceLock<regex::Regex> = std::sync::OnceLock::new();
@@ -40,10 +325,10 @@ pub async fn resolve_project_depth(
         let dep_depth = depth
             .checked_sub(1)
             .context("project dependency depth exceeded")?;
-        let dependency = match dependency_def {
+        let (dependency_hash, _) = match dependency_def {
             DependencyDefinition::Path { path: subpath } => {
                 let dep_path = path.join(subpath);
-                resolve_project_depth(brioche, &dep_path, dep_depth)
+                load_project_inner(projects, brioche, &dep_path, dep_depth)
                     .await
                     .with_context(|| {
                         format!(
@@ -54,7 +339,7 @@ pub async fn resolve_project_depth(
             }
             DependencyDefinition::Version(Version::Any) => {
                 let local_path = repo.join(name);
-                resolve_project_depth(brioche, &local_path, dep_depth)
+                load_project_inner(projects, brioche, &local_path, dep_depth)
                     .await
                     .with_context(|| {
                         format!(
@@ -65,71 +350,48 @@ pub async fn resolve_project_depth(
             }
         };
 
-        dependencies.insert(name.to_owned(), dependency);
+        dependencies.insert(name.to_owned(), dependency_hash);
     }
 
-    Ok(Project {
-        local_path: path.to_owned(),
-        analysis: project_analysis,
+    let modules = project_analysis
+        .local_modules
+        .values()
+        .map(|module| (module.project_subpath.clone(), module.file_id))
+        .collect();
+
+    let project = Project {
+        definition: project_analysis.definition,
         dependencies,
-    })
-}
+        modules,
+    };
+    let project = Arc::new(project);
+    let project_hash = ProjectHash::from_serializable(&project)?;
 
-pub fn find_project_root_sync(path: &Path) -> anyhow::Result<&Path> {
-    let mut current_path = path;
-    loop {
-        if current_path.is_dir() {
-            let project_definition_path = current_path.join("project.bri");
-            if project_definition_path.exists() {
-                return Ok(current_path);
-            }
-        }
+    {
+        let mut projects = projects
+            .inner
+            .write()
+            .map_err(|_| anyhow::anyhow!("failed to acquire 'projects' lock"))?;
 
-        current_path = match current_path.parent() {
-            Some(parent) => parent,
-            None => anyhow::bail!("project root not found"),
-        };
+        projects.projects.insert(project_hash, project.clone());
+        projects
+            .paths_to_projects
+            .insert(path.clone(), project_hash);
+        projects
+            .projects_to_paths
+            .entry(project_hash)
+            .or_default()
+            .insert(path);
     }
+
+    Ok((project_hash, project))
 }
 
-pub async fn find_project_root(path: &Path) -> anyhow::Result<&Path> {
-    let mut current_path = path;
-    loop {
-        if is_dir(current_path).await {
-            let project_definition_path = current_path.join("project.bri");
-            let exists = tokio::fs::try_exists(&project_definition_path).await?;
-            if exists {
-                return Ok(current_path);
-            }
-        }
-
-        current_path = match current_path.parent() {
-            Some(parent) => parent,
-            None => anyhow::bail!("project root not found"),
-        };
-    }
-}
-
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
 pub struct Project {
-    pub local_path: PathBuf,
-    pub analysis: analyze::ProjectAnalysis,
-    pub dependencies: HashMap<String, Project>,
-}
-
-impl Project {
-    pub fn local_modules(
-        &self,
-    ) -> impl Iterator<Item = &super::script::specifier::BriocheModuleSpecifier> + '_ {
-        self.analysis.local_modules.keys()
-    }
-
-    pub fn local_module_paths(&self) -> impl Iterator<Item = &Path> + '_ {
-        self.local_modules().filter_map(|module| match module {
-            super::script::specifier::BriocheModuleSpecifier::Runtime { .. } => None,
-            super::script::specifier::BriocheModuleSpecifier::File { path } => Some(&**path),
-        })
-    }
+    pub definition: ProjectDefinition,
+    pub dependencies: HashMap<String, ProjectHash>,
+    pub modules: HashMap<RelativePathBuf, FileId>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -168,5 +430,46 @@ impl std::fmt::Display for Version {
         match self {
             Self::Any => write!(f, "*"),
         }
+    }
+}
+
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    serde_with::SerializeDisplay,
+    serde_with::DeserializeFromStr,
+)]
+pub struct ProjectHash(blake3::Hash);
+
+impl ProjectHash {
+    fn from_serializable<V>(value: &V) -> anyhow::Result<Self>
+    where
+        V: serde::Serialize,
+    {
+        let mut hasher = blake3::Hasher::new();
+
+        json_canon::to_writer(&mut hasher, value)?;
+
+        let hash = hasher.finalize();
+        Ok(Self(hash))
+    }
+}
+
+impl std::fmt::Display for ProjectHash {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl std::str::FromStr for ProjectHash {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let hash = blake3::Hash::from_hex(s)?;
+        Ok(Self(hash))
     }
 }

--- a/crates/brioche/src/brioche/project.rs
+++ b/crates/brioche/src/brioche/project.rs
@@ -46,7 +46,7 @@ impl Projects {
             }
         }
 
-        for ancestor in path.ancestors() {
+        for ancestor in path.ancestors().skip(1) {
             if tokio::fs::try_exists(ancestor.join("project.bri")).await? {
                 return self.load(brioche, ancestor).await;
             }

--- a/crates/brioche/src/brioche/project.rs
+++ b/crates/brioche/src/brioche/project.rs
@@ -134,9 +134,7 @@ impl Projects {
             .inner
             .read()
             .map_err(|_| anyhow::anyhow!("failed to acquire 'projects' lock"))?;
-        projects
-            .project(project_hash)
-            .map(|project| project.clone())
+        projects.project(project_hash).cloned()
     }
 
     pub fn local_paths(&self, project_hash: ProjectHash) -> anyhow::Result<BTreeSet<PathBuf>> {

--- a/crates/brioche/src/brioche/script.rs
+++ b/crates/brioche/src/brioche/script.rs
@@ -78,7 +78,6 @@ impl deno_core::ModuleLoader for BriocheModuleLoader {
         let vfs = self.brioche.vfs.clone();
         let future = async move {
             let module_specifier = module_specifier?;
-            let vfs = vfs.snapshot().await;
             let contents = specifier::read_specifier_contents(&vfs, &module_specifier)?;
 
             let code = std::str::from_utf8(&contents)

--- a/crates/brioche/src/brioche/script/check.rs
+++ b/crates/brioche/src/brioche/script/check.rs
@@ -4,7 +4,7 @@ use anyhow::Context as _;
 
 use crate::brioche::{
     project::{ProjectHash, Projects},
-    vfs::VfsSnapshot,
+    vfs::Vfs,
     Brioche,
 };
 
@@ -144,7 +144,7 @@ pub struct DiagnosticError {
 }
 
 impl DiagnosticError {
-    pub fn write(&self, vfs: &VfsSnapshot, out: &mut impl std::io::Write) -> anyhow::Result<()> {
+    pub fn write(&self, vfs: &Vfs, out: &mut impl std::io::Write) -> anyhow::Result<()> {
         for (n, diagnostic) in self.diagnostics.iter().enumerate() {
             if n != 0 {
                 writeln!(out)?;

--- a/crates/brioche/src/brioche/script/compiler_host.rs
+++ b/crates/brioche/src/brioche/script/compiler_host.rs
@@ -44,9 +44,6 @@ impl BriocheCompilerHost {
         }
     }
 
-    // FIXME: Ensure that loading/updating a document can reload a project
-    // FIXME: Update project snapshots when loading/updating a document
-
     pub async fn load_document(&self, specifier: &BriocheModuleSpecifier) -> anyhow::Result<()> {
         let mut already_visited = HashSet::new();
         let mut specifiers_to_load = vec![specifier.clone()];
@@ -175,6 +172,17 @@ impl BriocheCompilerHost {
                         version: 0,
                     }
                 });
+        }
+
+        match &specifier {
+            BriocheModuleSpecifier::Runtime { .. } => {}
+            BriocheModuleSpecifier::File { path } => {
+                if let Some((file_id, _)) = self.brioche.vfs.load_cached(path)? {
+                    self.brioche
+                        .vfs
+                        .update(file_id, Arc::new(contents.as_bytes().to_vec()))?;
+                };
+            }
         }
 
         self.load_document(&specifier).await?;

--- a/crates/brioche/src/brioche/script/lsp.rs
+++ b/crates/brioche/src/brioche/script/lsp.rs
@@ -157,8 +157,8 @@ impl LanguageServer for BriocheLspServer {
                 .compiler_host
                 .update_document(&params.text_document.uri, &change.text)
                 .await;
-            if result.is_err() {
-                tracing::error!("failed to update document");
+            if let Err(error) = result {
+                tracing::error!("failed to update document: {error:#}");
                 return;
             }
         }

--- a/crates/brioche/src/brioche/script/specifier.rs
+++ b/crates/brioche/src/brioche/script/specifier.rs
@@ -7,10 +7,7 @@ use std::{
 use anyhow::Context as _;
 use relative_path::{PathExt, RelativePathBuf};
 
-use crate::brioche::{
-    project::Projects,
-    vfs::{Vfs, VfsSnapshot},
-};
+use crate::brioche::{project::Projects, vfs::Vfs};
 
 /// A specifier from an `import` statement in a JavaScript module. Can
 /// be resolved to a module specifier using the `resolve` function.
@@ -185,7 +182,7 @@ pub fn runtime_specifiers_with_contents(
 }
 
 pub fn read_specifier_contents(
-    vfs: &VfsSnapshot,
+    vfs: &Vfs,
     specifier: &BriocheModuleSpecifier,
 ) -> anyhow::Result<Arc<Vec<u8>>> {
     match specifier {
@@ -196,7 +193,7 @@ pub fn read_specifier_contents(
         }
         BriocheModuleSpecifier::File { path } => {
             let (_, contents) = vfs
-                .load_cached(path)
+                .load_cached(path)?
                 .with_context(|| format!("module '{specifier}' not loaded"))?;
             Ok(contents)
         }
@@ -216,8 +213,7 @@ pub async fn load_specifier_contents(
         }
     }
 
-    let snapshot = vfs.snapshot().await;
-    read_specifier_contents(&snapshot, specifier)
+    read_specifier_contents(vfs, specifier)
 }
 
 pub fn resolve(

--- a/crates/brioche/src/brioche/vfs.rs
+++ b/crates/brioche/src/brioche/vfs.rs
@@ -1,0 +1,104 @@
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+
+use anyhow::Context as _;
+use tokio::sync::RwLock;
+
+#[derive(Debug, Clone, Default)]
+pub struct Vfs {
+    inner: Arc<RwLock<Arc<VfsInner>>>,
+}
+
+impl Vfs {
+    pub async fn load(&self, path: &Path) -> anyhow::Result<(FileId, Arc<Vec<u8>>)> {
+        {
+            let vfs = self.inner.read().await;
+            if let Some(file_id) = vfs.locations_to_ids.get(path) {
+                let contents = vfs.contents[file_id].clone();
+                return Ok((*file_id, contents));
+            }
+        }
+
+        let contents = tokio::fs::read(path)
+            .await
+            .with_context(|| format!("failed to read file {}", path.display()))?;
+        let contents = Arc::new(contents);
+
+        let hash = blake3::hash(&contents);
+        let file_id = FileId(hash);
+
+        let mut vfs = self.inner.write().await;
+        let vfs = Arc::make_mut(&mut vfs);
+        vfs.contents.insert(file_id, contents.clone());
+        vfs.locations_to_ids.insert(path.to_owned(), file_id);
+        vfs.ids_to_locations
+            .entry(file_id)
+            .or_default()
+            .push(path.to_owned());
+
+        Ok((file_id, contents))
+    }
+
+    pub async fn read(&self, file_id: FileId) -> Option<Arc<Vec<u8>>> {
+        let vfs = self.inner.read().await;
+        vfs.contents.get(&file_id).cloned()
+    }
+
+    pub async fn snapshot(&self) -> VfsSnapshot {
+        let inner = self.inner.read().await.clone();
+        VfsSnapshot { inner }
+    }
+}
+
+pub struct VfsSnapshot {
+    inner: Arc<VfsInner>,
+}
+
+impl VfsSnapshot {
+    pub fn load_cached(&self, path: &Path) -> Option<(FileId, Arc<Vec<u8>>)> {
+        let file_id = self.inner.locations_to_ids.get(path)?;
+        let contents = self.inner.contents.get(file_id)?.clone();
+        Some((*file_id, contents))
+    }
+
+    pub fn read(&self, file_id: FileId) -> Option<Arc<Vec<u8>>> {
+        self.inner.contents.get(&file_id).cloned()
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+struct VfsInner {
+    contents: HashMap<FileId, Arc<Vec<u8>>>,
+    locations_to_ids: HashMap<PathBuf, FileId>,
+    ids_to_locations: HashMap<FileId, Vec<PathBuf>>,
+}
+
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    serde_with::SerializeDisplay,
+    serde_with::DeserializeFromStr,
+)]
+pub struct FileId(blake3::Hash);
+
+impl std::fmt::Display for FileId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0.to_hex())
+    }
+}
+
+impl std::str::FromStr for FileId {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let hash = blake3::Hash::from_hex(s)?;
+        Ok(Self(hash))
+    }
+}

--- a/crates/brioche/src/fs_utils.rs
+++ b/crates/brioche/src/fs_utils.rs
@@ -1,6 +1,23 @@
-use std::path::Path;
+use std::path::{Component, Path, PathBuf};
 
 use anyhow::Context as _;
+
+pub fn logical_path(path: &Path) -> PathBuf {
+    let mut components = vec![];
+    for component in path.components() {
+        match component {
+            Component::Prefix(_) | Component::RootDir | Component::Normal(_) => {
+                components.push(component);
+            }
+            Component::CurDir => {}
+            Component::ParentDir => {
+                components.pop();
+            }
+        }
+    }
+
+    PathBuf::from_iter(components)
+}
 
 pub async fn is_file(path: &Path) -> bool {
     let Ok(metadata) = tokio::fs::metadata(path).await else {

--- a/crates/brioche/src/main.rs
+++ b/crates/brioche/src/main.rs
@@ -303,6 +303,7 @@ async fn lsp(_args: LspArgs) -> anyhow::Result<()> {
         futures::executor::block_on(async move {
             let (reporter, _guard) = brioche::reporter::start_lsp_reporter(client.clone());
             let brioche = brioche::brioche::BriocheBuilder::new(reporter)
+                .vfs(brioche::brioche::vfs::Vfs::mutable())
                 .build()
                 .await?;
             let projects = brioche::brioche::project::Projects::default();

--- a/crates/brioche/src/main.rs
+++ b/crates/brioche/src/main.rs
@@ -330,7 +330,7 @@ struct AnalyzeArgs {
 }
 
 async fn analyze(args: AnalyzeArgs) -> anyhow::Result<()> {
-    let vfs = brioche::brioche::vfs::Vfs::default();
+    let vfs = brioche::brioche::vfs::Vfs::immutable();
     let project = brioche::brioche::project::analyze::analyze_project(&vfs, &args.project).await?;
     println!("{project:#?}");
     Ok(())

--- a/crates/brioche/src/main.rs
+++ b/crates/brioche/src/main.rs
@@ -127,7 +127,7 @@ async fn build(args: BuildArgs) -> anyhow::Result<ExitCode> {
                 Err(diagnostics) => {
                     guard.shutdown_console().await;
 
-                    diagnostics.write(&brioche.vfs.snapshot().await, &mut std::io::stdout())?;
+                    diagnostics.write(&brioche.vfs, &mut std::io::stdout())?;
                     return anyhow::Ok(ExitCode::FAILURE);
                 }
             }
@@ -220,7 +220,7 @@ async fn check(args: CheckArgs) -> anyhow::Result<ExitCode> {
                 anyhow::Ok(ExitCode::SUCCESS)
             }
             Err(diagnostics) => {
-                diagnostics.write(&brioche.vfs.snapshot().await, &mut std::io::stdout())?;
+                diagnostics.write(&brioche.vfs, &mut std::io::stdout())?;
                 anyhow::Ok(ExitCode::FAILURE)
             }
         }

--- a/crates/brioche/tests/brioche_test/mod.rs
+++ b/crates/brioche/tests/brioche_test/mod.rs
@@ -13,6 +13,12 @@ use brioche::brioche::{
 };
 
 pub async fn brioche_test() -> (Brioche, TestContext) {
+    brioche_test_with(|builder| builder).await
+}
+
+pub async fn brioche_test_with(
+    f: impl FnOnce(BriocheBuilder) -> BriocheBuilder,
+) -> (Brioche, TestContext) {
     let temp = tempdir::TempDir::new("brioche-test").unwrap();
 
     let brioche_home = temp.path().join("brioche-home");
@@ -25,13 +31,12 @@ pub async fn brioche_test() -> (Brioche, TestContext) {
         .expect("failed to create brioche repo");
 
     let (reporter, reporter_guard) = brioche::reporter::start_test_reporter();
-    let brioche = BriocheBuilder::new(reporter)
+    let builder = BriocheBuilder::new(reporter)
         .home(brioche_home)
         .repo_dir(brioche_repo)
-        .self_exec_processes(false)
-        .build()
-        .await
-        .unwrap();
+        .self_exec_processes(false);
+    let builder = f(builder);
+    let brioche = builder.build().await.unwrap();
     let context = TestContext {
         temp,
         _reporter_guard: reporter_guard,

--- a/crates/brioche/tests/brioche_test/mod.rs
+++ b/crates/brioche/tests/brioche_test/mod.rs
@@ -8,6 +8,7 @@ use std::{
 use brioche::brioche::{
     artifact::{CreateDirectory, Directory, DirectoryListing, File, WithMeta},
     blob::{BlobId, SaveBlobOptions},
+    project::{ProjectHash, Projects},
     Brioche, BriocheBuilder,
 };
 
@@ -36,6 +37,16 @@ pub async fn brioche_test() -> (Brioche, TestContext) {
         _reporter_guard: reporter_guard,
     };
     (brioche, context)
+}
+
+pub async fn load_project(
+    brioche: &Brioche,
+    path: &Path,
+) -> anyhow::Result<(Projects, ProjectHash)> {
+    let projects = Projects::default();
+    let project_hash = projects.load(brioche, path).await?;
+
+    Ok((projects, project_hash))
 }
 
 pub async fn resolve_without_meta(

--- a/crates/brioche/tests/project_hash.rs
+++ b/crates/brioche/tests/project_hash.rs
@@ -1,0 +1,129 @@
+use brioche::brioche::vfs::Vfs;
+
+mod brioche_test;
+
+#[tokio::test]
+async fn test_project_hash_immutable() -> anyhow::Result<()> {
+    let project_hash_1 = {
+        let (brioche, context) = brioche_test::brioche_test().await;
+
+        let project_dir = context.mkdir("myproject").await;
+
+        context
+            .write_file(
+                "myproject/project.bri",
+                r#"
+                    export const project = {};
+                    export default () => {
+                        return {
+                            briocheSerialize: () => {
+                                return {
+                                    type: "directory",
+                                    listingBlob: null,
+                                }
+                            },
+                        };
+                    };
+                "#,
+            )
+            .await;
+
+        let (_, project_hash) = brioche_test::load_project(&brioche, &project_dir).await?;
+        project_hash
+    };
+
+    let project_hash_2 = {
+        let (brioche, context) = brioche_test::brioche_test().await;
+
+        let project_dir = context.mkdir("myproject2").await;
+
+        context
+            .write_file(
+                "myproject2/project.bri",
+                r#"
+                    export const project = {};
+                    export default () => {
+                        return {
+                            briocheSerialize: () => {
+                                return {
+                                    type: "directory",
+                                    listingBlob: null,
+                                }
+                            },
+                        };
+                    };
+                "#,
+            )
+            .await;
+
+        let (_, project_hash) = brioche_test::load_project(&brioche, &project_dir).await?;
+        project_hash
+    };
+
+    assert_eq!(project_hash_1, project_hash_2);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_project_hash_mutable() -> anyhow::Result<()> {
+    let project_hash_1 = {
+        let (brioche, context) = brioche_test::brioche_test_with(|b| b.vfs(Vfs::mutable())).await;
+
+        let project_dir = context.mkdir("myproject").await;
+
+        context
+            .write_file(
+                "myproject/project.bri",
+                r#"
+                    export const project = {};
+                    export default () => {
+                        return {
+                            briocheSerialize: () => {
+                                return {
+                                    type: "directory",
+                                    listingBlob: null,
+                                }
+                            },
+                        };
+                    };
+                "#,
+            )
+            .await;
+
+        let (_, project_hash) = brioche_test::load_project(&brioche, &project_dir).await?;
+        project_hash
+    };
+
+    let project_hash_2 = {
+        let (brioche, context) = brioche_test::brioche_test_with(|b| b.vfs(Vfs::mutable())).await;
+
+        let project_dir = context.mkdir("myproject2").await;
+
+        context
+            .write_file(
+                "myproject2/project.bri",
+                r#"
+                    export const project = {};
+                    export default () => {
+                        return {
+                            briocheSerialize: () => {
+                                return {
+                                    type: "directory",
+                                    listingBlob: null,
+                                }
+                            },
+                        };
+                    };
+                "#,
+            )
+            .await;
+
+        let (_, project_hash) = brioche_test::load_project(&brioche, &project_dir).await?;
+        project_hash
+    };
+
+    assert_ne!(project_hash_1, project_hash_2);
+
+    Ok(())
+}

--- a/crates/brioche/tests/script_check.rs
+++ b/crates/brioche/tests/script_check.rs
@@ -1,7 +1,6 @@
 use std::path::PathBuf;
 
 use assert_matches::assert_matches;
-use brioche::brioche::project::resolve_project;
 use brioche::brioche::script::check::{CheckResult, DiagnosticLevel};
 
 mod brioche_test;
@@ -45,9 +44,9 @@ async fn test_check_basic_valid() -> anyhow::Result<()> {
         "#,
     )
     .await;
-    let project = resolve_project(&brioche, &project_dir).await?;
+    let (projects, project_hash) = brioche_test::load_project(&brioche, &project_dir).await?;
 
-    let result = brioche::brioche::script::check::check(&brioche, &project).await?;
+    let result = brioche::brioche::script::check::check(&brioche, &projects, project_hash).await?;
 
     assert_matches!(worst_level(&result), None);
 
@@ -77,9 +76,9 @@ async fn test_check_basic_invalid() -> anyhow::Result<()> {
         "#,
     )
     .await;
-    let project = resolve_project(&brioche, &project_dir).await?;
+    let (projects, project_hash) = brioche_test::load_project(&brioche, &project_dir).await?;
 
-    let result = brioche::brioche::script::check::check(&brioche, &project).await?;
+    let result = brioche::brioche::script::check::check(&brioche, &projects, project_hash).await?;
 
     assert_matches!(worst_level(&result), Some(DiagnosticLevel::Error));
 
@@ -126,9 +125,9 @@ async fn test_check_import_valid() -> anyhow::Result<()> {
         )
         .await;
 
-    let project = resolve_project(&brioche, &project_dir).await?;
+    let (projects, project_hash) = brioche_test::load_project(&brioche, &project_dir).await?;
 
-    let result = brioche::brioche::script::check::check(&brioche, &project).await?;
+    let result = brioche::brioche::script::check::check(&brioche, &projects, project_hash).await?;
 
     assert_matches!(worst_level(&result), None);
 
@@ -169,9 +168,9 @@ async fn test_check_import_invalid() -> anyhow::Result<()> {
         )
         .await;
 
-    let project = resolve_project(&brioche, &project_dir).await?;
+    let (projects, project_hash) = brioche_test::load_project(&brioche, &project_dir).await?;
 
-    let result = brioche::brioche::script::check::check(&brioche, &project).await?;
+    let result = brioche::brioche::script::check::check(&brioche, &projects, project_hash).await?;
 
     assert_matches!(worst_level(&result), Some(DiagnosticLevel::Error));
 
@@ -202,9 +201,9 @@ async fn test_check_import_nonexistent() -> anyhow::Result<()> {
     )
     .await;
 
-    let project = resolve_project(&brioche, &project_dir).await?;
+    let (projects, project_hash) = brioche_test::load_project(&brioche, &project_dir).await?;
 
-    let result = brioche::brioche::script::check::check(&brioche, &project).await?;
+    let result = brioche::brioche::script::check::check(&brioche, &projects, project_hash).await?;
 
     assert_matches!(worst_level(&result), Some(DiagnosticLevel::Error));
 
@@ -234,9 +233,9 @@ async fn test_check_invalid_unused_var() -> anyhow::Result<()> {
         "#,
     )
     .await;
-    let project = resolve_project(&brioche, &project_dir).await?;
+    let (projects, project_hash) = brioche_test::load_project(&brioche, &project_dir).await?;
 
-    let result = brioche::brioche::script::check::check(&brioche, &project).await?;
+    let result = brioche::brioche::script::check::check(&brioche, &projects, project_hash).await?;
 
     assert_matches!(worst_level(&result), Some(DiagnosticLevel::Warning));
 
@@ -273,9 +272,9 @@ async fn test_check_invalid_missing_await() -> anyhow::Result<()> {
         "#,
     )
     .await;
-    let project = resolve_project(&brioche, &project_dir).await?;
+    let (projects, project_hash) = brioche_test::load_project(&brioche, &project_dir).await?;
 
-    let result = brioche::brioche::script::check::check(&brioche, &project).await?;
+    let result = brioche::brioche::script::check::check(&brioche, &projects, project_hash).await?;
 
     assert_matches!(worst_level(&result), Some(DiagnosticLevel::Warning));
 

--- a/crates/brioche/tests/script_eval.rs
+++ b/crates/brioche/tests/script_eval.rs
@@ -1,4 +1,4 @@
-use brioche::brioche::{project::resolve_project, script::evaluate::evaluate};
+use brioche::brioche::script::evaluate::evaluate;
 
 mod brioche_test;
 
@@ -27,9 +27,11 @@ async fn test_eval_basic() -> anyhow::Result<()> {
         )
         .await;
 
-    let project = resolve_project(&brioche, &project_dir).await?;
+    let (projects, project_hash) = brioche_test::load_project(&brioche, &project_dir).await?;
 
-    let resolved = evaluate(&brioche, &project, "default").await?.value;
+    let resolved = evaluate(&brioche, &projects, project_hash, "default")
+        .await?
+        .value;
 
     assert_eq!(resolved, brioche_test::dir_empty().into());
 
@@ -61,9 +63,11 @@ async fn test_eval_custom_export() -> anyhow::Result<()> {
         )
         .await;
 
-    let project = resolve_project(&brioche, &project_dir).await?;
+    let (projects, project_hash) = brioche_test::load_project(&brioche, &project_dir).await?;
 
-    let resolved = evaluate(&brioche, &project, "custom").await?.value;
+    let resolved = evaluate(&brioche, &projects, project_hash, "custom")
+        .await?
+        .value;
 
     assert_eq!(resolved, brioche_test::dir_empty().into());
 
@@ -95,9 +99,11 @@ async fn test_eval_async() -> anyhow::Result<()> {
         )
         .await;
 
-    let project = resolve_project(&brioche, &project_dir).await?;
+    let (projects, project_hash) = brioche_test::load_project(&brioche, &project_dir).await?;
 
-    let resolved = evaluate(&brioche, &project, "default").await?.value;
+    let resolved = evaluate(&brioche, &projects, project_hash, "default")
+        .await?
+        .value;
 
     assert_eq!(resolved, brioche_test::dir_empty().into());
 
@@ -129,9 +135,11 @@ async fn test_eval_serialize_async() -> anyhow::Result<()> {
         )
         .await;
 
-    let project = resolve_project(&brioche, &project_dir).await?;
+    let (projects, project_hash) = brioche_test::load_project(&brioche, &project_dir).await?;
 
-    let resolved = evaluate(&brioche, &project, "default").await?.value;
+    let resolved = evaluate(&brioche, &projects, project_hash, "default")
+        .await?
+        .value;
 
     assert_eq!(resolved, brioche_test::dir_empty().into());
 
@@ -175,9 +183,11 @@ async fn test_eval_import_local() -> anyhow::Result<()> {
         )
         .await;
 
-    let project = resolve_project(&brioche, &project_dir).await?;
+    let (projects, project_hash) = brioche_test::load_project(&brioche, &project_dir).await?;
 
-    let resolved = evaluate(&brioche, &project, "default").await?.value;
+    let resolved = evaluate(&brioche, &projects, project_hash, "default")
+        .await?
+        .value;
 
     assert_eq!(resolved, brioche_test::dir_empty().into());
 
@@ -226,9 +236,11 @@ async fn test_eval_import_dep() -> anyhow::Result<()> {
         )
         .await;
 
-    let project = resolve_project(&brioche, &project_dir).await?;
+    let (projects, project_hash) = brioche_test::load_project(&brioche, &project_dir).await?;
 
-    let resolved = evaluate(&brioche, &project, "default").await?.value;
+    let resolved = evaluate(&brioche, &projects, project_hash, "default")
+        .await?
+        .value;
 
     assert_eq!(resolved, brioche_test::dir_empty().into());
 

--- a/crates/brioche/tests/script_project_analyze.rs
+++ b/crates/brioche/tests/script_project_analyze.rs
@@ -32,7 +32,7 @@ fn get_local_module(
 
 #[tokio::test]
 async fn test_analyze_simple_project() -> anyhow::Result<()> {
-    let (_brioche, context) = brioche_test::brioche_test().await;
+    let (brioche, context) = brioche_test::brioche_test().await;
 
     let project_dir = context.mkdir("myproject").await;
     context
@@ -44,7 +44,7 @@ async fn test_analyze_simple_project() -> anyhow::Result<()> {
         )
         .await;
 
-    let project = analyze_project(&project_dir)?;
+    let project = analyze_project(&brioche.vfs, &project_dir).await?;
 
     assert_eq!(
         project.definition,
@@ -61,7 +61,7 @@ async fn test_analyze_simple_project() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn test_analyze_imports() -> anyhow::Result<()> {
-    let (_brioche, context) = brioche_test::brioche_test().await;
+    let (brioche, context) = brioche_test::brioche_test().await;
 
     let project_dir = context.mkdir("myproject").await;
     context
@@ -94,7 +94,7 @@ async fn test_analyze_imports() -> anyhow::Result<()> {
         .write_file("myproject/asdf.bri", "export const asdf = 'asdf';")
         .await;
 
-    let project = analyze_project(&project_dir)?;
+    let project = analyze_project(&brioche.vfs, &project_dir).await?;
 
     let root_module = &project.local_modules[&project.root_module];
     assert_matches!(
@@ -123,7 +123,7 @@ async fn test_analyze_imports() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn test_analyze_nested_imports() -> anyhow::Result<()> {
-    let (_brioche, context) = brioche_test::brioche_test().await;
+    let (brioche, context) = brioche_test::brioche_test().await;
 
     let project_dir = context.mkdir("myproject").await;
     context
@@ -146,7 +146,7 @@ async fn test_analyze_nested_imports() -> anyhow::Result<()> {
         .write_file("myproject/baz/index.bri", "export const x = 'baz';")
         .await;
 
-    let project = analyze_project(&project_dir)?;
+    let project = analyze_project(&brioche.vfs, &project_dir).await?;
 
     let foo_module = get_local_module(&project, &project.root_module, "./foo");
     let bar_module = get_local_module(&project, &foo_module, "../bar");
@@ -159,7 +159,7 @@ async fn test_analyze_nested_imports() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn test_analyze_import_loop() -> anyhow::Result<()> {
-    let (_brioche, context) = brioche_test::brioche_test().await;
+    let (brioche, context) = brioche_test::brioche_test().await;
 
     let project_dir = context.mkdir("myproject").await;
     context
@@ -190,7 +190,7 @@ async fn test_analyze_import_loop() -> anyhow::Result<()> {
         )
         .await;
 
-    let project = analyze_project(&project_dir)?;
+    let project = analyze_project(&brioche.vfs, &project_dir).await?;
 
     let foo_module_from_root = get_local_module(&project, &project.root_module, "./foo.bri");
     let bar_module_from_root = get_local_module(&project, &project.root_module, "./bar.bri");
@@ -205,7 +205,7 @@ async fn test_analyze_import_loop() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn test_analyze_external_dep() -> anyhow::Result<()> {
-    let (_brioche, context) = brioche_test::brioche_test().await;
+    let (brioche, context) = brioche_test::brioche_test().await;
 
     let project_dir = context.mkdir("myproject").await;
     context
@@ -223,7 +223,7 @@ async fn test_analyze_external_dep() -> anyhow::Result<()> {
         )
         .await;
 
-    let project = analyze_project(&project_dir)?;
+    let project = analyze_project(&brioche.vfs, &project_dir).await?;
 
     assert_eq!(
         project.definition,

--- a/crates/brioche/tests/script_specifiers.rs
+++ b/crates/brioche/tests/script_specifiers.rs
@@ -1,54 +1,32 @@
 use assert_matches::assert_matches;
 use brioche::brioche::{
+    project::Projects,
     script::specifier::{
-        self, read_specifier_contents, read_specifier_contents_sync, BriocheImportSpecifier,
-        BriocheModuleSpecifier,
+        self, read_specifier_contents, BriocheImportSpecifier, BriocheModuleSpecifier,
     },
-    Brioche,
 };
-use tokio::io::AsyncReadExt as _;
 
 mod brioche_test;
 
 async fn resolve(
-    brioche: &Brioche,
+    projects: &Projects,
     specifier: &str,
     referrer: &BriocheModuleSpecifier,
 ) -> anyhow::Result<BriocheModuleSpecifier> {
     let specifier: BriocheImportSpecifier = specifier.parse()?;
-    let resolved = specifier::resolve(brioche, &specifier, referrer).await?;
+    let resolved = specifier::resolve(projects, &specifier, referrer)?;
 
     Ok(resolved)
 }
 
 #[tokio::test]
-async fn test_specifier_read_runtime_sync() -> anyhow::Result<()> {
-    let (_brioche, _context) = brioche_test::brioche_test().await;
-
-    let specifier: BriocheModuleSpecifier = "briocheruntime:///dist/index.js"
-        .parse()
-        .expect("failed to parse specifier");
-    let mut reader = read_specifier_contents_sync(&specifier)?.expect("specifier not found");
-    let mut contents = String::new();
-    reader.read_to_string(&mut contents)?;
-
-    assert!(!contents.is_empty());
-
-    Ok(())
-}
-
-#[tokio::test]
 async fn test_specifier_read_runtime() -> anyhow::Result<()> {
-    let (_brioche, _context) = brioche_test::brioche_test().await;
+    let (brioche, _context) = brioche_test::brioche_test().await;
 
     let specifier: BriocheModuleSpecifier = "briocheruntime:///dist/index.js"
         .parse()
         .expect("failed to parse specifier");
-    let mut reader = read_specifier_contents(&specifier)
-        .await?
-        .expect("specifier not found");
-    let mut contents = String::new();
-    reader.read_to_string(&mut contents).await?;
+    let contents = read_specifier_contents(&brioche.vfs.snapshot().await, &specifier)?;
 
     assert!(!contents.is_empty());
 
@@ -57,50 +35,29 @@ async fn test_specifier_read_runtime() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn test_specifier_read_project() -> anyhow::Result<()> {
-    let (_brioche, context) = brioche_test::brioche_test().await;
+    let (brioche, context) = brioche_test::brioche_test().await;
 
+    let project_dir = context.mkdir("myproject").await;
     context
         .write_file(
             "myproject/project.bri",
             r#"
+                import { hello } from "./foo.bri";
                 export const project = {};
             "#,
         )
         .await;
-    let foo_path = context.write_file("myproject/foo.txt", "Hello world").await;
+    let foo_script = r#"export const hello = "Hello world";"#;
+    let foo_path = context.write_file("myproject/foo.bri", foo_script).await;
+
+    // Ensure the project files get loaded into the VFS
+    brioche_test::load_project(&brioche, &project_dir).await?;
 
     let specifier = BriocheModuleSpecifier::from_path(&foo_path);
-    let mut reader = read_specifier_contents(&specifier)
-        .await?
-        .expect("specifier not found");
-    let mut contents = String::new();
-    reader.read_to_string(&mut contents).await?;
+    let contents = read_specifier_contents(&brioche.vfs.snapshot().await, &specifier)?;
+    let contents = std::str::from_utf8(&contents).unwrap();
 
-    assert_eq!(contents, "Hello world");
-
-    Ok(())
-}
-
-#[tokio::test]
-async fn test_specifier_read_project_sync() -> anyhow::Result<()> {
-    let (_brioche, context) = brioche_test::brioche_test().await;
-
-    context
-        .write_file(
-            "myproject/project.bri",
-            r#"
-                export const project = {};
-            "#,
-        )
-        .await;
-    let foo_path = context.write_file("myproject/foo.txt", "Hello world").await;
-
-    let specifier = BriocheModuleSpecifier::from_path(&foo_path);
-    let mut reader = read_specifier_contents_sync(&specifier)?.expect("specifier not found");
-    let mut contents = String::new();
-    reader.read_to_string(&mut contents)?;
-
-    assert_eq!(contents, "Hello world");
+    assert_eq!(contents, foo_script);
 
     Ok(())
 }
@@ -109,7 +66,7 @@ async fn test_specifier_read_project_sync() -> anyhow::Result<()> {
 async fn test_specifier_resolve_relative() -> anyhow::Result<()> {
     let (brioche, context) = brioche_test::brioche_test().await;
 
-    context.mkdir("myproject").await;
+    let project_dir = context.mkdir("myproject").await;
     context
         .write_file(
             "myproject/project.bri",
@@ -129,21 +86,22 @@ async fn test_specifier_resolve_relative() -> anyhow::Result<()> {
         .await;
     let test_path = context.write_file("myproject/test.txt", "Hi world!").await;
 
+    let (projects, _) = brioche_test::load_project(&brioche, &project_dir).await?;
     let referrer = BriocheModuleSpecifier::from_path(&foo_hello_path);
 
-    let sibling_specifier = resolve(&brioche, "./test.txt", &referrer).await?;
+    let sibling_specifier = resolve(&projects, "./test.txt", &referrer).await?;
     assert_eq!(
         sibling_specifier,
         BriocheModuleSpecifier::from_path(&foo_test_path),
     );
 
-    let inner_specifier = resolve(&brioche, "./inner/test.txt", &referrer).await?;
+    let inner_specifier = resolve(&projects, "./inner/test.txt", &referrer).await?;
     assert_eq!(
         inner_specifier,
         BriocheModuleSpecifier::from_path(&foo_inner_test_path),
     );
 
-    let outer_specifier = resolve(&brioche, "../test.txt", &referrer).await?;
+    let outer_specifier = resolve(&projects, "../test.txt", &referrer).await?;
     assert_eq!(
         outer_specifier,
         BriocheModuleSpecifier::from_path(&test_path),
@@ -156,6 +114,7 @@ async fn test_specifier_resolve_relative() -> anyhow::Result<()> {
 async fn test_specifier_resolve_project_relative() -> anyhow::Result<()> {
     let (brioche, context) = brioche_test::brioche_test().await;
 
+    let project_dir = context.mkdir("myproject").await;
     context
         .write_file(
             "myproject/project.bri",
@@ -175,21 +134,22 @@ async fn test_specifier_resolve_project_relative() -> anyhow::Result<()> {
         .await;
     let test_path = context.write_file("myproject/test.txt", "Hi world!").await;
 
+    let (projects, _) = brioche_test::load_project(&brioche, &project_dir).await?;
     let referrer = BriocheModuleSpecifier::from_path(&foo_hello_path);
 
-    let root_specifier = resolve(&brioche, "/test.txt", &referrer).await?;
+    let root_specifier = resolve(&projects, "/test.txt", &referrer).await?;
     assert_eq!(
         root_specifier,
         BriocheModuleSpecifier::from_path(&test_path),
     );
 
-    let foo_specifier = resolve(&brioche, "/foo/test.txt", &referrer).await?;
+    let foo_specifier = resolve(&projects, "/foo/test.txt", &referrer).await?;
     assert_eq!(
         foo_specifier,
         BriocheModuleSpecifier::from_path(&foo_test_path),
     );
 
-    let inner_specifier = resolve(&brioche, "/foo/inner/test.txt", &referrer).await?;
+    let inner_specifier = resolve(&projects, "/foo/inner/test.txt", &referrer).await?;
     assert_eq!(
         inner_specifier,
         BriocheModuleSpecifier::from_path(&foo_inner_test_path),
@@ -202,6 +162,7 @@ async fn test_specifier_resolve_project_relative() -> anyhow::Result<()> {
 async fn test_specifier_resolve_relative_dir() -> anyhow::Result<()> {
     let (brioche, context) = brioche_test::brioche_test().await;
 
+    let project_dir = context.mkdir("myproject").await;
     let main_path = context
         .write_file(
             "myproject/project.bri",
@@ -218,33 +179,34 @@ async fn test_specifier_resolve_relative_dir() -> anyhow::Result<()> {
         .await;
     let foo_main_path = context.write_file("myproject/foo/index.bri", "").await;
 
+    let (projects, _) = brioche_test::load_project(&brioche, &project_dir).await?;
     let referrer = BriocheModuleSpecifier::from_path(&foo_hello_path);
 
-    let sibling_specifier = resolve(&brioche, "./", &referrer).await?;
+    let sibling_specifier = resolve(&projects, "./", &referrer).await?;
     assert_eq!(
         sibling_specifier,
         BriocheModuleSpecifier::from_path(&foo_main_path),
     );
 
-    let sibling_bare_specifier = resolve(&brioche, ".", &referrer).await?;
+    let sibling_bare_specifier = resolve(&projects, ".", &referrer).await?;
     assert_eq!(
         sibling_bare_specifier,
         BriocheModuleSpecifier::from_path(&foo_main_path),
     );
 
-    let inner_specifier = resolve(&brioche, "./inner", &referrer).await?;
+    let inner_specifier = resolve(&projects, "./inner", &referrer).await?;
     assert_eq!(
         inner_specifier,
         BriocheModuleSpecifier::from_path(&foo_inner_main_path),
     );
 
-    let outer_specifier = resolve(&brioche, "../", &referrer).await?;
+    let outer_specifier = resolve(&projects, "../", &referrer).await?;
     assert_eq!(
         outer_specifier,
         BriocheModuleSpecifier::from_path(&main_path),
     );
 
-    let outer_bare_specifier = resolve(&brioche, "..", &referrer).await?;
+    let outer_bare_specifier = resolve(&projects, "..", &referrer).await?;
     assert_eq!(
         outer_bare_specifier,
         BriocheModuleSpecifier::from_path(&main_path),
@@ -257,6 +219,7 @@ async fn test_specifier_resolve_relative_dir() -> anyhow::Result<()> {
 async fn test_specifier_resolve_project_relative_dir() -> anyhow::Result<()> {
     let (brioche, context) = brioche_test::brioche_test().await;
 
+    let project_dir = context.mkdir("myproject").await;
     let main_path = context
         .write_file(
             "myproject/project.bri",
@@ -273,27 +236,28 @@ async fn test_specifier_resolve_project_relative_dir() -> anyhow::Result<()> {
         .await;
     let foo_main_path = context.write_file("myproject/foo/index.bri", "").await;
 
+    let (projects, _) = brioche_test::load_project(&brioche, &project_dir).await?;
     let referrer = BriocheModuleSpecifier::from_path(&foo_hello_path);
 
-    let root_specifier = resolve(&brioche, "/", &referrer).await?;
+    let root_specifier = resolve(&projects, "/", &referrer).await?;
     assert_eq!(
         root_specifier,
         BriocheModuleSpecifier::from_path(&main_path),
     );
 
-    let foo_specifier = resolve(&brioche, "/foo/", &referrer).await?;
+    let foo_specifier = resolve(&projects, "/foo/", &referrer).await?;
     assert_eq!(
         foo_specifier,
         BriocheModuleSpecifier::from_path(&foo_main_path),
     );
 
-    let foo_bare_specifier = resolve(&brioche, "/foo", &referrer).await?;
+    let foo_bare_specifier = resolve(&projects, "/foo", &referrer).await?;
     assert_eq!(
         foo_bare_specifier,
         BriocheModuleSpecifier::from_path(&foo_main_path),
     );
 
-    let inner_specifier = resolve(&brioche, "/foo/inner", &referrer).await?;
+    let inner_specifier = resolve(&projects, "/foo/inner", &referrer).await?;
     assert_eq!(
         inner_specifier,
         BriocheModuleSpecifier::from_path(&foo_inner_main_path),
@@ -305,6 +269,8 @@ async fn test_specifier_resolve_project_relative_dir() -> anyhow::Result<()> {
 #[tokio::test]
 async fn test_specifier_resolve_subproject() -> anyhow::Result<()> {
     let (brioche, context) = brioche_test::brioche_test().await;
+
+    let root_project_dir = context.mkdir("root").await;
 
     context
         .write_file(
@@ -359,9 +325,10 @@ async fn test_specifier_resolve_subproject() -> anyhow::Result<()> {
         .write_file("brioche-repo/baz/inner/file.txt", "")
         .await;
 
+    let (projects, _) = brioche_test::load_project(&brioche, &root_project_dir).await?;
     let referrer = BriocheModuleSpecifier::from_path(&bar_file_path);
 
-    let baz_specifier = resolve(&brioche, "baz", &referrer).await?;
+    let baz_specifier = resolve(&projects, "baz", &referrer).await?;
     assert_eq!(
         baz_specifier,
         BriocheModuleSpecifier::from_path(&baz_main_path),
@@ -369,10 +336,10 @@ async fn test_specifier_resolve_subproject() -> anyhow::Result<()> {
 
     // Resolving paths under a dependency is not allowed
 
-    let baz_file_specifier = resolve(&brioche, "baz/file.txt", &referrer).await;
+    let baz_file_specifier = resolve(&projects, "baz/file.txt", &referrer).await;
     assert_matches!(baz_file_specifier, Err(_));
 
-    let baz_inner_specifier = resolve(&brioche, "baz/inner/file.txt", &referrer).await;
+    let baz_inner_specifier = resolve(&projects, "baz/inner/file.txt", &referrer).await;
     assert_matches!(baz_inner_specifier, Err(_));
 
     Ok(())

--- a/crates/brioche/tests/script_specifiers.rs
+++ b/crates/brioche/tests/script_specifiers.rs
@@ -26,7 +26,7 @@ async fn test_specifier_read_runtime() -> anyhow::Result<()> {
     let specifier: BriocheModuleSpecifier = "briocheruntime:///dist/index.js"
         .parse()
         .expect("failed to parse specifier");
-    let contents = read_specifier_contents(&brioche.vfs.snapshot().await, &specifier)?;
+    let contents = read_specifier_contents(&brioche.vfs, &specifier)?;
 
     assert!(!contents.is_empty());
 
@@ -54,7 +54,7 @@ async fn test_specifier_read_project() -> anyhow::Result<()> {
     brioche_test::load_project(&brioche, &project_dir).await?;
 
     let specifier = BriocheModuleSpecifier::from_path(&foo_path);
-    let contents = read_specifier_contents(&brioche.vfs.snapshot().await, &specifier)?;
+    let contents = read_specifier_contents(&brioche.vfs, &specifier)?;
     let contents = std::str::from_utf8(&contents).unwrap();
 
     assert_eq!(contents, foo_script);


### PR DESCRIPTION
This PR refactors how modules are loaded. The key is 2 new types:

- `Vfs` (virtual filesystem): Supports loading and caching files from disk, or synchronously getting the cached contents of a previously-loaded file. A VFS can be constructed using either `Vfs::immutable()` and `Vfs::mutable()`
  - `Vfs::immutable()`: Captures an immutable snapshot of files, then derives a file ID based on a hash of the file contents
  - `Vfs::mutable()`: Captures a mutable snapshot of files, then assigns a random ULID as the ID. Used for the LSP specifically, where we need to update an in-memory snapshot of files
- `Projects`: A set of projects loaded in memory. When a project is loaded, it returns a `ProjectHash`, which can be used to look up project-specific information

With these changes, `Project` itself now only stores minimal information (the project definition defined in code, the `ProjectHash`es of dependencies, and the `FileId`s of the project's submodules. This also means that a `ProjectHash`, when paired with an immutable VFS, is a full hash of all the modules and dependencies loaded by the project, which will be used in the future for caching / publishing projects

`Vfs::mutable()` was introduced to support the LSP. When using a mutable VFS, file IDs are not derived based on a hash of the file contents, which means we can update the in-memory contents of a file at will. This still isn't a perfect solution, as added/removed files don't end up getting added into a project, so there's still more to do here in the future, but it seems like this should be good enough for an initial pass