### PR TITLE
Implement lockfiles

### DIFF
--- a/crates/brioche/src/main.rs
+++ b/crates/brioche/src/main.rs
@@ -122,6 +122,11 @@ async fn build(args: BuildArgs) -> anyhow::Result<ExitCode> {
     let build_future = async {
         let project_hash = projects.load(&brioche, &args.project).await?;
 
+        let num_lockfiles_updated = projects.commit_dirty_lockfiles().await?;
+        if num_lockfiles_updated > 0 {
+            tracing::info!(num_lockfiles_updated, "updated lockfiles");
+        }
+
         if args.check {
             let checked = brioche::script::check::check(&brioche, &projects, project_hash).await?;
 
@@ -213,6 +218,12 @@ async fn check(args: CheckArgs) -> anyhow::Result<ExitCode> {
 
     let check_future = async {
         let project_hash = projects.load(&brioche, &args.project).await?;
+
+        let num_lockfiles_updated = projects.commit_dirty_lockfiles().await?;
+        if num_lockfiles_updated > 0 {
+            tracing::info!(num_lockfiles_updated, "updated lockfiles");
+        }
+
         let checked = brioche::script::check::check(&brioche, &projects, project_hash).await?;
 
         guard.shutdown_console().await;

--- a/crates/brioche/src/main.rs
+++ b/crates/brioche/src/main.rs
@@ -120,7 +120,7 @@ async fn build(args: BuildArgs) -> anyhow::Result<ExitCode> {
     let projects = brioche::project::Projects::default();
 
     let build_future = async {
-        let project_hash = projects.load(&brioche, &args.project).await?;
+        let project_hash = projects.load(&brioche, &args.project, true).await?;
 
         let num_lockfiles_updated = projects.commit_dirty_lockfiles().await?;
         if num_lockfiles_updated > 0 {
@@ -217,7 +217,7 @@ async fn check(args: CheckArgs) -> anyhow::Result<ExitCode> {
     let projects = brioche::project::Projects::default();
 
     let check_future = async {
-        let project_hash = projects.load(&brioche, &args.project).await?;
+        let project_hash = projects.load(&brioche, &args.project, true).await?;
 
         let num_lockfiles_updated = projects.commit_dirty_lockfiles().await?;
         if num_lockfiles_updated > 0 {
@@ -264,7 +264,7 @@ async fn format(args: FormatArgs) -> anyhow::Result<ExitCode> {
     let projects = brioche::project::Projects::default();
 
     let format_future = async {
-        let project_hash = projects.load(&brioche, &args.project).await?;
+        let project_hash = projects.load(&brioche, &args.project, true).await?;
 
         if args.check {
             let mut unformatted_files =
@@ -364,7 +364,7 @@ async fn export_project(args: ExportProjectArgs) -> anyhow::Result<()> {
 
     let brioche = brioche::BriocheBuilder::new(reporter).build().await?;
     let projects = brioche::project::Projects::default();
-    let project_hash = projects.load(&brioche, &args.project).await?;
+    let project_hash = projects.load(&brioche, &args.project, true).await?;
     let project_listing = projects
         .export_listing(&brioche, project_hash)
         .context("failed to export listing")?;

--- a/crates/brioche/src/project.rs
+++ b/crates/brioche/src/project.rs
@@ -580,7 +580,6 @@ async fn load_project_inner(
                                 resolved_dep.local_path.display()
                             ),
                         });
-                        continue;
                     }
                 }
 

--- a/crates/brioche/src/project.rs
+++ b/crates/brioche/src/project.rs
@@ -164,7 +164,7 @@ impl Projects {
         Ok(())
     }
 
-    pub async fn commit_dirty_lockfiles(&self) -> anyhow::Result<()> {
+    pub async fn commit_dirty_lockfiles(&self) -> anyhow::Result<usize> {
         let dirty_lockfiles = {
             let projects = self
                 .inner
@@ -185,9 +185,10 @@ impl Projects {
             .inner
             .write()
             .map_err(|_| anyhow::anyhow!("failed to acquire 'projects' lock"))?;
+        let num_lockfiles = projects.dirty_lockfiles.len();
         projects.dirty_lockfiles.clear();
 
-        Ok(())
+        Ok(num_lockfiles)
     }
 
     pub async fn commit_dirty_lockfile_for_project_path(

--- a/crates/brioche/src/project.rs
+++ b/crates/brioche/src/project.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{BTreeSet, HashMap, HashSet},
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     path::{Path, PathBuf},
     sync::Arc,
 };
@@ -1121,7 +1121,7 @@ impl<'de> serde::Deserialize<'de> for ProjectListing {
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct Lockfile {
-    pub dependencies: HashMap<String, ProjectHash>,
+    pub dependencies: BTreeMap<String, ProjectHash>,
 }
 
 #[serde_with::serde_as]

--- a/crates/brioche/src/project.rs
+++ b/crates/brioche/src/project.rs
@@ -613,6 +613,10 @@ async fn load_project_inner(
     let project = Arc::new(project);
     let project_hash = ProjectHash::from_serializable(&project)?;
 
+    if !errors.is_empty() {
+        tracing::debug!(?path, ?errors, "project loaded with errors");
+    }
+
     {
         let mut projects = projects
             .inner

--- a/crates/brioche/src/project.rs
+++ b/crates/brioche/src/project.rs
@@ -174,8 +174,10 @@ impl Projects {
         };
 
         for (path, lockfile) in dirty_lockfiles {
-            let lockfile_contents = serde_json::to_string_pretty(&lockfile)
+            let mut lockfile_contents = serde_json::to_string_pretty(&lockfile)
                 .with_context(|| format!("failed to serialize lockfile at {}", path.display()))?;
+            lockfile_contents.push('\n');
+
             tokio::fs::write(&path, lockfile_contents)
                 .await
                 .context("failed to write lockfile")?;
@@ -209,13 +211,15 @@ impl Projects {
             return Ok(false);
         };
 
-        let lockfile_contents =
+        let mut lockfile_contents =
             serde_json::to_string_pretty(&dirty_lockfile).with_context(|| {
                 format!(
                     "failed to serialize lockfile at {}",
                     lockfile_path.display()
                 )
             })?;
+        lockfile_contents.push('\n');
+
         tokio::fs::write(&lockfile_path, lockfile_contents)
             .await
             .context("failed to write lockfile")?;

--- a/crates/brioche/src/reporter.rs
+++ b/crates/brioche/src/reporter.rs
@@ -407,6 +407,25 @@ pub fn start_lsp_reporter(client: tower_lsp::Client) -> (Reporter, ReporterGuard
     (reporter, guard)
 }
 
+pub fn start_null_reporter() -> (Reporter, ReporterGuard) {
+    let (tx, _) = tokio::sync::mpsc::unbounded_channel();
+    let (_, shutdown_rx) = tokio::sync::oneshot::channel();
+
+    let reporter = Reporter {
+        start: std::time::Instant::now(),
+        num_jobs: Arc::new(AtomicUsize::new(0)),
+        is_evaluating: Arc::new(AtomicBool::new(false)),
+        tx: tx.clone(),
+    };
+    let guard = ReporterGuard {
+        tx,
+        shutdown_rx: Some(shutdown_rx),
+        shutdown_opentelemetry: false,
+    };
+
+    (reporter, guard)
+}
+
 #[cfg_attr(not(test), allow(unused))]
 pub fn start_test_reporter() -> (Reporter, ReporterGuard) {
     let (tx, _) = tokio::sync::mpsc::unbounded_channel();

--- a/crates/brioche/src/script/compiler_host.rs
+++ b/crates/brioche/src/script/compiler_host.rs
@@ -206,6 +206,38 @@ impl BriocheCompilerHost {
         let result = f(document);
         Ok(Some(result))
     }
+
+    pub async fn reload_module_project(&self, uri: &url::Url) -> anyhow::Result<()> {
+        let specifier: BriocheModuleSpecifier = uri.try_into()?;
+
+        match &specifier {
+            BriocheModuleSpecifier::File { path } => {
+                let project = self
+                    .projects
+                    .find_containing_project(path)
+                    .with_context(|| format!("no project found for path '{}'", path.display()))?;
+
+                if let Some(project) = project {
+                    self.projects.clear(project).await?;
+                }
+
+                self.projects
+                    .load_from_module_path(&self.brioche, path, false)
+                    .await?;
+
+                let mut documents = self
+                    .documents
+                    .write()
+                    .map_err(|_| anyhow::anyhow!("failed to acquire lock on documents"))?;
+                documents.entry(specifier.clone()).and_modify(|doc| {
+                    doc.version += 1;
+                });
+            }
+            BriocheModuleSpecifier::Runtime { .. } => {}
+        }
+
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/crates/brioche/src/script/compiler_host.rs
+++ b/crates/brioche/src/script/compiler_host.rs
@@ -64,7 +64,7 @@ impl BriocheCompilerHost {
             match &specifier {
                 BriocheModuleSpecifier::File { path } => {
                     self.projects
-                        .load_from_module_path(&self.brioche, path)
+                        .load_from_module_path(&self.brioche, path, false)
                         .await
                         .inspect_err(|err| {
                             tracing::warn!("failed to load project from module path: {err:#}");

--- a/crates/brioche/src/script/lsp.rs
+++ b/crates/brioche/src/script/lsp.rs
@@ -133,6 +133,20 @@ impl LanguageServer for BriocheLspServer {
 
     async fn did_save(&self, params: DidSaveTextDocumentParams) {
         tracing::info!(uri = %params.text_document.uri, "did open");
+
+        // Try to reload the project for the current document so we can
+        // resolve new dependencies
+        let reload_result = self
+            .compiler_host
+            .reload_module_project(&params.text_document.uri)
+            .await;
+        match reload_result {
+            Ok(()) => {}
+            Err(error) => {
+                tracing::warn!("failed to reload module project: {error:#}");
+            }
+        }
+
         let diagnostics = self
             .diagnostics(TextDocumentIdentifier {
                 uri: params.text_document.uri.clone(),

--- a/crates/brioche/src/script/specifier.rs
+++ b/crates/brioche/src/script/specifier.rs
@@ -342,12 +342,12 @@ pub fn resolve(
                 BriocheImportSpecifier::External(dep) => {
                     let project = projects.project(project_hash)?;
                     let dependency_project_hash =
-                        project.dependencies.get(dep).with_context(|| {
+                        project.dependency_hash(dep).with_context(|| {
                             format!("dependency '{specifier}' not found (imported from {referrer})")
                         })?;
 
                     let dependency_root_module_specifier =
-                        projects.project_root_module_specifier(*dependency_project_hash)?;
+                        projects.project_root_module_specifier(dependency_project_hash)?;
                     Ok(dependency_root_module_specifier)
                 }
             }

--- a/crates/brioche/tests/brioche_test/mod.rs
+++ b/crates/brioche/tests/brioche_test/mod.rs
@@ -261,6 +261,7 @@ impl TestContext {
             .load(&self.brioche, &temp_project_path)
             .await
             .expect("failed to load temp project");
+        projects.commit_dirty_lockfiles().await.unwrap();
 
         (projects, project_hash, temp_project_path)
     }

--- a/crates/brioche/tests/brioche_test/mod.rs
+++ b/crates/brioche/tests/brioche_test/mod.rs
@@ -54,7 +54,7 @@ pub async fn load_project(
     path: &Path,
 ) -> anyhow::Result<(Projects, ProjectHash)> {
     let projects = Projects::default();
-    let project_hash = projects.load(brioche, path).await?;
+    let project_hash = projects.load(brioche, path, true).await?;
 
     Ok((projects, project_hash))
 }
@@ -258,7 +258,7 @@ impl TestContext {
 
         let projects = Projects::default();
         let project_hash = projects
-            .load(&self.brioche, &temp_project_path)
+            .load(&self.brioche, &temp_project_path, true)
             .await
             .expect("failed to load temp project");
         projects.commit_dirty_lockfiles().await.unwrap();


### PR DESCRIPTION
This PR builds on #18 with an initial implementation of lockfiles.

Every time a dependency is loaded from the registry, we record its hash in a special JSON file called `brioche.lock`. Then, next time the project is loaded, we first try to resolve the dependency first using the hash from `brioche.lock`, and only change it if that fails.

This also resolves the limitation introduced in #18 where the LSP couldn't load registry dependencies (since the registry is disabled in the LSP). Now, the LSP will use the dependencies as specified in the lockfile, which will work as long as the lockfile is up-to-date and all the dependencies have been cached under the `~/.local/share/brioche/projects` directory. I found it annoying to deal with the LSP when adding/removing dependencies, so **I also made it so saving a file causes the LSP to temporarily use the registry to update the lockfile if needed** (in practice, this feels similar to Rust Analyzer's behavior, but I'm not sure exactly how they do it).

There was also a subtle change to the `Project` structure: what used to be called `dependencies` has been split into the fields `lockfile` (containing the lockfile, including all registry dependency hashes) and `internalDependencies` (containing all workspace or path dependency hashes). Doing it this way both made for a nice normalized representation while also making it really easy to recreate the lockfile when resolving a project from the registry.

---

I'm not super happy with the LSP implementation in this PR. Dealing with the split of mutable/immutable VFS causes problems around project hashes in the lockfile, and that led to me adding some weird logic to allow loading partially-invalid projects but only for the LSP. It's weird and I feel like there are probably some scary edge cases in the LSP I haven't spotted yet.