### PR TITLE
Rename `unpack` recipe to `unarchive`

### DIFF
--- a/crates/brioche/src/bake.rs
+++ b/crates/brioche/src/bake.rs
@@ -20,7 +20,7 @@ use super::{
 
 mod download;
 mod process;
-mod unpack;
+mod unarchive;
 
 #[derive(Debug, Default)]
 pub struct CachedRecipes {
@@ -354,9 +354,9 @@ async fn run_bake(brioche: &Brioche, recipe: Recipe, meta: &Arc<Meta>) -> anyhow
             let downloaded = download::bake_download(brioche, download).await?;
             Ok(Artifact::File(downloaded))
         }
-        Recipe::Unpack(unpack) => {
-            let unpacked = unpack::bake_unpack(brioche, &scope, meta, unpack).await?;
-            Ok(Artifact::Directory(unpacked))
+        Recipe::Unarchive(unarchive) => {
+            let unarchived = unarchive::bake_unarchive(brioche, &scope, meta, unarchive).await?;
+            Ok(Artifact::Directory(unarchived))
         }
         Recipe::Process(process) => {
             // We call `bake` recursively here so that two different

--- a/crates/brioche/src/bake/process.rs
+++ b/crates/brioche/src/bake/process.rs
@@ -14,7 +14,7 @@ use crate::{
     recipe::{
         ArchiveFormat, Artifact, CompleteProcessRecipe, CompleteProcessTemplate,
         CompleteProcessTemplateComponent, CompressionFormat, DownloadRecipe, Meta, ProcessRecipe,
-        ProcessTemplate, ProcessTemplateComponent, Recipe, UnpackRecipe, WithMeta,
+        ProcessTemplate, ProcessTemplateComponent, Recipe, Unarchive, WithMeta,
     },
     sandbox::{
         HostPathMode, SandboxExecutionConfig, SandboxPath, SandboxPathOptions, SandboxTemplate,
@@ -595,7 +595,7 @@ async fn set_up_rootfs(
         link_locals: true,
     };
 
-    let dash = Recipe::Unpack(UnpackRecipe {
+    let dash = Recipe::Unarchive(Unarchive {
         archive: ArchiveFormat::Tar,
         compression: CompressionFormat::Zstd,
         file: Box::new(WithMeta::without_meta(Recipe::Download(DownloadRecipe {
@@ -603,7 +603,7 @@ async fn set_up_rootfs(
             hash: crate::Hash::Sha256 { value: hex::decode("ff52ae7e883ee4cbb0878f0e17decc18cd80b364147881fb576440e72e0129b2")? }
         }))),
     });
-    let env = Recipe::Unpack(UnpackRecipe {
+    let env = Recipe::Unarchive(Unarchive {
         archive: ArchiveFormat::Tar,
         compression: CompressionFormat::Zstd,
         file: Box::new(WithMeta::without_meta(Recipe::Download(DownloadRecipe {

--- a/crates/brioche/src/recipe.rs
+++ b/crates/brioche/src/recipe.rs
@@ -46,7 +46,7 @@ pub enum Recipe {
     #[serde(rename_all = "camelCase")]
     Download(DownloadRecipe),
     #[serde(rename_all = "camelCase")]
-    Unpack(UnpackRecipe),
+    Unarchive(Unarchive),
     Process(ProcessRecipe),
     CompleteProcess(CompleteProcessRecipe),
     #[serde(rename_all = "camelCase")]
@@ -137,7 +137,7 @@ impl Recipe {
             Recipe::File { .. }
             | Recipe::Directory(_)
             | Recipe::Symlink { .. }
-            | Recipe::Unpack(_)
+            | Recipe::Unarchive(_)
             | Recipe::Process(_)
             | Recipe::CreateFile { .. }
             | Recipe::CreateDirectory(_)
@@ -491,7 +491,7 @@ pub struct DownloadRecipe {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct UnpackRecipe {
+pub struct Unarchive {
     pub file: Box<WithMeta<Recipe>>,
     pub archive: ArchiveFormat,
     #[serde(default)]
@@ -944,7 +944,7 @@ impl TryFrom<Recipe> for Artifact {
             }
             Recipe::Sync { recipe } => recipe.value.try_into(),
             Recipe::Download { .. }
-            | Recipe::Unpack { .. }
+            | Recipe::Unarchive { .. }
             | Recipe::Process { .. }
             | Recipe::CompleteProcess { .. }
             | Recipe::CreateFile { .. }

--- a/crates/brioche/src/references.rs
+++ b/crates/brioche/src/references.rs
@@ -53,7 +53,7 @@ pub fn referenced_blobs(recipe: &Recipe) -> Vec<BlobHash> {
         Recipe::Directory(_)
         | Recipe::Symlink { .. }
         | Recipe::Download(_)
-        | Recipe::Unpack(_)
+        | Recipe::Unarchive(_)
         | Recipe::Process(_)
         | Recipe::CompleteProcess(_)
         | Recipe::CreateFile { .. }
@@ -83,7 +83,7 @@ pub fn referenced_recipes(recipe: &Recipe) -> Vec<RecipeHash> {
             .collect(),
         Recipe::Symlink { .. } => vec![],
         Recipe::Download(_) => vec![],
-        Recipe::Unpack(unpack) => referenced_recipes(&unpack.file),
+        Recipe::Unarchive(unarchive) => referenced_recipes(&unarchive.file),
         Recipe::Process(process) => {
             let ProcessRecipe {
                 command,

--- a/crates/brioche/src/reporter.rs
+++ b/crates/brioche/src/reporter.rs
@@ -231,7 +231,7 @@ impl ConsoleReporter {
                 NewJob::Download { url } => {
                     eprintln!("Downloading {}", url);
                 }
-                NewJob::Unpack => {}
+                NewJob::Unarchive => {}
                 NewJob::Process { status } => {
                     if let Some(child_id) = status.child_id() {
                         eprintln!("Started process {child_id}");
@@ -301,9 +301,9 @@ impl ConsoleReporter {
                         eprintln!("Finished download");
                     }
                 }
-                UpdateJob::Unpack { progress_percent } => {
+                UpdateJob::Unarchive { progress_percent } => {
                     if progress_percent == 100 {
-                        eprintln!("Unpacked");
+                        eprintln!("Unarchive");
                     }
                 }
                 UpdateJob::Process { mut packet, status } => {
@@ -517,7 +517,7 @@ pub enum NewJob {
     Download {
         url: url::Url,
     },
-    Unpack,
+    Unarchive,
     Process {
         status: ProcessStatus,
     },
@@ -532,7 +532,7 @@ pub enum UpdateJob {
     Download {
         progress_percent: Option<u8>,
     },
-    Unpack {
+    Unarchive {
         progress_percent: u8,
     },
     Process {
@@ -552,7 +552,7 @@ pub enum Job {
         url: url::Url,
         progress_percent: Option<u8>,
     },
-    Unpack {
+    Unarchive {
         progress_percent: u8,
     },
     Process {
@@ -574,7 +574,7 @@ impl Job {
                 url,
                 progress_percent: Some(0),
             },
-            NewJob::Unpack => Self::Unpack {
+            NewJob::Unarchive => Self::Unarchive {
                 progress_percent: 0,
             },
             NewJob::Process { status } => Self::Process {
@@ -606,14 +606,14 @@ impl Job {
                 };
                 *progress_percent = new_progress_percent;
             }
-            UpdateJob::Unpack {
+            UpdateJob::Unarchive {
                 progress_percent: new_progress_percent,
             } => {
-                let Self::Unpack {
+                let Self::Unarchive {
                     progress_percent, ..
                 } = self
                 else {
-                    anyhow::bail!("tried to update a non-unpack job with an unpack update");
+                    anyhow::bail!("tried to update a non-unarchive job with an unarchive update");
                 };
                 *progress_percent = new_progress_percent;
             }
@@ -681,7 +681,7 @@ impl Job {
             Job::Download {
                 progress_percent, ..
             } => progress_percent.map(|p| p >= 100).unwrap_or(false),
-            Job::Unpack { progress_percent } => *progress_percent >= 100,
+            Job::Unarchive { progress_percent } => *progress_percent >= 100,
             Job::Process {
                 status,
                 packet_queue: _,
@@ -699,7 +699,7 @@ impl Job {
     // priority jobs are displayed first.
     fn job_type_priority(&self) -> u8 {
         match self {
-            Job::Unpack { .. } => 0,
+            Job::Unarchive { .. } => 0,
             Job::Download { .. } | Job::RegistryFetch { .. } => 1,
             Job::Process { .. } => 2,
         }
@@ -730,11 +730,11 @@ impl superconsole::Component for Job {
                 };
                 superconsole::Lines::from_iter([superconsole::Line::sanitized(&message)])
             }
-            Job::Unpack { progress_percent } => {
+            Job::Unarchive { progress_percent } => {
                 let message = if *progress_percent == 100 {
-                    "[100%] Unpacked".to_string()
+                    "[100%] Unarchived".to_string()
                 } else {
-                    format!("[{progress_percent:>3}%] Unpacking")
+                    format!("[{progress_percent:>3}%] Unarchiving")
                 };
                 superconsole::Lines::from_iter([superconsole::Line::sanitized(&message)])
             }

--- a/crates/brioche/tests/bake_process.rs
+++ b/crates/brioche/tests/bake_process.rs
@@ -10,7 +10,7 @@ use brioche::{
     platform::current_platform,
     recipe::{
         ArchiveFormat, Artifact, CompressionFormat, Directory, DownloadRecipe, File, ProcessRecipe,
-        ProcessTemplate, ProcessTemplateComponent, Recipe, UnpackRecipe, WithMeta,
+        ProcessTemplate, ProcessTemplateComponent, Recipe, Unarchive, WithMeta,
     },
     Hash,
 };
@@ -85,7 +85,7 @@ fn utils() -> Recipe {
         hash: sha256_hash("eb29ea059fcd9ca457841f5c79151721a74761a31610d694bce61a62f4de6d33"),
     });
 
-    Recipe::Unpack(UnpackRecipe {
+    Recipe::Unarchive(Unarchive {
         file: Box::new(brioche_test::without_meta(utils_download)),
         archive: ArchiveFormat::Tar,
         compression: CompressionFormat::Zstd,


### PR DESCRIPTION
This PR renames the `unpack` recipe type to `unarchive`, and all related functions, variables, etc. I made this change because we already use the term "packed executable", and I was worried that the two uses of the term could be easily confused