### PR TITLE
Make project definition optional in `project.bri`

### DIFF
--- a/crates/brioche/src/project.rs
+++ b/crates/brioche/src/project.rs
@@ -930,7 +930,7 @@ pub enum LoadProjectError {
     },
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ProjectDefinition {
     pub name: Option<String>,


### PR DESCRIPTION
This PR relaxes the requirement that every `project.bri` file needs to include an explicit project definition (`export const project = { /* ... */ };`). Now, omitting the project definition will be equivalent to having a project definition of `{}`.

At the moment, this is fairly useless because nearly every project will still need to include a project definition to import dependencies, including `std`. This should change fairly quickly: you will soon also be able to include dependencies implicitly via `import` statements (instead of including each one in the project definition explicitly).