### PR TITLE
Improve syncing consistency with retries and partial syncing

### DIFF
--- a/crates/brioche/src/lib.rs
+++ b/crates/brioche/src/lib.rs
@@ -179,8 +179,12 @@ impl BriocheBuilder {
 
         tracing::debug!("finished running database migrations");
 
-        let download_retry_policy =
-            reqwest_retry::policies::ExponentialBackoff::builder().build_with_max_retries(5);
+        let download_retry_policy = reqwest_retry::policies::ExponentialBackoff::builder()
+            .retry_bounds(
+                std::time::Duration::from_secs(1),
+                std::time::Duration::from_secs(30),
+            )
+            .build_with_max_retries(5);
         let download_retry_middleware =
             reqwest_retry::RetryTransientMiddleware::new_with_policy(download_retry_policy);
         let download_client = reqwest_middleware::ClientBuilder::new(reqwest::Client::new())


### PR DESCRIPTION
This PR implements a few minor changes to the syncing process to (hopefully) make it less painful to have large, long-running builds e.g. in CI/CD pipelines:

- Use [`reqwest-retry`](https://crates.io/crates/reqwest-retry) to automatically retry requests for all registry endpoints
- Tweak `reqwest-retry` settings for download recipes
- Update `--sync` to spawn a task to start syncing recipes mid-build. This makes it so, even if a build fails, hopefully at least some bakes should be synced to the registry. This would make a second run of the build hopefully able to pull already-cached versions of the parts of the build that succeeded.