### PR TITLE
Add `brioche run` subcommand

### DIFF
--- a/crates/brioche/src/main.rs
+++ b/crates/brioche/src/main.rs
@@ -12,6 +12,8 @@ use tracing::Instrument;
 enum Args {
     Build(BuildArgs),
 
+    Run(RunArgs),
+
     Check(CheckArgs),
 
     #[command(name = "fmt")]
@@ -40,6 +42,15 @@ fn main() -> anyhow::Result<ExitCode> {
                 .build()?;
 
             let exit_code = rt.block_on(build(args))?;
+
+            Ok(exit_code)
+        }
+        Args::Run(args) => {
+            let rt = tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()?;
+
+            let exit_code = rt.block_on(run(args))?;
 
             Ok(exit_code)
         }
@@ -257,6 +268,144 @@ async fn build(args: BuildArgs) -> anyhow::Result<ExitCode> {
         .await?;
 
     Ok(exit_code)
+}
+
+#[derive(Debug, Parser)]
+struct RunArgs {
+    #[arg(short, long)]
+    project: PathBuf,
+    #[arg(short, long, default_value = "default")]
+    export: String,
+    #[arg(short, long, default_value = "brioche-run")]
+    command: String,
+    #[arg(long)]
+    check: bool,
+    #[arg(long)]
+    keep: bool,
+    args: Vec<std::ffi::OsString>,
+}
+
+async fn run(args: RunArgs) -> anyhow::Result<ExitCode> {
+    let (reporter, mut guard) =
+        brioche::reporter::start_console_reporter(ConsoleReporterKind::Auto)?;
+    reporter.set_is_evaluating(true);
+
+    let brioche = brioche::BriocheBuilder::new(reporter.clone())
+        .keep_temps(args.keep)
+        .build()
+        .await?;
+    let projects = brioche::project::Projects::default();
+
+    let build_future = async {
+        let project_hash = projects.load(&brioche, &args.project, true).await?;
+
+        let num_lockfiles_updated = projects.commit_dirty_lockfiles().await?;
+        if num_lockfiles_updated > 0 {
+            tracing::info!(num_lockfiles_updated, "updated lockfiles");
+        }
+
+        if args.check {
+            let checked = brioche::script::check::check(&brioche, &projects, project_hash).await?;
+
+            let result = checked.ensure_ok(brioche::script::check::DiagnosticLevel::Error);
+
+            match result {
+                Ok(()) => reporter.emit(superconsole::Lines::from_multiline_string(
+                    "No errors found",
+                    superconsole::style::ContentStyle {
+                        foreground_color: Some(superconsole::style::Color::Green),
+                        ..superconsole::style::ContentStyle::default()
+                    },
+                )),
+                Err(diagnostics) => {
+                    guard.shutdown_console().await;
+
+                    diagnostics.write(&brioche.vfs, &mut std::io::stdout())?;
+                    anyhow::bail!("checks failed");
+                }
+            }
+        }
+
+        let recipe =
+            brioche::script::evaluate::evaluate(&brioche, &projects, project_hash, &args.export)
+                .await?;
+
+        reporter.set_is_evaluating(false);
+        let artifact = brioche::bake::bake(
+            &brioche,
+            recipe,
+            &brioche::bake::BakeScope::Project {
+                project_hash,
+                export: args.export.to_string(),
+            },
+        )
+        .await?;
+
+        guard.shutdown_console().await;
+
+        let elapsed = reporter.elapsed().human_duration();
+        let num_jobs = reporter.num_jobs();
+        let jobs_message = match num_jobs {
+            0 => "(no new jobs)".to_string(),
+            1 => "1 job".to_string(),
+            n => format!("{n} jobs"),
+        };
+        eprintln!("Build finished, completed {jobs_message} in {elapsed}");
+
+        // Validate that the artifact is a directory that contains the
+        // command to run before returning
+        let command_artifact = match &artifact.value {
+            brioche::recipe::Artifact::File(_) => {
+                anyhow::bail!("artifact returned a file, expected a directory");
+            }
+            brioche::recipe::Artifact::Symlink { .. } => {
+                anyhow::bail!("artifact returned a symlink, expected a directory");
+            }
+            brioche::recipe::Artifact::Directory(dir) => dir
+                .get(&brioche, args.command.as_bytes())
+                .await
+                .with_context(|| {
+                    format!(
+                        "failed to retrieve {:?} from returned artifact",
+                        args.command
+                    )
+                })?,
+        };
+        anyhow::ensure!(
+            command_artifact.is_some(),
+            "{:?} not found in returned artifact",
+            args.command
+        );
+
+        let output = brioche::output::create_local_output(&brioche, &artifact.value).await?;
+
+        Ok(output)
+    };
+
+    let output = build_future
+        .instrument(tracing::info_span!("run_build", args = ?args))
+        .await?;
+
+    let command_path = output.path.join(&args.command);
+
+    let mut command = std::process::Command::new(command_path);
+    command.args(&args.args);
+
+    if let Some(resources_dir) = output.resources_dir {
+        command.env("BRIOCHE_PACK_RESOURCES_DIR", resources_dir);
+    }
+
+    let result = command.status().context("failed to run process")?;
+    if result.success() {
+        Ok(ExitCode::SUCCESS)
+    } else {
+        let code = result
+            .code()
+            .and_then(|code| u8::try_from(code).ok())
+            .map(ExitCode::from)
+            .unwrap_or(ExitCode::FAILURE);
+        Ok(code)
+    }
 }
 
 #[derive(Debug, Parser)]

--- a/crates/brioche/src/main.rs
+++ b/crates/brioche/src/main.rs
@@ -396,6 +396,10 @@ async fn run(args: RunArgs) -> anyhow::Result<ExitCode> {
 
     let command_path = output.path.join(&args.command);
 
+    if !args.quiet {
+        eprintln!("Running {}", args.command);
+    }
+
     let mut command = std::process::Command::new(command_path);
     command.args(&args.args);
 

--- a/crates/brioche/src/main.rs
+++ b/crates/brioche/src/main.rs
@@ -284,6 +284,7 @@ struct RunArgs {
     check: bool,
     #[arg(long)]
     keep: bool,
+    #[arg(last = true)]
     args: Vec<std::ffi::OsString>,
 }
 


### PR DESCRIPTION
This PR adds a new `brioche run` subcommand. It takes `-p` and `-e` args just like `brioche build` to specify the project/export to build, then runs the command from the output artifacts specified by the `-c` arg (defaults to `brioche-run`).

Here's a minimal example:

```ts
// example/project.bri
import * as std from "std";

export default function (): std.Recipe {
  return std
    .tools()
    .insert("brioche-run", std.symlink({ target: "./bin/bash" }));
}
```

Running `brioche run -p example` will then run Bash.