### PR TITLE
Pin Rust toolchain to 1.77

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "stable"
+channel = "1.77"
 profile = "default"
 targets = ["x86_64-unknown-linux-musl"]


### PR DESCRIPTION
This PR updates the `rust-toolchain.toml` file to lock the Rust toolchain to v1.77.x, the last version that was passing on `main`. Due to some unsoundness on the version of `deno_core` we're currently using, the upgrade to 1.78.0 broke the build. Pinning to v1.77 is a temporary fix until we update `deno_core` (which has already fixed the unsoundness upstream).