### PR TITLE
Ensure Brioche can minimally run on platforms other than x86-64 Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,11 +166,6 @@ jobs:
         with:
           name: brioche-x86_64-linux
           path: artifacts/brioche
-      - name: Download artifacts (aarch64-linux)
-        uses: actions/download-artifact@v4
-        with:
-          name: brioche-aarch64-linux
-          path: artifacts/brioche
       - name: Download artifacts (x86_64-macos)
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,14 @@ jobs:
             runs_on: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
             tools_target: x86_64-unknown-linux-musl
+          - name: x86_64-macos
+            runs_on: macos-14
+            target: x86_64-apple-darwin
+            tools_target: x86_64-apple-darwin
+          - name: aarch64-macos
+            runs_on: macos-14
+            target: aarch64-apple-darwin
+            tools_target: aarch64-apple-darwin
 
     runs-on: ${{ matrix.platform.runs_on }}
     steps:
@@ -148,6 +156,21 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: brioche-x86_64-linux
+          path: artifacts/brioche
+      - name: Download artifacts (aarch64-linux)
+        uses: actions/download-artifact@v4
+        with:
+          name: brioche-aarch64-linux
+          path: artifacts/brioche
+      - name: Download artifacts (x86_64-macos)
+        uses: actions/download-artifact@v4
+        with:
+          name: brioche-x86_64-macos
+          path: artifacts/brioche
+      - name: Download artifacts (aarch64-macos)
+        uses: actions/download-artifact@v4
+        with:
+          name: brioche-aarch64-macos
           path: artifacts/brioche
       # Prepare the upload for the current commit and branch:
       # - The current branch will be uploaded with all artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,12 @@ jobs:
           fi
   test:
     name: Run tests
-    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        runs_on:
+          - ubuntu-22.04
+          - macos-14
+    runs-on: ${{ matrix.runs_on }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,8 +139,12 @@ jobs:
             "target/$TOOLS_TARGET/release-tiny/brioche-packed-userland-exec" \
             "artifacts/brioche-pack/$PLATFORM/"
           (cd "artifacts/brioche-pack/$PLATFORM/" && tar --zstd -cf "../../brioche/$PLATFORM/brioche-pack.tar.zstd" .)
-          tree --du -h artifacts/brioche-pack
-          tree --du -h artifacts/brioche
+
+
+          if command -v tree &> /dev/null; then
+            tree --du -h artifacts/brioche-pack
+            tree --du -h artifacts/brioche
+          fi
         env:
           TARGET: ${{ matrix.platform.target }}
           TOOLS_TARGET: ${{ matrix.platform.tools_target }}
@@ -192,6 +196,11 @@ jobs:
           cp -r artifacts/brioche/* artifacts/uploads/branch/
 
           rm artifacts/uploads/commit/*/brioche
+
+          if command -v tree &> /dev/null; then
+            tree --du -h artifacts/uploads/commit
+            tree --du -h artifacts/uploads/branch
+          fi
 
           aws s3 sync \
             --endpoint "$S3_ENDPOINT" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,22 +60,39 @@ jobs:
         run: cargo test --all --release
   build:
     name: Build artifacts
-    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        platform:
+          - name: x86_64-linux
+            runs_on: ubuntu-22.04
+            target: x86_64-unknown-linux-gnu
+            tools_target: x86_64-unknown-linux-musl
+
+    runs-on: ${{ matrix.platform.runs_on }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      - name: Install Rust targets
+        run: rustup target add "$TARGET" "$TOOLS_TARGET"
+        env:
+          TARGET: ${{ matrix.platform.target }}
+          TOOLS_TARGET: ${{ matrix.platform.tools_target }}
       - name: Install Rust nightly toolchain
         run: |
           rustup toolchain install "$NIGHTLY_TOOLCHAIN" \
-            --target x86_64-unknown-linux-musl \
+            --target "$TOOLS_TARGET" \
             --component rust-src
+        env:
+          TOOLS_TARGET: ${{ matrix.platform.tools_target }}
       - name: Build Brioche
         run: |
             cargo build \
               --all \
               --bin brioche \
               --release \
-              --target=x86_64-unknown-linux-gnu
+              --target="$TARGET"
+        env:
+          TARGET: ${{ matrix.platform.target }}
       - name: Build brioche-pack tools
         run: |
           cargo build \
@@ -83,36 +100,42 @@ jobs:
             --bin brioche-packer \
             --bin brioche-ld \
             --release \
-            --target=x86_64-unknown-linux-musl
+            --target="$TOOLS_TARGET"
 
           cargo +"$NIGHTLY_TOOLCHAIN" build \
             --all \
             --bin brioche-packed-exec \
             --bin brioche-packed-userland-exec \
             --profile=release-tiny \
-            --target=x86_64-unknown-linux-musl \
+            --target="$TOOLS_TARGET" \
             -Z 'build-std=std,panic_abort' \
             -Z 'build-std-features=panic_immediate_abort'
+        env:
+          TOOLS_TARGET: ${{ matrix.platform.tools_target }}
       - name: Prepare artifact
         run: |
-          mkdir -p artifacts/brioche/x86_64-linux/
-          mkdir -p artifacts/brioche-pack/x86_64-linux/
+          mkdir -p "artifacts/brioche/$PLATFORM/"
+          mkdir -p "artifacts/brioche-pack/$PLATFORM/"
           cp \
-            target/x86_64-unknown-linux-gnu/release/brioche \
-            artifacts/brioche/x86_64-linux/
+            "target/$TARGET/release/brioche" \
+            "artifacts/brioche/$PLATFORM/"
           cp \
-            target/x86_64-unknown-linux-musl/release/brioche-packer \
-            target/x86_64-unknown-linux-musl/release/brioche-ld \
-            target/x86_64-unknown-linux-musl/release-tiny/brioche-packed-exec \
-            target/x86_64-unknown-linux-musl/release-tiny/brioche-packed-userland-exec \
-            artifacts/brioche-pack/x86_64-linux/
-          (cd artifacts/brioche-pack/x86_64-linux/ && tar --zstd -cf ../../brioche/x86_64-linux/brioche-pack.tar.zstd .)
+            "target/$TOOLS_TARGET/release/brioche-packer" \
+            "target/$TOOLS_TARGET/release/brioche-ld" \
+            "target/$TOOLS_TARGET/release-tiny/brioche-packed-exec" \
+            "target/$TOOLS_TARGET/release-tiny/brioche-packed-userland-exec" \
+            "artifacts/brioche-pack/$PLATFORM/"
+          (cd "artifacts/brioche-pack/$PLATFORM/" && tar --zstd -cf "../../brioche/$PLATFORM/brioche-pack.tar.zstd" .)
           tree --du -h artifacts/brioche-pack
           tree --du -h artifacts/brioche
+        env:
+          TARGET: ${{ matrix.platform.target }}
+          TOOLS_TARGET: ${{ matrix.platform.tools_target }}
+          PLATFORM: ${{ matrix.platform.name }}
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: brioche
+          name: brioche-${{ matrix.platform.name }}
           if-no-files-found: error
           path: artifacts/brioche
   push:
@@ -121,10 +144,10 @@ jobs:
     needs: [check, test, build]
     runs-on: ubuntu-22.04
     steps:
-      - name: Download artifacts
+      - name: Download artifacts (x86_64-linux)
         uses: actions/download-artifact@v4
         with:
-          name: brioche
+          name: brioche-x86_64-linux
           path: artifacts/brioche
       # Prepare the upload for the current commit and branch:
       # - The current branch will be uploaded with all artifacts

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -845,6 +845,7 @@ dependencies = [
  "bincode 2.0.0-rc.3",
  "brioche-pack",
  "bstr 1.8.0",
+ "cfg-if 1.0.0",
  "libc",
  "thiserror",
  "userland-execve",

--- a/crates/brioche-packed-userland-exec/Cargo.toml
+++ b/crates/brioche-packed-userland-exec/Cargo.toml
@@ -7,6 +7,9 @@ edition = "2021"
 bincode = "2.0.0-rc.3"
 brioche-pack = { path = "../brioche-pack", default-features = false }
 bstr = "1.8.0"
+cfg-if = "1.0.0"
 libc = "0.2.151"
 thiserror = "1.0.51"
+
+[target.'cfg(target_os = "linux")'.dependencies]
 userland-execve = "0.2.0"

--- a/crates/brioche-packed-userland-exec/src/linux.rs
+++ b/crates/brioche-packed-userland-exec/src/linux.rs
@@ -1,0 +1,177 @@
+#![cfg(target_os = "linux")]
+
+use std::ffi::{CStr, CString};
+
+use bstr::ByteSlice as _;
+
+const BRIOCHE_PACKED_ERROR: u8 = 121;
+
+extern "C" {
+    static environ: *const *const libc::c_char;
+}
+
+#[inline(always)]
+#[allow(clippy::missing_safety_doc)]
+pub unsafe fn entrypoint(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int {
+    let mut args = vec![];
+    let mut env_vars = vec![];
+
+    let argc: usize = argc.try_into().unwrap_or(0);
+    for n in 0..argc {
+        let arg = unsafe { *argv.add(n) };
+
+        if arg.is_null() {
+            break;
+        }
+
+        let arg = unsafe { CStr::from_ptr(arg) };
+        args.push(arg);
+    }
+
+    for n in 0.. {
+        let var = unsafe { *environ.add(n) };
+
+        if var.is_null() {
+            break;
+        }
+
+        let var = unsafe { CStr::from_ptr(var) };
+        env_vars.push(var);
+    }
+
+    let result = run(&args, &env_vars);
+    match result {
+        Ok(()) => libc::EXIT_SUCCESS,
+        Err(err) => {
+            eprintln!("brioche-packed error: {err}");
+            BRIOCHE_PACKED_ERROR.into()
+        }
+    }
+}
+
+fn run(args: &[&CStr], env_vars: &[&CStr]) -> Result<(), PackedError> {
+    let path = std::env::current_exe()?;
+    let resource_dir = brioche_pack::find_resource_dir(&path)?;
+    let mut program = std::fs::File::open(&path)?;
+    let pack = brioche_pack::extract_pack(&mut program)?;
+
+    match pack.interpreter {
+        Some(brioche_pack::Interpreter::LdLinux {
+            path: interpreter,
+            library_paths,
+        }) => {
+            let interpreter = interpreter
+                .to_path()
+                .map_err(|_| PackedError::InvalidPath)?;
+            let interpreter = resource_dir.join(interpreter);
+
+            let program = pack
+                .program
+                .to_path()
+                .map_err(|_| PackedError::InvalidPath)?;
+            let program = resource_dir.join(program).canonicalize()?;
+            let mut exec = userland_execve::ExecOptions::new(&interpreter);
+
+            let interpreter =
+                <[u8]>::from_path(&interpreter).ok_or_else(|| PackedError::InvalidPath)?;
+            let interpreter = CString::new(interpreter).map_err(|_| PackedError::InvalidPath)?;
+
+            // Add argv0
+            exec.arg(interpreter);
+
+            if !library_paths.is_empty() {
+                let mut ld_library_path = bstr::BString::default();
+                for (n, library_path) in library_paths.iter().enumerate() {
+                    let library_path = library_path
+                        .to_path()
+                        .map_err(|_| PackedError::InvalidPath)?;
+                    let library_path = resource_dir.join(library_path);
+
+                    if n > 0 {
+                        ld_library_path.push(b':');
+                    }
+
+                    let path =
+                        <[u8]>::from_path(&library_path).ok_or_else(|| PackedError::InvalidPath)?;
+                    ld_library_path.extend(path);
+                }
+
+                if let Some(env_library_path) = std::env::var_os("LD_LIBRARY_PATH") {
+                    let env_library_path = <[u8]>::from_os_str(&env_library_path)
+                        .ok_or_else(|| PackedError::InvalidPath)?;
+                    if !env_library_path.is_empty() {
+                        ld_library_path.push(b':');
+                        ld_library_path.extend(env_library_path);
+                    }
+                }
+
+                exec.arg(CStr::from_bytes_with_nul(b"--library-path\0").unwrap());
+
+                let ld_library_path =
+                    CString::new(ld_library_path).map_err(|_| PackedError::InvalidPath)?;
+                exec.arg(ld_library_path);
+            }
+
+            let mut args = args.iter();
+            if let Some(arg0) = args.next() {
+                exec.arg(CStr::from_bytes_with_nul(b"--argv0\0").unwrap());
+                exec.arg(arg0);
+            }
+
+            let program = <[u8]>::from_path(&program).ok_or_else(|| PackedError::InvalidPath)?;
+            let program = CString::new(program).map_err(|_| PackedError::InvalidPath)?;
+            exec.arg(program);
+
+            exec.args(args);
+
+            exec.env_pairs(env_vars);
+
+            userland_execve::exec_with_options(exec);
+        }
+        None => {
+            unimplemented!("execution without an interpreter");
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+enum PackedError {
+    IoError(#[from] std::io::Error),
+    ExtractPackError(#[from] brioche_pack::ExtractPackError),
+    PackResourceDirError(#[from] brioche_pack::PackResourceDirError),
+    InvalidPath,
+}
+
+impl std::fmt::Display for PackedError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(error_summary(self))
+    }
+}
+
+fn error_summary(error: &PackedError) -> &'static str {
+    match error {
+        PackedError::IoError(_) => "io error",
+        PackedError::ExtractPackError(error) => match error {
+            brioche_pack::ExtractPackError::ReadPackedProgramError(_) => {
+                "failed to read packed program: io error"
+            }
+            brioche_pack::ExtractPackError::MarkerNotFound => {
+                "marker not found at the end of the packed program"
+            }
+            brioche_pack::ExtractPackError::MalformedMarker => {
+                "malformed marker at the end of the packed program"
+            }
+            brioche_pack::ExtractPackError::InvalidPack(_) => "failed to parse pack: bincode error",
+        },
+        PackedError::PackResourceDirError(error) => match error {
+            brioche_pack::PackResourceDirError::NotFound => "brioche pack resource dir not found",
+            brioche_pack::PackResourceDirError::DepthLimitReached => {
+                "reached depth limit while searching for brioche pack resource dir"
+            }
+            brioche_pack::PackResourceDirError::IoError(_) => {
+                "error while searching for brioche pack resource dir: io error"
+            }
+        },
+        PackedError::InvalidPath => "invalid path",
+    }
+}

--- a/crates/brioche-packed-userland-exec/src/main.rs
+++ b/crates/brioche-packed-userland-exec/src/main.rs
@@ -1,177 +1,18 @@
-#![cfg_attr(not(test), no_main)]
+#![cfg_attr(all(target_os = "linux", not(test)), no_main)]
 
-use std::ffi::{CStr, CString};
+mod linux;
 
-use bstr::ByteSlice as _;
-
-const BRIOCHE_PACKED_ERROR: u8 = 121;
-
-extern "C" {
-    static environ: *const *const libc::c_char;
-}
-
-#[cfg_attr(not(test), no_mangle)]
-#[allow(clippy::missing_safety_doc)]
-pub unsafe extern "C" fn main(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int {
-    let mut args = vec![];
-    let mut env_vars = vec![];
-
-    let argc: usize = argc.try_into().unwrap_or(0);
-    for n in 0..argc {
-        let arg = unsafe { *argv.add(n) };
-
-        if arg.is_null() {
-            break;
+cfg_if::cfg_if! {
+    if #[cfg(target_os = "linux")] {
+        #[cfg_attr(not(test), no_mangle)]
+        #[allow(clippy::missing_safety_doc)]
+        pub unsafe extern "C" fn main(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int {
+            linux::entrypoint(argc, argv)
         }
-
-        let arg = unsafe { CStr::from_ptr(arg) };
-        args.push(arg);
-    }
-
-    for n in 0.. {
-        let var = unsafe { *environ.add(n) };
-
-        if var.is_null() {
-            break;
+    } else {
+        fn main() {
+            eprintln!("brioche-packed-userland-exec is only supported on Linux");
+            std::process::exit(1);
         }
-
-        let var = unsafe { CStr::from_ptr(var) };
-        env_vars.push(var);
-    }
-
-    let result = run(&args, &env_vars);
-    match result {
-        Ok(()) => libc::EXIT_SUCCESS,
-        Err(err) => {
-            eprintln!("brioche-packed error: {err}");
-            BRIOCHE_PACKED_ERROR.into()
-        }
-    }
-}
-
-fn run(args: &[&CStr], env_vars: &[&CStr]) -> Result<(), PackedError> {
-    let path = std::env::current_exe()?;
-    let resource_dir = brioche_pack::find_resource_dir(&path)?;
-    let mut program = std::fs::File::open(&path)?;
-    let pack = brioche_pack::extract_pack(&mut program)?;
-
-    match pack.interpreter {
-        Some(brioche_pack::Interpreter::LdLinux {
-            path: interpreter,
-            library_paths,
-        }) => {
-            let interpreter = interpreter
-                .to_path()
-                .map_err(|_| PackedError::InvalidPath)?;
-            let interpreter = resource_dir.join(interpreter);
-
-            let program = pack
-                .program
-                .to_path()
-                .map_err(|_| PackedError::InvalidPath)?;
-            let program = resource_dir.join(program).canonicalize()?;
-            let mut exec = userland_execve::ExecOptions::new(&interpreter);
-
-            let interpreter =
-                <[u8]>::from_path(&interpreter).ok_or_else(|| PackedError::InvalidPath)?;
-            let interpreter = CString::new(interpreter).map_err(|_| PackedError::InvalidPath)?;
-
-            // Add argv0
-            exec.arg(interpreter);
-
-            if !library_paths.is_empty() {
-                let mut ld_library_path = bstr::BString::default();
-                for (n, library_path) in library_paths.iter().enumerate() {
-                    let library_path = library_path
-                        .to_path()
-                        .map_err(|_| PackedError::InvalidPath)?;
-                    let library_path = resource_dir.join(library_path);
-
-                    if n > 0 {
-                        ld_library_path.push(b':');
-                    }
-
-                    let path =
-                        <[u8]>::from_path(&library_path).ok_or_else(|| PackedError::InvalidPath)?;
-                    ld_library_path.extend(path);
-                }
-
-                if let Some(env_library_path) = std::env::var_os("LD_LIBRARY_PATH") {
-                    let env_library_path = <[u8]>::from_os_str(&env_library_path)
-                        .ok_or_else(|| PackedError::InvalidPath)?;
-                    if !env_library_path.is_empty() {
-                        ld_library_path.push(b':');
-                        ld_library_path.extend(env_library_path);
-                    }
-                }
-
-                exec.arg(CStr::from_bytes_with_nul(b"--library-path\0").unwrap());
-
-                let ld_library_path =
-                    CString::new(ld_library_path).map_err(|_| PackedError::InvalidPath)?;
-                exec.arg(ld_library_path);
-            }
-
-            let mut args = args.iter();
-            if let Some(arg0) = args.next() {
-                exec.arg(CStr::from_bytes_with_nul(b"--argv0\0").unwrap());
-                exec.arg(arg0);
-            }
-
-            let program = <[u8]>::from_path(&program).ok_or_else(|| PackedError::InvalidPath)?;
-            let program = CString::new(program).map_err(|_| PackedError::InvalidPath)?;
-            exec.arg(program);
-
-            exec.args(args);
-
-            exec.env_pairs(env_vars);
-
-            userland_execve::exec_with_options(exec);
-        }
-        None => {
-            unimplemented!("execution without an interpreter");
-        }
-    }
-}
-
-#[derive(Debug, thiserror::Error)]
-enum PackedError {
-    IoError(#[from] std::io::Error),
-    ExtractPackError(#[from] brioche_pack::ExtractPackError),
-    PackResourceDirError(#[from] brioche_pack::PackResourceDirError),
-    InvalidPath,
-}
-
-impl std::fmt::Display for PackedError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(error_summary(self))
-    }
-}
-
-fn error_summary(error: &PackedError) -> &'static str {
-    match error {
-        PackedError::IoError(_) => "io error",
-        PackedError::ExtractPackError(error) => match error {
-            brioche_pack::ExtractPackError::ReadPackedProgramError(_) => {
-                "failed to read packed program: io error"
-            }
-            brioche_pack::ExtractPackError::MarkerNotFound => {
-                "marker not found at the end of the packed program"
-            }
-            brioche_pack::ExtractPackError::MalformedMarker => {
-                "malformed marker at the end of the packed program"
-            }
-            brioche_pack::ExtractPackError::InvalidPack(_) => "failed to parse pack: bincode error",
-        },
-        PackedError::PackResourceDirError(error) => match error {
-            brioche_pack::PackResourceDirError::NotFound => "brioche pack resource dir not found",
-            brioche_pack::PackResourceDirError::DepthLimitReached => {
-                "reached depth limit while searching for brioche pack resource dir"
-            }
-            brioche_pack::PackResourceDirError::IoError(_) => {
-                "error while searching for brioche pack resource dir: io error"
-            }
-        },
-        PackedError::InvalidPath => "invalid path",
     }
 }

--- a/crates/brioche/Cargo.toml
+++ b/crates/brioche/Cargo.toml
@@ -30,7 +30,6 @@ hex = "0.4.3"
 human-repr = "1.1.0"
 joinery = "3.1.0"
 json-canon = "0.1.3"
-libmount = "0.1.15"
 nix = { version = "0.27.1", features = ["user"] }
 opentelemetry = "0.21.0"
 opentelemetry-http = { version = "0.10.0", features = ["reqwest"] }
@@ -63,7 +62,6 @@ tracing = "0.1.40"
 tracing-opentelemetry = "0.22.0"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json", "tracing-log"] }
 ulid = "1.1.0"
-unshare = { git = "https://github.com/brioche-dev/unshare.git" }
 url = { version = "2.5.0", features = ["serde"] }
 urlencoding = "2.1.3"
 
@@ -74,6 +72,10 @@ mockito = "1.2.0"
 pretty_assertions = "1.4.0"
 tempdir = "0.3.7"
 zstd = "0.13.1"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+libmount = "0.1.15"
+unshare = { git = "https://github.com/brioche-dev/unshare.git" }
 
 [[bench]]
 name = "resolve"

--- a/crates/brioche/src/input.rs
+++ b/crates/brioche/src/input.rs
@@ -107,7 +107,16 @@ pub async fn create_input_inner(
                                     continue;
                                 }
                             };
-                            let target = match target.strip_prefix(resources_dir) {
+                            let canonical_resources_dir =
+                                tokio::fs::canonicalize(&resources_dir).await;
+                            let canonical_resources_dir = match canonical_resources_dir {
+                                Ok(target) => target,
+                                Err(err) => {
+                                    tracing::warn!(resources_dir = %resources_dir.display(), "failed to canonicalize resources dir: {err}");
+                                    continue;
+                                }
+                            };
+                            let target = match target.strip_prefix(&canonical_resources_dir) {
                                 Ok(target) => target,
                                 Err(err) => {
                                     tracing::warn!(resource = %resource_path.display(), "resource symlink target not under resources dir: {err}");

--- a/crates/brioche/src/platform.rs
+++ b/crates/brioche/src/platform.rs
@@ -15,12 +15,10 @@ pub enum Platform {
     X86_64Linux,
 }
 
-cfg_if::cfg_if! {
-    if #[cfg(all(target_os = "linux", target_arch = "x86_64"))] {
-        pub fn current_platform() -> Platform {
-            Platform::X86_64Linux
-        }
+pub fn current_platform() -> Platform {
+    if cfg!(all(target_os = "linux", target_arch = "x86_64")) {
+        Platform::X86_64Linux
     } else {
-        compile_error!("unsupported platform");
+        unimplemented!("unsupported platform");
     }
 }

--- a/crates/brioche/src/sandbox.rs
+++ b/crates/brioche/src/sandbox.rs
@@ -1,8 +1,8 @@
-use std::{collections::HashMap, ffi::OsString, path::PathBuf};
-
-use bstr::ByteSlice as _;
+use std::{collections::HashMap, path::PathBuf};
 
 use crate::encoding::{AsPath, TickEncoded};
+
+mod linux;
 
 #[serde_with::serde_as]
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
@@ -65,173 +65,31 @@ pub enum HostPathMode {
     ReadWriteCreate,
 }
 
-pub fn run_sandbox(exec: SandboxExecutionConfig) -> anyhow::Result<unshare::ExitStatus> {
-    let mut host_paths = exec.include_host_paths;
-
-    let sandbox_host_dir = exec.sandbox_root.join("mnt").join("brioche-host");
-    std::fs::create_dir_all(&sandbox_host_dir)?;
-
-    let program = build_template(&exec.command, &mut host_paths)?;
-    let args = exec
-        .args
-        .iter()
-        .map(|arg| build_template(arg, &mut host_paths))
-        .collect::<anyhow::Result<Vec<_>>>()?;
-    let env = exec
-        .env
-        .iter()
-        .map(|(key, value)| {
-            let key = key.to_os_str()?.to_owned();
-            let value = build_template(value, &mut host_paths)?;
-            anyhow::Ok((key, value))
-        })
-        .collect::<anyhow::Result<HashMap<_, _>>>()?;
-
-    let mut command = unshare::Command::new(program);
-    command.args(&args);
-    command.env_clear();
-    command.envs(env);
-
-    let current_dir = build_template(
-        &SandboxTemplate {
-            components: vec![SandboxTemplateComponent::Path(exec.current_dir.clone())],
-        },
-        &mut host_paths,
-    )?;
-    command.current_dir(current_dir);
-
-    let host_uid = nix::unistd::Uid::current().as_raw();
-    let host_gid = nix::unistd::Gid::current().as_raw();
-    command.set_id_maps(
-        vec![unshare::UidMap {
-            inside_uid: exec.uid_hint,
-            outside_uid: host_uid,
-            count: 1,
-        }],
-        vec![unshare::GidMap {
-            inside_gid: exec.gid_hint,
-            outside_gid: host_gid,
-            count: 1,
-        }],
-    );
-    command.uid(exec.uid_hint);
-    command.gid(exec.gid_hint);
-    command.deny_setgroups(true);
-
-    command.unshare([
-        &unshare::Namespace::Mount,
-        &unshare::Namespace::Net,
-        &unshare::Namespace::User,
-    ]);
-
-    command.pivot_root(&exec.sandbox_root, &sandbox_host_dir, true);
-    command.before_chroot({
-        let sandbox_root = exec.sandbox_root.clone();
-        move || {
-            for (path, options) in &host_paths {
-                let path_metadata = path.metadata().map_err(|error| {
-                    std::io::Error::new(
-                        error.kind(),
-                        format!(
-                            "error getting metadata for path {}: {error}",
-                            path.display()
-                        ),
-                    )
-                })?;
-
-                let guest_path = options.guest_path_hint.to_path().map_err(|_| {
-                    std::io::Error::new(std::io::ErrorKind::Other, "invalid guest path")
-                })?;
-                let guest_path_under_root = guest_path.strip_prefix("/").map_err(|error| {
-                    std::io::Error::new(
-                        std::io::ErrorKind::Other,
-                        format!("invalid guest path: {error}"),
-                    )
-                })?;
-                let dest_path = sandbox_root.join(guest_path_under_root);
-
-                // Create either an empty file or directory as the mountpoint
-                if path_metadata.is_dir() {
-                    std::fs::create_dir_all(&dest_path)?;
-                } else {
-                    if let Some(dest_parent) = dest_path.parent() {
-                        std::fs::create_dir_all(dest_parent)?;
-                    }
-
-                    std::fs::write(&dest_path, "")?;
-                }
-
-                let readonly = match options.mode {
-                    HostPathMode::Read => true,
-                    HostPathMode::ReadWriteCreate => false,
-                };
-
-                libmount::BindMount::new(path, &dest_path)
-                    .readonly(readonly)
-                    .recursive(true)
-                    .mount()
-                    .map_err(|error| {
-                        std::io::Error::new(
-                            std::io::ErrorKind::Other,
-                            format!(
-                                "failed to mount {} -> {}: {error}",
-                                path.display(),
-                                dest_path.display()
-                            ),
-                        )
-                    })?;
-            }
-
-            libmount::BindMount::new(&sandbox_root, &sandbox_root)
-                .recursive(true)
-                .readonly(true)
-                .mount()
-                .map_err(|error| {
-                    std::io::Error::new(
-                        std::io::ErrorKind::Other,
-                        format!("failed to remount rootfs: {error}"),
-                    )
-                })?;
-
-            Ok(())
-        }
-    });
-
-    let mut child = command
-        .spawn()
-        .map_err(|error| anyhow::anyhow!("failed to spawn sandbox: {error}"))?;
-
-    let result = child.wait()?;
-
-    Ok(result)
+pub enum ExitStatus {
+    Code(i8),
+    Signal(i32),
 }
 
-fn build_template(
-    template: &SandboxTemplate,
-    host_paths: &mut HashMap<PathBuf, SandboxPathOptions>,
-) -> anyhow::Result<OsString> {
-    let mut result = bstr::BString::default();
-    for component in &template.components {
-        match component {
-            SandboxTemplateComponent::Literal { value } => {
-                result.extend_from_slice(value);
-            }
-            SandboxTemplateComponent::Path(SandboxPath { host_path, options }) => {
-                let existing_options = host_paths.insert(host_path.clone(), options.clone());
-                if let Some(existing_options) = existing_options {
-                    anyhow::ensure!(
-                        existing_options == *options,
-                        "tried to mount host path {} with conflicting mount options",
-                        host_path.display()
-                    );
-                }
-
-                let guest_path = &options.guest_path_hint;
-                result.extend_from_slice(guest_path);
-            }
-        }
+impl ExitStatus {
+    pub fn success(&self) -> bool {
+        matches!(self, Self::Code(0))
     }
 
-    let result = result.to_os_str()?;
-    Ok(result.to_owned())
+    pub fn code(&self) -> Option<i32> {
+        match self {
+            Self::Code(code) => Some((*code).into()),
+            _ => None,
+        }
+    }
+}
+
+pub fn run_sandbox(exec: SandboxExecutionConfig) -> anyhow::Result<ExitStatus> {
+    cfg_if::cfg_if! {
+        if #[cfg(target_os = "linux")] {
+            linux::run_sandbox(exec)
+        } else {
+            let _ = exec;
+            anyhow::bail!("process execution is not supported on this platform");
+        }
+    }
 }

--- a/crates/brioche/src/sandbox/linux.rs
+++ b/crates/brioche/src/sandbox/linux.rs
@@ -1,0 +1,186 @@
+#![cfg(target_os = "linux")]
+
+use std::{collections::HashMap, ffi::OsString, path::PathBuf};
+
+use bstr::ByteSlice as _;
+
+use super::{
+    ExitStatus, HostPathMode, SandboxPath, SandboxPathOptions, SandboxTemplate,
+    SandboxTemplateComponent,
+};
+
+pub fn run_sandbox(exec: super::SandboxExecutionConfig) -> anyhow::Result<super::ExitStatus> {
+    let mut host_paths = exec.include_host_paths;
+
+    let sandbox_host_dir = exec.sandbox_root.join("mnt").join("brioche-host");
+    std::fs::create_dir_all(&sandbox_host_dir)?;
+
+    let program = build_template(&exec.command, &mut host_paths)?;
+    let args = exec
+        .args
+        .iter()
+        .map(|arg| build_template(arg, &mut host_paths))
+        .collect::<anyhow::Result<Vec<_>>>()?;
+    let env = exec
+        .env
+        .iter()
+        .map(|(key, value)| {
+            let key = key.to_os_str()?.to_owned();
+            let value = build_template(value, &mut host_paths)?;
+            anyhow::Ok((key, value))
+        })
+        .collect::<anyhow::Result<HashMap<_, _>>>()?;
+
+    let mut command = unshare::Command::new(program);
+    command.args(&args);
+    command.env_clear();
+    command.envs(env);
+
+    let current_dir = build_template(
+        &SandboxTemplate {
+            components: vec![SandboxTemplateComponent::Path(exec.current_dir.clone())],
+        },
+        &mut host_paths,
+    )?;
+    command.current_dir(current_dir);
+
+    let host_uid = nix::unistd::Uid::current().as_raw();
+    let host_gid = nix::unistd::Gid::current().as_raw();
+    command.set_id_maps(
+        vec![unshare::UidMap {
+            inside_uid: exec.uid_hint,
+            outside_uid: host_uid,
+            count: 1,
+        }],
+        vec![unshare::GidMap {
+            inside_gid: exec.gid_hint,
+            outside_gid: host_gid,
+            count: 1,
+        }],
+    );
+    command.uid(exec.uid_hint);
+    command.gid(exec.gid_hint);
+    command.deny_setgroups(true);
+
+    command.unshare([
+        &unshare::Namespace::Mount,
+        &unshare::Namespace::Net,
+        &unshare::Namespace::User,
+    ]);
+
+    command.pivot_root(&exec.sandbox_root, &sandbox_host_dir, true);
+    command.before_chroot({
+        let sandbox_root = exec.sandbox_root.clone();
+        move || {
+            for (path, options) in &host_paths {
+                let path_metadata = path.metadata().map_err(|error| {
+                    std::io::Error::new(
+                        error.kind(),
+                        format!(
+                            "error getting metadata for path {}: {error}",
+                            path.display()
+                        ),
+                    )
+                })?;
+
+                let guest_path = options.guest_path_hint.to_path().map_err(|_| {
+                    std::io::Error::new(std::io::ErrorKind::Other, "invalid guest path")
+                })?;
+                let guest_path_under_root = guest_path.strip_prefix("/").map_err(|error| {
+                    std::io::Error::new(
+                        std::io::ErrorKind::Other,
+                        format!("invalid guest path: {error}"),
+                    )
+                })?;
+                let dest_path = sandbox_root.join(guest_path_under_root);
+
+                // Create either an empty file or directory as the mountpoint
+                if path_metadata.is_dir() {
+                    std::fs::create_dir_all(&dest_path)?;
+                } else {
+                    if let Some(dest_parent) = dest_path.parent() {
+                        std::fs::create_dir_all(dest_parent)?;
+                    }
+
+                    std::fs::write(&dest_path, "")?;
+                }
+
+                let readonly = match options.mode {
+                    HostPathMode::Read => true,
+                    HostPathMode::ReadWriteCreate => false,
+                };
+
+                libmount::BindMount::new(path, &dest_path)
+                    .readonly(readonly)
+                    .recursive(true)
+                    .mount()
+                    .map_err(|error| {
+                        std::io::Error::new(
+                            std::io::ErrorKind::Other,
+                            format!(
+                                "failed to mount {} -> {}: {error}",
+                                path.display(),
+                                dest_path.display()
+                            ),
+                        )
+                    })?;
+            }
+
+            libmount::BindMount::new(&sandbox_root, &sandbox_root)
+                .recursive(true)
+                .readonly(true)
+                .mount()
+                .map_err(|error| {
+                    std::io::Error::new(
+                        std::io::ErrorKind::Other,
+                        format!("failed to remount rootfs: {error}"),
+                    )
+                })?;
+
+            Ok(())
+        }
+    });
+
+    let mut child = command
+        .spawn()
+        .map_err(|error| anyhow::anyhow!("failed to spawn sandbox: {error}"))?;
+
+    let exit_status = child.wait()?;
+
+    let exit_status = match exit_status {
+        unshare::ExitStatus::Exited(code) => ExitStatus::Code(code),
+        unshare::ExitStatus::Signaled(signal, _) => ExitStatus::Signal(signal as i32),
+    };
+
+    Ok(exit_status)
+}
+
+fn build_template(
+    template: &SandboxTemplate,
+    host_paths: &mut HashMap<PathBuf, SandboxPathOptions>,
+) -> anyhow::Result<OsString> {
+    let mut result = bstr::BString::default();
+    for component in &template.components {
+        match component {
+            SandboxTemplateComponent::Literal { value } => {
+                result.extend_from_slice(value);
+            }
+            SandboxTemplateComponent::Path(SandboxPath { host_path, options }) => {
+                let existing_options = host_paths.insert(host_path.clone(), options.clone());
+                if let Some(existing_options) = existing_options {
+                    anyhow::ensure!(
+                        existing_options == *options,
+                        "tried to mount host path {} with conflicting mount options",
+                        host_path.display()
+                    );
+                }
+
+                let guest_path = &options.guest_path_hint;
+                result.extend_from_slice(guest_path);
+            }
+        }
+    }
+
+    let result = result.to_os_str()?;
+    Ok(result.to_owned())
+}

--- a/crates/brioche/tests/bake_process.rs
+++ b/crates/brioche/tests/bake_process.rs
@@ -1,3 +1,5 @@
+#![cfg(target_os = "linux")]
+
 use std::collections::BTreeMap;
 
 use anyhow::Context;


### PR DESCRIPTION
`process` recipes have a `platform` field describing which platform they should bake on. Currently, the only variant for this field is `x86_64-linux`, meaning you can really only bake process recipes if you're already running on x86-64 Linux. That's not changing today, but there is a lot of code that's x86-64 Linux-specific, and that code causes builds to fail when trying to build on other platforms.

This PR adds `#[cfg]` attributes and uses the Cargo `targets.cfg(...)` feature so the build succeeds on other platforms. While you still won't be able to do a lot of things on other platforms, you can still interact with the registry, meaning you could still download Linux-specific artifacts that have already been baked and synced. You can also run the LSP or run `brioche check`.