### PR TITLE
Implement process networking

### DIFF
--- a/crates/brioche/src/bake/process.rs
+++ b/crates/brioche/src/bake/process.rs
@@ -32,6 +32,20 @@ pub async fn bake_lazy_process_to_process(
     scope: &super::BakeScope,
     process: ProcessRecipe,
 ) -> anyhow::Result<CompleteProcessRecipe> {
+    let unsafe_required = process.networking;
+
+    if unsafe_required {
+        anyhow::ensure!(
+            process.is_unsafe,
+            "to enable networking, `unsafe` must be set to true"
+        );
+    } else {
+        anyhow::ensure!(
+            !process.is_unsafe,
+            "process is marked as unsafe but does not use any unsafe features"
+        );
+    }
+
     let command =
         bake_lazy_process_template_to_process_template(brioche, scope, process.command).await?;
     let args = futures::stream::iter(process.args)

--- a/crates/brioche/src/bake/process.rs
+++ b/crates/brioche/src/bake/process.rs
@@ -67,6 +67,8 @@ pub async fn bake_lazy_process_to_process(
         work_dir,
         output_scaffold,
         platform: process.platform,
+        is_unsafe: process.is_unsafe,
+        networking: process.networking,
     })
 }
 

--- a/crates/brioche/src/lib.rs
+++ b/crates/brioche/src/lib.rs
@@ -25,6 +25,7 @@ pub mod reporter;
 pub mod sandbox;
 pub mod script;
 pub mod sync;
+pub mod utils;
 pub mod vfs;
 
 const MAX_CONCURRENT_PROCESSES: usize = 20;

--- a/crates/brioche/src/recipe.rs
+++ b/crates/brioche/src/recipe.rs
@@ -515,6 +515,16 @@ pub struct ProcessRecipe {
     pub output_scaffold: Option<Box<WithMeta<Recipe>>>,
 
     pub platform: Platform,
+
+    #[serde(
+        rename = "unsafe",
+        default,
+        skip_serializing_if = "crate::utils::is_default"
+    )]
+    pub is_unsafe: bool,
+
+    #[serde(default, skip_serializing_if = "crate::utils::is_default")]
+    pub networking: bool,
 }
 
 #[serde_with::serde_as]
@@ -535,6 +545,16 @@ pub struct CompleteProcessRecipe {
     pub output_scaffold: Option<Box<Artifact>>,
 
     pub platform: Platform,
+
+    #[serde(
+        rename = "unsafe",
+        default,
+        skip_serializing_if = "crate::utils::is_default"
+    )]
+    pub is_unsafe: bool,
+
+    #[serde(default, skip_serializing_if = "crate::utils::is_default")]
+    pub networking: bool,
 }
 
 #[serde_with::serde_as]

--- a/crates/brioche/src/references.rs
+++ b/crates/brioche/src/references.rs
@@ -92,6 +92,8 @@ pub fn referenced_recipes(recipe: &Recipe) -> Vec<RecipeHash> {
                 work_dir,
                 output_scaffold,
                 platform: _,
+                is_unsafe: _,
+                networking: _,
             } = process;
 
             let templates = [command].into_iter().chain(args).chain(env.values());
@@ -123,6 +125,8 @@ pub fn referenced_recipes(recipe: &Recipe) -> Vec<RecipeHash> {
                 work_dir,
                 output_scaffold,
                 platform: _,
+                is_unsafe: _,
+                networking: _,
             } = process;
 
             let work_dir = Recipe::from(work_dir.clone());

--- a/crates/brioche/src/sandbox.rs
+++ b/crates/brioche/src/sandbox.rs
@@ -17,6 +17,7 @@ pub struct SandboxExecutionConfig {
     #[serde_as(as = "HashMap<TickEncoded, _>")]
     pub env: HashMap<bstr::BString, SandboxTemplate>,
     pub current_dir: SandboxPath,
+    pub networking: bool,
     pub uid_hint: u32,
     pub gid_hint: u32,
 }

--- a/crates/brioche/src/utils.rs
+++ b/crates/brioche/src/utils.rs
@@ -1,0 +1,6 @@
+pub fn is_default<T>(value: &T) -> bool
+where
+    T: Default + PartialEq,
+{
+    *value == Default::default()
+}

--- a/crates/brioche/tests/bake_process.rs
+++ b/crates/brioche/tests/bake_process.rs
@@ -145,6 +145,8 @@ async fn test_bake_process() -> anyhow::Result<()> {
         work_dir: Box::new(brioche_test::without_meta(brioche_test::lazy_dir_empty())),
         output_scaffold: None,
         platform: current_platform(),
+        is_unsafe: false,
+        networking: false,
     });
 
     assert_eq!(
@@ -167,6 +169,8 @@ async fn test_bake_process_fail_on_no_output() -> anyhow::Result<()> {
         work_dir: Box::new(brioche_test::without_meta(brioche_test::lazy_dir_empty())),
         output_scaffold: None,
         platform: current_platform(),
+        is_unsafe: false,
+        networking: false,
     });
 
     assert_matches!(bake_without_meta(&brioche, process).await, Err(_));
@@ -190,6 +194,8 @@ async fn test_bake_process_scaffold_output() -> anyhow::Result<()> {
             hello_blob, false,
         )))),
         platform: current_platform(),
+        is_unsafe: false,
+        networking: false,
     });
 
     assert_eq!(
@@ -220,6 +226,8 @@ async fn test_bake_process_scaffold_and_modify_output() -> anyhow::Result<()> {
             brioche_test::lazy_dir_empty(),
         ))),
         platform: current_platform(),
+        is_unsafe: false,
+        networking: false,
     });
 
     assert_eq!(
@@ -250,6 +258,8 @@ async fn test_bake_process_fail_on_non_zero_exit() -> anyhow::Result<()> {
         work_dir: Box::new(brioche_test::without_meta(brioche_test::lazy_dir_empty())),
         output_scaffold: None,
         platform: current_platform(),
+        is_unsafe: false,
+        networking: false,
     });
 
     assert_matches!(bake_without_meta(&brioche, process).await, Err(_));
@@ -269,6 +279,8 @@ async fn test_bake_process_command_no_path() -> anyhow::Result<()> {
         work_dir: Box::new(brioche_test::without_meta(brioche_test::lazy_dir_empty())),
         output_scaffold: None,
         platform: current_platform(),
+        is_unsafe: false,
+        networking: false,
     });
 
     assert_matches!(bake_without_meta(&brioche, process).await, Err(_));
@@ -294,6 +306,8 @@ async fn test_bake_process_command_path() -> anyhow::Result<()> {
         work_dir: Box::new(brioche_test::without_meta(brioche_test::lazy_dir_empty())),
         output_scaffold: None,
         platform: current_platform(),
+        is_unsafe: false,
+        networking: false,
     });
 
     assert_matches!(bake_without_meta(&brioche, process).await, Err(_));
@@ -319,6 +333,8 @@ async fn test_bake_process_with_utils() -> anyhow::Result<()> {
         work_dir: Box::new(brioche_test::without_meta(brioche_test::lazy_dir_empty())),
         output_scaffold: None,
         platform: current_platform(),
+        is_unsafe: false,
+        networking: false,
     });
 
     assert_matches!(bake_without_meta(&brioche, process).await, Ok(_));
@@ -353,6 +369,8 @@ async fn test_bake_process_with_readonly_contents() -> anyhow::Result<()> {
         work_dir: Box::new(brioche_test::without_meta(brioche_test::lazy_dir_empty())),
         output_scaffold: None,
         platform: current_platform(),
+        is_unsafe: false,
+        networking: false,
     });
 
     assert_matches!(bake_without_meta(&brioche, process).await, Ok(_));
@@ -382,6 +400,8 @@ async fn test_bake_process_cached() -> anyhow::Result<()> {
         work_dir: Box::new(brioche_test::without_meta(brioche_test::lazy_dir_empty())),
         output_scaffold: None,
         platform: current_platform(),
+        is_unsafe: false,
+        networking: false,
     });
 
     // Even though the process is non-deterministic, the result of the first
@@ -415,6 +435,8 @@ async fn test_bake_process_cached_equivalent_inputs() -> anyhow::Result<()> {
         work_dir: Box::new(brioche_test::without_meta(brioche_test::lazy_dir_empty())),
         output_scaffold: None,
         platform: current_platform(),
+        is_unsafe: false,
+        networking: false,
     });
 
     let empty_dir_1_baked = bake_without_meta(&brioche, empty_dir_1.clone()).await?;
@@ -439,6 +461,8 @@ async fn test_bake_process_cached_equivalent_inputs() -> anyhow::Result<()> {
         work_dir: Box::new(brioche_test::without_meta(brioche_test::lazy_dir_empty())),
         output_scaffold: None,
         platform: current_platform(),
+        is_unsafe: false,
+        networking: false,
     });
 
     let process_random_2 = Recipe::Process(ProcessRecipe {
@@ -459,6 +483,8 @@ async fn test_bake_process_cached_equivalent_inputs() -> anyhow::Result<()> {
         work_dir: Box::new(brioche_test::without_meta(brioche_test::lazy_dir_empty())),
         output_scaffold: None,
         platform: current_platform(),
+        is_unsafe: false,
+        networking: false,
     });
 
     // Both processes are different, but their inputs bake to identical
@@ -491,6 +517,8 @@ async fn test_bake_process_cached_equivalent_inputs_parallel() -> anyhow::Result
         work_dir: Box::new(brioche_test::without_meta(brioche_test::lazy_dir_empty())),
         output_scaffold: None,
         platform: current_platform(),
+        is_unsafe: false,
+        networking: false,
     });
 
     let empty_dir_1_baked = bake_without_meta(&brioche, empty_dir_1.clone()).await?;
@@ -515,6 +543,8 @@ async fn test_bake_process_cached_equivalent_inputs_parallel() -> anyhow::Result
         work_dir: Box::new(brioche_test::without_meta(brioche_test::lazy_dir_empty())),
         output_scaffold: None,
         platform: current_platform(),
+        is_unsafe: false,
+        networking: false,
     });
 
     let process_random_2 = Recipe::Process(ProcessRecipe {
@@ -535,6 +565,8 @@ async fn test_bake_process_cached_equivalent_inputs_parallel() -> anyhow::Result
         work_dir: Box::new(brioche_test::without_meta(brioche_test::lazy_dir_empty())),
         output_scaffold: None,
         platform: current_platform(),
+        is_unsafe: false,
+        networking: false,
     });
 
     let process_random_1_proxy =
@@ -607,6 +639,8 @@ async fn test_bake_process_cache_busted() -> anyhow::Result<()> {
         work_dir: Box::new(brioche_test::without_meta(brioche_test::lazy_dir_empty())),
         output_scaffold: None,
         platform: current_platform(),
+        is_unsafe: false,
+        networking: false,
     };
     let mut process_random_2 = process_random_1.clone();
     process_random_2
@@ -665,6 +699,8 @@ async fn test_bake_process_custom_env_vars() -> anyhow::Result<()> {
         work_dir: Box::new(brioche_test::without_meta(brioche_test::lazy_dir_empty())),
         output_scaffold: None,
         platform: current_platform(),
+        is_unsafe: false,
+        networking: false,
     };
 
     bake_without_meta(&brioche, Recipe::Process(process)).await?;
@@ -703,6 +739,8 @@ async fn test_bake_process_no_default_env_vars() -> anyhow::Result<()> {
         work_dir: Box::new(brioche_test::without_meta(brioche_test::lazy_dir_empty())),
         output_scaffold: None,
         platform: current_platform(),
+        is_unsafe: false,
+        networking: false,
     };
 
     bake_without_meta(&brioche, Recipe::Process(process)).await?;
@@ -742,6 +780,8 @@ async fn test_bake_process_starts_with_work_dir_contents() -> anyhow::Result<()>
         )]))),
         output_scaffold: None,
         platform: current_platform(),
+        is_unsafe: false,
+        networking: false,
     };
 
     bake_without_meta(&brioche, Recipe::Process(process)).await?;
@@ -785,6 +825,8 @@ async fn test_bake_process_edit_work_dir_contents() -> anyhow::Result<()> {
         ]))),
         output_scaffold: None,
         platform: current_platform(),
+        is_unsafe: false,
+        networking: false,
     };
 
     bake_without_meta(&brioche, Recipe::Process(process)).await?;
@@ -819,6 +861,8 @@ async fn test_bake_process_has_resource_dir() -> anyhow::Result<()> {
         work_dir: Box::new(brioche_test::without_meta(brioche_test::lazy_dir_empty())),
         output_scaffold: None,
         platform: current_platform(),
+        is_unsafe: false,
+        networking: false,
     };
 
     bake_without_meta(&brioche, Recipe::Process(process)).await?;
@@ -894,6 +938,8 @@ async fn test_bake_process_contains_all_resources() -> anyhow::Result<()> {
         work_dir: Box::new(brioche_test::without_meta(brioche_test::lazy_dir_empty())),
         output_scaffold: None,
         platform: current_platform(),
+        is_unsafe: false,
+        networking: false,
     };
 
     bake_without_meta(&brioche, Recipe::Process(process)).await?;
@@ -951,6 +997,8 @@ async fn test_bake_process_output_with_resources() -> anyhow::Result<()> {
         work_dir: Box::new(brioche_test::without_meta(brioche_test::lazy_dir_empty())),
         output_scaffold: None,
         platform: current_platform(),
+        is_unsafe: false,
+        networking: false,
     };
 
     let result = bake_without_meta(&brioche, Recipe::Process(process)).await?;

--- a/crates/brioche/tests/recipe_hash_stable.rs
+++ b/crates/brioche/tests/recipe_hash_stable.rs
@@ -272,6 +272,8 @@ async fn test_recipe_hash_stable_process() -> anyhow::Result<()> {
             work_dir: Box::new(brioche_test::without_meta(brioche_test::lazy_dir_empty())),
             output_scaffold: None,
             platform: Platform::X86_64Linux,
+            is_unsafe: false,
+            networking: false,
         })
         .hash()
         .to_string(),
@@ -290,6 +292,8 @@ async fn test_recipe_hash_stable_process() -> anyhow::Result<()> {
             work_dir: Box::new(brioche_test::without_meta(brioche_test::lazy_dir_empty())),
             output_scaffold: None,
             platform: Platform::X86_64Linux,
+            is_unsafe: false,
+            networking: false,
         })
         .hash()
         .to_string(),
@@ -310,6 +314,8 @@ async fn test_recipe_hash_stable_process() -> anyhow::Result<()> {
             work_dir: Box::new(brioche_test::without_meta(brioche_test::lazy_dir_empty())),
             output_scaffold: None,
             platform: Platform::X86_64Linux,
+            is_unsafe: false,
+            networking: false,
         })
         .hash()
         .to_string(),
@@ -337,6 +343,8 @@ async fn test_recipe_hash_stable_process() -> anyhow::Result<()> {
             work_dir: Box::new(brioche_test::without_meta(brioche_test::lazy_dir_empty())),
             output_scaffold: None,
             platform: Platform::X86_64Linux,
+            is_unsafe: false,
+            networking: false,
         })
         .hash()
         .to_string(),
@@ -369,10 +377,80 @@ async fn test_recipe_hash_stable_process() -> anyhow::Result<()> {
             work_dir: Box::new(brioche_test::without_meta(brioche_test::lazy_dir_empty())),
             output_scaffold: None,
             platform: Platform::X86_64Linux,
+            is_unsafe: false,
+            networking: false,
         })
         .hash()
         .to_string(),
         "9cf41f944bfa3d76830e6edf7de386d67f7f56a3cd737aa3632550ef1edee9d2",
+    ));
+
+    asserts.push((
+        Recipe::Process(ProcessRecipe {
+            command: ProcessTemplate {
+                components: vec![ProcessTemplateComponent::Literal {
+                    value: "/usr/bin/env".into(),
+                }],
+            },
+            args: vec![ProcessTemplate {
+                components: vec![ProcessTemplateComponent::Literal { value: "sh".into() }],
+            }],
+            env: BTreeMap::from_iter([(
+                "PATH".into(),
+                ProcessTemplate {
+                    components: vec![
+                        ProcessTemplateComponent::Input {
+                            recipe: brioche_test::without_meta(brioche_test::lazy_dir_empty()),
+                        },
+                        ProcessTemplateComponent::Literal {
+                            value: "/bin".into(),
+                        },
+                    ],
+                },
+            )]),
+            work_dir: Box::new(brioche_test::without_meta(brioche_test::lazy_dir_empty())),
+            output_scaffold: None,
+            platform: Platform::X86_64Linux,
+            is_unsafe: true,
+            networking: false,
+        })
+        .hash()
+        .to_string(),
+        "2badfafffeb1deadd0e384816ff202800c48080a7fbc1aaff354d0e6515337f2",
+    ));
+
+    asserts.push((
+        Recipe::Process(ProcessRecipe {
+            command: ProcessTemplate {
+                components: vec![ProcessTemplateComponent::Literal {
+                    value: "/usr/bin/env".into(),
+                }],
+            },
+            args: vec![ProcessTemplate {
+                components: vec![ProcessTemplateComponent::Literal { value: "sh".into() }],
+            }],
+            env: BTreeMap::from_iter([(
+                "PATH".into(),
+                ProcessTemplate {
+                    components: vec![
+                        ProcessTemplateComponent::Input {
+                            recipe: brioche_test::without_meta(brioche_test::lazy_dir_empty()),
+                        },
+                        ProcessTemplateComponent::Literal {
+                            value: "/bin".into(),
+                        },
+                    ],
+                },
+            )]),
+            work_dir: Box::new(brioche_test::without_meta(brioche_test::lazy_dir_empty())),
+            output_scaffold: None,
+            platform: Platform::X86_64Linux,
+            is_unsafe: true,
+            networking: true,
+        })
+        .hash()
+        .to_string(),
+        "5d14c32fce7134257ede8918680a83d9b33a292879192ac99461202851ab82e5",
     ));
 
     let left: Vec<_> = asserts.iter().map(|(left, _)| left).collect();


### PR DESCRIPTION
Companion PR: brioche-dev/brioche-packages#6

This PR adds a way to enable networking for processes. This can be done by setting both the `unsafe` and `networking` options to true:

```ts
std.process({
  command: std.tpl`${std.tools()}/bin/bash`,
  args: ["-c", 'wget https://example.com -O "$BRIOCHE_OUTPUT"'],
  env: {
    // ...
  },
  unsafe: true,
  networking: true,
});
```

When enabled, the sandbox will run the new process in the host's networking namespace to allow IP connections, and will also copy the host's `/etc/resolv.conf` file into the guest to support proper DNS resolution.

The idea behind `unsafe` is that enabling networking breaks the idea of "hermetic builds", since it depends on an external source. `unsafe` indicates extra care needs to be taken when using this feature, such as by using tools that hash downloaded files. Just like with `unsafe` in Rust, the idea is that users shouldn't normally use unsafe, but will use functions that do, where those functions are written to provide a "safe" wrapper. In the case of Rust, a function like `cargoBuild` could use a process with networking, but would make sure to call cargo with `--locked` to ensure that all downloaded crates are verified against the lockfile.