### PR TITLE
Implement initial support for project registry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -796,6 +796,7 @@ dependencies = [
  "ulid",
  "unshare",
  "url",
+ "urlencoding",
 ]
 
 [[package]]

--- a/crates/brioche/Cargo.toml
+++ b/crates/brioche/Cargo.toml
@@ -65,6 +65,7 @@ tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json", "tr
 ulid = "1.1.0"
 unshare = { git = "https://github.com/brioche-dev/unshare.git" }
 url = { version = "2.5.0", features = ["serde"] }
+urlencoding = "2.1.3"
 
 [dev-dependencies]
 assert_matches = "1.5.0"

--- a/crates/brioche/benches/brioche_bench/mod.rs
+++ b/crates/brioche/benches/brioche_bench/mod.rs
@@ -15,18 +15,13 @@ pub async fn brioche_test() -> (Brioche, TestContext) {
     let temp = tempdir::TempDir::new("brioche-test").unwrap();
 
     let brioche_home = temp.path().join("brioche-home");
-    let brioche_repo = temp.path().join("brioche-repo");
     tokio::fs::create_dir_all(&brioche_home)
         .await
         .expect("failed to create brioche home");
-    tokio::fs::create_dir_all(&brioche_repo)
-        .await
-        .expect("failed to create brioche repo");
 
     let (reporter, reporter_guard) = brioche::reporter::start_test_reporter();
     let brioche = BriocheBuilder::new(reporter)
         .home(brioche_home)
-        .repo_dir(brioche_repo)
         .self_exec_processes(false)
         .build()
         .await

--- a/crates/brioche/src/lib.rs
+++ b/crates/brioche/src/lib.rs
@@ -15,6 +15,7 @@ pub mod input;
 pub mod output;
 pub mod platform;
 pub mod project;
+pub mod registry;
 pub mod reporter;
 pub mod resolve;
 pub mod sandbox;

--- a/crates/brioche/src/lib.rs
+++ b/crates/brioche/src/lib.rs
@@ -2,6 +2,7 @@ use std::{path::PathBuf, sync::Arc};
 
 use anyhow::Context as _;
 use futures::TryFutureExt as _;
+use registry::RegistryClient;
 use reporter::Reporter;
 use sha2::Digest as _;
 use sqlx::Connection as _;
@@ -34,7 +35,7 @@ pub struct Brioche {
     /// The directory where all of Brioche's data is stored. Usually configured
     /// to follow the platform's conventions for storing application data, such
     /// as `~/.local/share/brioche` on Linux.
-    home: PathBuf,
+    pub home: PathBuf,
     /// Causes Brioche to call itself to execute processes in a sandbox, rather
     /// than using a `tokio::spawn_blocking` thread. This could allow for
     /// running more processes at a time. This option mainly exists because
@@ -82,6 +83,11 @@ impl BriocheBuilder {
 
     pub fn repo_dir(mut self, repo_dir: PathBuf) -> Self {
         self.repo_dir = Some(repo_dir);
+        self
+    }
+
+    pub fn registry_client(mut self, registry_client: RegistryClient) -> Self {
+        self.registry_client = Some(registry_client);
         self
     }
 

--- a/crates/brioche/src/main.rs
+++ b/crates/brioche/src/main.rs
@@ -307,6 +307,7 @@ async fn lsp(_args: LspArgs) -> anyhow::Result<()> {
         futures::executor::block_on(async move {
             let (reporter, _guard) = brioche::reporter::start_lsp_reporter(client.clone());
             let brioche = brioche::BriocheBuilder::new(reporter)
+                .registry_client(brioche::registry::RegistryClient::disabled())
                 .vfs(brioche::vfs::Vfs::mutable())
                 .build()
                 .await?;

--- a/crates/brioche/src/project.rs
+++ b/crates/brioche/src/project.rs
@@ -621,7 +621,7 @@ async fn find_workspace(project_path: &Path) -> anyhow::Result<Option<Workspace>
     Ok(None)
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Project {
     pub definition: ProjectDefinition,

--- a/crates/brioche/src/project.rs
+++ b/crates/brioche/src/project.rs
@@ -465,15 +465,6 @@ async fn resolve_dependency_to_local_path(
         }
     }
 
-    let repo = &brioche.repo_dir;
-    let repo_path = repo.join(dependency_name);
-    if tokio::fs::try_exists(&repo_path).await? {
-        return Ok(ResolvedDependency {
-            local_path: repo_path,
-            expected_hash: None,
-        });
-    }
-
     let dep_hash = resolve_project_from_registry(brioche, dependency_name, dependency_version)
         .await
         .with_context(|| format!("failed to resolve '{dependency_name}' from registry"))?;

--- a/crates/brioche/src/registry.rs
+++ b/crates/brioche/src/registry.rs
@@ -1,0 +1,126 @@
+use anyhow::Context as _;
+
+use crate::{
+    project::{Project, ProjectHash, ProjectListing},
+    vfs::FileId,
+};
+
+#[derive(Clone)]
+pub struct RegistryClient {
+    client: reqwest::Client,
+    url: url::Url,
+    auth: RegistryAuthentication,
+}
+
+impl RegistryClient {
+    pub fn new(url: url::Url, auth: RegistryAuthentication) -> Self {
+        Self {
+            client: reqwest::Client::new(),
+            url,
+            auth,
+        }
+    }
+
+    fn request(
+        &self,
+        method: reqwest::Method,
+        url: impl reqwest::IntoUrl,
+    ) -> reqwest::RequestBuilder {
+        let request = self.client.request(method, url);
+        match &self.auth {
+            RegistryAuthentication::Anonymous => request,
+            RegistryAuthentication::Admin { password } => {
+                request.basic_auth("admin", Some(password))
+            }
+        }
+    }
+
+    pub async fn get_blob(&self, file_id: FileId) -> anyhow::Result<Vec<u8>> {
+        let url = self
+            .url
+            .join("blobs/")?
+            .join(&urlencoding::encode(&file_id.to_string()))?;
+        let response = self.request(reqwest::Method::GET, url).send().await?;
+        let response_body = response.error_for_status()?.bytes().await?;
+        let response_body = response_body.to_vec();
+
+        file_id
+            .validate_matches(&response_body)
+            .context("blob hash did not match")?;
+
+        Ok(response_body)
+    }
+
+    pub async fn get_project_tag(
+        &self,
+        project_name: &str,
+        tag: &str,
+    ) -> anyhow::Result<GetProjectTagResponse> {
+        let url = self
+            .url
+            .join("project-tags/")?
+            .join(&format!("{}/", urlencoding::encode(project_name)))?
+            .join(&urlencoding::encode(tag))?;
+        let response = self.request(reqwest::Method::GET, url).send().await?;
+        let response_body = response.error_for_status()?.json().await?;
+        Ok(response_body)
+    }
+
+    pub async fn get_project(&self, project_hash: ProjectHash) -> anyhow::Result<Project> {
+        let url = self
+            .url
+            .join("projects/")?
+            .join(&urlencoding::encode(&project_hash.to_string()))?;
+        let response = self.request(reqwest::Method::GET, url).send().await?;
+        let project = response.error_for_status()?.json().await?;
+
+        project_hash.validate_matches(&project)?;
+
+        Ok(project)
+    }
+
+    pub async fn publish_project(
+        &self,
+        project: &ProjectListing,
+    ) -> anyhow::Result<PublishProjectResponse> {
+        let url = self.url.join("projects")?;
+        let response = self
+            .request(reqwest::Method::POST, url)
+            .json(project)
+            .send()
+            .await?;
+        let response_body = response.error_for_status()?.json().await?;
+        Ok(response_body)
+    }
+}
+
+#[derive(Clone)]
+pub enum RegistryAuthentication {
+    Anonymous,
+    Admin { password: String },
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GetProjectTagResponse {
+    pub project_hash: ProjectHash,
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PublishProjectResponse {
+    pub root_project: ProjectHash,
+    pub new_files: u64,
+    pub new_projects: u64,
+    pub tags: Vec<UpdatedTag>,
+}
+
+#[serde_with::serde_as]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdatedTag {
+    pub name: String,
+    pub tag: String,
+    #[serde_as(as = "Option<serde_with::DisplayFromStr>")]
+    pub previous_hash: Option<ProjectHash>,
+}

--- a/crates/brioche/tests/brioche_test/mod.rs
+++ b/crates/brioche/tests/brioche_test/mod.rs
@@ -24,18 +24,13 @@ pub async fn brioche_test_with(
     let registry_server = mockito::Server::new();
 
     let brioche_home = temp.path().join("brioche-home");
-    let brioche_repo = temp.path().join("brioche-repo");
     tokio::fs::create_dir_all(&brioche_home)
         .await
         .expect("failed to create brioche home");
-    tokio::fs::create_dir_all(&brioche_repo)
-        .await
-        .expect("failed to create brioche repo");
 
     let (reporter, reporter_guard) = brioche::reporter::start_test_reporter();
     let builder = BriocheBuilder::new(reporter)
         .home(brioche_home)
-        .repo_dir(brioche_repo)
         .registry_client(brioche::registry::RegistryClient::new(
             registry_server.url().parse().unwrap(),
             brioche::registry::RegistryAuthentication::Admin {

--- a/crates/brioche/tests/project_load.rs
+++ b/crates/brioche/tests/project_load.rs
@@ -194,6 +194,117 @@ async fn test_project_load_with_path_dep() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+async fn test_project_load_with_local_registry_dep() -> anyhow::Result<()> {
+    let (brioche, mut context) = brioche_test::brioche_test().await;
+
+    let (foo_hash, foo_path) = context
+        .local_registry_project(|path| async move {
+            tokio::fs::write(
+                path.join("project.bri"),
+                r#"
+                    export const project = {};
+                "#,
+            )
+            .await
+            .unwrap();
+        })
+        .await;
+    let mock_foo_latest = context
+        .mock_registry_publish_tag("foo", "latest", foo_hash)
+        .create_async()
+        .await;
+
+    let project_dir = context.mkdir("myproject").await;
+    context
+        .write_file(
+            "myproject/project.bri",
+            r#"
+                export const project = {
+                    dependencies: {
+                        foo: "*",
+                    },
+                };
+            "#,
+        )
+        .await;
+
+    let (projects, project_hash) = brioche_test::load_project(&brioche, &project_dir).await?;
+    let project = projects.project(project_hash).unwrap();
+    assert!(projects
+        .local_paths(project_hash)
+        .unwrap()
+        .contains(&project_dir));
+
+    let foo_dep_hash = project.dependencies["foo"];
+    let foo_dep = projects.project(foo_dep_hash).unwrap();
+    assert!(projects
+        .local_paths(foo_dep_hash)
+        .unwrap()
+        .contains(&foo_path));
+    assert!(foo_dep.dependencies.is_empty());
+
+    mock_foo_latest.assert_async().await;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_project_load_with_remote_registry_dep() -> anyhow::Result<()> {
+    let (brioche, mut context) = brioche_test::brioche_test().await;
+
+    let foo_hash = context
+        .remote_registry_project(|path| async move {
+            tokio::fs::write(
+                path.join("project.bri"),
+                r#"
+                    export const project = {};
+                "#,
+            )
+            .await
+            .unwrap();
+        })
+        .await;
+    let mock_foo_latest = context
+        .mock_registry_publish_tag("foo", "latest", foo_hash)
+        .create_async()
+        .await;
+
+    let project_dir = context.mkdir("myproject").await;
+    context
+        .write_file(
+            "myproject/project.bri",
+            r#"
+                export const project = {
+                    dependencies: {
+                        foo: "*",
+                    },
+                };
+            "#,
+        )
+        .await;
+
+    let (projects, project_hash) = brioche_test::load_project(&brioche, &project_dir).await?;
+    let project = projects.project(project_hash).unwrap();
+    assert!(projects
+        .local_paths(project_hash)
+        .unwrap()
+        .contains(&project_dir));
+
+    let foo_dep_hash = project.dependencies["foo"];
+    let foo_dep = projects.project(foo_dep_hash).unwrap();
+    let foo_path = brioche.home.join("projects").join(foo_dep_hash.to_string());
+    assert!(projects
+        .local_paths(foo_dep_hash)
+        .unwrap()
+        .contains(&foo_path));
+    assert!(foo_dep.dependencies.is_empty());
+
+    mock_foo_latest.assert_async().await;
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_project_load_complex() -> anyhow::Result<()> {
     let (brioche, context) = brioche_test::brioche_test().await;
 

--- a/crates/brioche/tests/project_load.rs
+++ b/crates/brioche/tests/project_load.rs
@@ -29,53 +29,8 @@ async fn test_project_load_simple() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
-async fn test_project_load_with_repo_dep() -> anyhow::Result<()> {
-    let (brioche, context) = brioche_test::brioche_test().await;
-
-    let project_dir = context.mkdir("myproject").await;
-    context
-        .write_file(
-            "myproject/project.bri",
-            r#"
-                export const project = {
-                    dependencies: {
-                        foo: "*",
-                    },
-                };
-            "#,
-        )
-        .await;
-
-    context
-        .write_file(
-            "brioche-repo/foo/project.bri",
-            r#"
-                export const project = {};
-            "#,
-        )
-        .await;
-
-    let (projects, project_hash) = brioche_test::load_project(&brioche, &project_dir).await?;
-    let project = projects.project(project_hash).unwrap();
-    assert!(projects
-        .local_paths(project_hash)
-        .unwrap()
-        .contains(&project_dir));
-
-    let foo_dep_hash = project.dependencies["foo"];
-    let foo_dep = projects.project(foo_dep_hash).unwrap();
-    assert!(projects
-        .local_paths(foo_dep_hash)
-        .unwrap()
-        .contains(&brioche.repo_dir.join("foo")));
-    assert!(foo_dep.dependencies.is_empty());
-
-    Ok(())
-}
-
-#[tokio::test]
 async fn test_project_load_with_workspace_dep() -> anyhow::Result<()> {
-    let (brioche, context) = brioche_test::brioche_test().await;
+    let (brioche, mut context) = brioche_test::brioche_test().await;
 
     context
         .write_toml(
@@ -96,15 +51,22 @@ async fn test_project_load_with_workspace_dep() -> anyhow::Result<()> {
         )
         .await;
 
-    let repo_foo_dir = context.mkdir("brioche-repo/foo").await;
+    let (registry_foo_hash, registry_foo_dir) = context
+        .local_registry_project(|path| async move {
+            tokio::fs::write(
+                path.join("project.bri"),
+                r#"
+                    // registry foo
+                    export const project = {};
+                "#,
+            )
+            .await
+            .unwrap();
+        })
+        .await;
     context
-        .write_file(
-            "brioche-repo/foo/project.bri",
-            r#"
-                // repo foo
-                export const project = {};
-            "#,
-        )
+        .mock_registry_publish_tag("foo", "latest", registry_foo_hash)
+        .create_async()
         .await;
 
     let project_dir = context.mkdir("myworkspace/myproject").await;
@@ -139,7 +101,7 @@ async fn test_project_load_with_workspace_dep() -> anyhow::Result<()> {
     assert!(!projects
         .local_paths(foo_dep_hash)
         .unwrap()
-        .contains(&repo_foo_dir));
+        .contains(&registry_foo_dir));
     assert!(foo_dep.dependencies.is_empty());
 
     Ok(())
@@ -306,7 +268,7 @@ async fn test_project_load_with_remote_registry_dep() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn test_project_load_complex() -> anyhow::Result<()> {
-    let (brioche, context) = brioche_test::brioche_test().await;
+    let (brioche, mut context) = brioche_test::brioche_test().await;
 
     let main_project_dir = context.mkdir("mainproject").await;
     context
@@ -339,26 +301,42 @@ async fn test_project_load_complex() -> anyhow::Result<()> {
         )
         .await;
 
+    let (bar_hash, bar_path) = context
+        .local_registry_project(|path| async move {
+            tokio::fs::write(
+                path.join("project.bri"),
+                r#"
+                        export const project = {};
+                    "#,
+            )
+            .await
+            .unwrap();
+        })
+        .await;
     context
-        .write_file(
-            "brioche-repo/foo/project.bri",
-            r#"
+        .mock_registry_publish_tag("bar", "latest", bar_hash)
+        .create_async()
+        .await;
+
+    let (foo_hash, foo_path) = context
+        .local_registry_project(|path| async move {
+            tokio::fs::write(
+                path.join("project.bri"),
+                r#"
                 export const project = {
                     dependencies: {
                         bar: "*",
                     },
                 };
             "#,
-        )
+            )
+            .await
+            .unwrap();
+        })
         .await;
-
     context
-        .write_file(
-            "brioche-repo/bar/project.bri",
-            r#"
-                export const project = {};
-            "#,
-        )
+        .mock_registry_publish_tag("foo", "latest", foo_hash)
+        .create_async()
         .await;
 
     let (projects, project_hash) = brioche_test::load_project(&brioche, &main_project_dir).await?;
@@ -384,19 +362,19 @@ async fn test_project_load_complex() -> anyhow::Result<()> {
     assert!(projects
         .local_paths(main_foo_project_hash)
         .unwrap()
-        .contains(&brioche.repo_dir.join("foo")));
+        .contains(&foo_path));
     assert!(projects
         .local_paths(main_dep_foo_project_hash)
         .unwrap()
-        .contains(&brioche.repo_dir.join("foo")));
+        .contains(&foo_path));
     assert!(projects
         .local_paths(main_foo_bar_project_hash)
         .unwrap()
-        .contains(&brioche.repo_dir.join("bar")));
+        .contains(&bar_path));
     assert!(projects
         .local_paths(main_dep_foo_bar_project_hash)
         .unwrap()
-        .contains(&brioche.repo_dir.join("bar")));
+        .contains(&bar_path));
 
     assert_eq!(main_foo_project_hash, main_dep_foo_project_hash);
     assert_eq!(main_foo_bar_project_hash, main_dep_foo_bar_project_hash);
@@ -453,7 +431,7 @@ async fn test_project_load_path_dep_not_found() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
-async fn test_project_load_repo_dep_not_found() -> anyhow::Result<()> {
+async fn test_project_load_dep_not_found() -> anyhow::Result<()> {
     let (brioche, context) = brioche_test::brioche_test().await;
 
     let project_dir = context.mkdir("myproject").await;
@@ -469,9 +447,6 @@ async fn test_project_load_repo_dep_not_found() -> anyhow::Result<()> {
             "#,
         )
         .await;
-
-    // project.bri does not exist
-    let _repo_foo_dir = context.mkdir("brioche-repo/foo").await;
 
     let result = brioche_test::load_project(&brioche, &project_dir)
         .await

--- a/crates/brioche/tests/registry_client.rs
+++ b/crates/brioche/tests/registry_client.rs
@@ -1,0 +1,116 @@
+use assert_matches::assert_matches;
+
+mod brioche_test;
+
+#[tokio::test]
+async fn test_registry_client_get_project() -> anyhow::Result<()> {
+    let (brioche, mut context) = brioche_test::brioche_test().await;
+
+    let (projects, project_hash, _) = context
+        .temp_project(|path| async move {
+            tokio::fs::write(
+                path.join("project.bri"),
+                r#"
+                    export const project = {};
+                "#,
+            )
+            .await
+            .unwrap();
+        })
+        .await;
+    let project = projects.project(project_hash).unwrap();
+
+    let mock = context
+        .registry_server
+        .mock("GET", &*format!("/projects/{project_hash}"))
+        .with_header("Content-Type", "application/json")
+        .with_body(serde_json::to_string(&project).unwrap())
+        .create();
+
+    let registry_project = brioche.registry_client.get_project(project_hash).await?;
+    assert_eq!(registry_project, *project);
+
+    mock.assert_async().await;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_registry_client_get_project_invalid_hash() -> anyhow::Result<()> {
+    let (brioche, mut context) = brioche_test::brioche_test().await;
+
+    let (projects, project_hash, _) = context
+        .temp_project(|path| async move {
+            tokio::fs::write(
+                path.join("project.bri"),
+                r#"
+                    export const project = {};
+                "#,
+            )
+            .await
+            .unwrap();
+        })
+        .await;
+    let project = projects.project(project_hash).unwrap();
+
+    let mut changed_project = (*project).clone();
+    changed_project.definition.name = Some("evil".to_string());
+
+    let mock = context
+        .registry_server
+        .mock("GET", &*format!("/projects/{project_hash}"))
+        .with_header("Content-Type", "application/json")
+        .with_body(serde_json::to_string(&changed_project).unwrap())
+        .create();
+
+    let result = brioche.registry_client.get_project(project_hash).await;
+    assert_matches!(result, Err(_));
+
+    mock.assert_async().await;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_registry_client_get_blob() -> anyhow::Result<()> {
+    let (brioche, mut context) = brioche_test::brioche_test().await;
+
+    let path = context.write_file("test.txt", "hello world!").await;
+    let (file_id, contents) = brioche.vfs.load(&path).await?;
+
+    let mock = context
+        .registry_server
+        .mock("GET", &*format!("/blobs/{file_id}"))
+        .with_header("Content-Type", "application/octet-stream")
+        .with_body(&*contents)
+        .create();
+
+    let registry_contents = brioche.registry_client.get_blob(file_id).await?;
+    assert_eq!(registry_contents, *contents);
+
+    mock.assert_async().await;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_registry_client_get_blob_invalid_hash() -> anyhow::Result<()> {
+    let (brioche, mut context) = brioche_test::brioche_test().await;
+
+    let path = context.write_file("test.txt", "hello world!").await;
+    let (file_id, _) = brioche.vfs.load(&path).await?;
+
+    let mock = context
+        .registry_server
+        .mock("GET", &*format!("/blobs/{file_id}"))
+        .with_header("Content-Type", "application/octet-stream")
+        .with_body("evil")
+        .create();
+
+    let result = brioche.registry_client.get_blob(file_id).await;
+    assert_matches!(result, Err(_));
+
+    mock.assert_async().await;
+
+    Ok(())
+}


### PR DESCRIPTION
This PR adds initial support for resolving projects from a registry. When a Brioche project includes a dependency like this:

```ts
export const project = {
  dependencies: {
    std: "*",
  },
};
```

...we now fetch the project named `std` (and tagged `latest`) from the registry API. The registry API can be configured with the key `registry_url` in `~/.config/brioche/config.toml`, which should point to a hosted instance of [brioche-registry](https://github.com/brioche-dev/brioche-registry) (the default value is currently `http://localhost:2000`-- the default development port-- since there isn't a publicly hosted instance yet).

There isn't a command to upload to the registry at the moment, so projects can be published like this:

```bash
brioche export-project -p ./projects/std \
| curl -X POST 'http://localhost:2000/projects' --user admin:password -H 'Content-
Type: application/json' -d @-
```

The Language Server has been configured to completely avoid loading from the registry-- it'd be bad if every keystroke tried to re-request a non-existent package! For now though, this means that projects with registry dependencies won't work properly  when using the LSP.

---

Previously, in the `config.toml` file, Brioche used a special `repo_dir` as a quick-and-dirty way to support "global" packages. This option has been completely removed in favor of the registry.