### PR TITLE
Implement support for global `Brioche.get(...)` function

### DIFF
--- a/crates/brioche/src/project.rs
+++ b/crates/brioche/src/project.rs
@@ -4,11 +4,12 @@ use std::{
     sync::Arc,
 };
 
+use analyze::StaticAnalysis;
 use anyhow::Context as _;
 use relative_path::{RelativePath, RelativePathBuf};
 use tokio::io::AsyncWriteExt as _;
 
-use crate::encoding::TickEncoded;
+use crate::{encoding::TickEncoded, recipe::RecipeHash};
 
 use super::{vfs::FileId, Brioche};
 
@@ -24,7 +25,7 @@ impl Projects {
         &self,
         brioche: &Brioche,
         path: &Path,
-        validate: bool,
+        fully_valid: bool,
     ) -> anyhow::Result<ProjectHash> {
         {
             let projects = self
@@ -32,7 +33,7 @@ impl Projects {
                 .read()
                 .map_err(|_| anyhow::anyhow!("failed to acquire 'projects' lock"))?;
             if let Some(project_hash) = projects.paths_to_projects.get(path) {
-                if validate {
+                if fully_valid {
                     let errors = &projects.project_load_errors[project_hash];
                     if !errors.is_empty() {
                         anyhow::bail!("project load errors: {errors:?}");
@@ -43,10 +44,16 @@ impl Projects {
             }
         }
 
-        let project_hash =
-            load_project(self.clone(), brioche.clone(), path.to_owned(), 100).await?;
+        let project_hash = load_project(
+            self.clone(),
+            brioche.clone(),
+            path.to_owned(),
+            fully_valid,
+            100,
+        )
+        .await?;
 
-        if validate {
+        if fully_valid {
             let projects = self
                 .inner
                 .read()
@@ -449,6 +456,7 @@ async fn load_project(
     projects: Projects,
     brioche: Brioche,
     path: PathBuf,
+    fully_valid: bool,
     depth: usize,
 ) -> anyhow::Result<ProjectHash> {
     let rt = tokio::runtime::Handle::current();
@@ -457,7 +465,8 @@ async fn load_project(
         let local_set = tokio::task::LocalSet::new();
 
         local_set.spawn_local(async move {
-            let result = load_project_inner(&projects, &brioche, &path, false, depth).await;
+            let result =
+                load_project_inner(&projects, &brioche, &path, fully_valid, false, depth).await;
             let _ = tx.send(result).inspect_err(|err| {
                 tracing::warn!("failed to send project load result: {err:?}");
             });
@@ -475,6 +484,7 @@ async fn load_project_inner(
     projects: &Projects,
     brioche: &Brioche,
     path: &Path,
+    fully_valid: bool,
     lockfile_required: bool,
     depth: usize,
 ) -> anyhow::Result<(ProjectHash, Arc<Project>, Vec<LoadProjectError>)> {
@@ -543,6 +553,7 @@ async fn load_project_inner(
                     brioche,
                     name,
                     &dep_path,
+                    fully_valid,
                     lockfile_required,
                     dep_depth,
                     &mut errors,
@@ -561,6 +572,7 @@ async fn load_project_inner(
                     workspace.as_ref(),
                     name,
                     version,
+                    fully_valid,
                     lockfile_required,
                     lockfile.as_ref(),
                     dep_depth,
@@ -603,6 +615,7 @@ async fn load_project_inner(
                         workspace.as_ref(),
                         dep_name,
                         &Version::Any,
+                        fully_valid,
                         lockfile_required,
                         lockfile.as_ref(),
                         dep_depth,
@@ -626,11 +639,29 @@ async fn load_project_inner(
         .values()
         .map(|module| (module.project_subpath.clone(), module.file_id))
         .collect();
+    let mut statics = HashMap::new();
+    for module in project_analysis.local_modules.values() {
+        let mut module_statics = BTreeMap::new();
+        for static_ in &module.statics {
+            // Only resolve the static if we need a fully valid project
+            if fully_valid {
+                let recipe_hash = resolve_static(brioche, &path, module, static_).await?;
+                module_statics.insert(static_.clone(), Some(recipe_hash));
+            } else {
+                module_statics.insert(static_.clone(), None);
+            }
+        }
+
+        if !module_statics.is_empty() {
+            statics.insert(module.project_subpath.clone(), module_statics);
+        }
+    }
 
     let project = Project {
         definition: project_analysis.definition,
         dependencies,
         modules,
+        statics,
     };
     let project = Arc::new(project);
     let project_hash = ProjectHash::from_serializable(&project)?;
@@ -670,17 +701,26 @@ async fn load_project_inner(
     Ok((project_hash, project, errors))
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn try_load_path_dependency_with_errors(
     projects: &Projects,
     brioche: &Brioche,
     name: &str,
     dep_path: &Path,
+    fully_valid: bool,
     lockfile_required: bool,
     dep_depth: usize,
     errors: &mut Vec<LoadProjectError>,
 ) -> Option<ProjectHash> {
-    let result =
-        load_project_inner(projects, brioche, dep_path, lockfile_required, dep_depth).await;
+    let result = load_project_inner(
+        projects,
+        brioche,
+        dep_path,
+        fully_valid,
+        lockfile_required,
+        dep_depth,
+    )
+    .await;
 
     match result {
         Ok((dep_hash, _, dep_errors)) => {
@@ -712,6 +752,7 @@ async fn try_load_registry_dependency_with_errors(
     workspace: Option<&Workspace>,
     name: &str,
     version: &Version,
+    fully_valid: bool,
     lockfile_required: bool,
     lockfile: Option<&Lockfile>,
     dep_depth: usize,
@@ -742,6 +783,7 @@ async fn try_load_registry_dependency_with_errors(
         projects,
         brioche,
         &resolved_dep.local_path,
+        fully_valid,
         resolved_dep.lockfile_required,
         dep_depth,
     )
@@ -1009,12 +1051,50 @@ async fn find_workspace(project_path: &Path) -> anyhow::Result<Option<Workspace>
     Ok(None)
 }
 
+async fn resolve_static(
+    brioche: &Brioche,
+    project_root: &Path,
+    module: &analyze::ModuleAnalysis,
+    static_: &analyze::StaticAnalysis,
+) -> anyhow::Result<RecipeHash> {
+    match static_ {
+        analyze::StaticAnalysis::Get { path } => {
+            let module_path = module.project_subpath.to_path(project_root);
+            let module_dir_path = module_path
+                .parent()
+                .context("no parent path for module path")?;
+            let input_path = module_dir_path.join(path);
+
+            let artifact = crate::input::create_input(
+                brioche,
+                crate::input::InputOptions {
+                    input_path: &input_path,
+                    meta: &Default::default(),
+                    remove_input: false,
+                    resources_dir: None,
+                },
+            )
+            .await?;
+            let artifact_hash = artifact.hash();
+
+            let recipe = crate::recipe::Recipe::from(artifact.value);
+            crate::recipe::save_recipes(brioche, [&recipe]).await?;
+
+            Ok(artifact_hash)
+        }
+    }
+}
+
+#[serde_with::serde_as]
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Project {
     pub definition: ProjectDefinition,
     pub dependencies: HashMap<String, ProjectHash>,
     pub modules: HashMap<RelativePathBuf, FileId>,
+    #[serde_as(as = "HashMap<_, Vec<(_, _)>>")]
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub statics: HashMap<RelativePathBuf, BTreeMap<StaticAnalysis, Option<RecipeHash>>>,
 }
 
 impl Project {

--- a/crates/brioche/src/project.rs
+++ b/crates/brioche/src/project.rs
@@ -1118,6 +1118,27 @@ async fn resolve_static(
                 .context("no parent path for module path")?;
             let input_path = module_dir_path.join(path);
 
+            let canonical_project_root =
+                tokio::fs::canonicalize(project_root)
+                    .await
+                    .with_context(|| {
+                        format!(
+                            "failed to canonicalize project root {}",
+                            project_root.display()
+                        )
+                    })?;
+            let canonical_input_path =
+                tokio::fs::canonicalize(&input_path)
+                    .await
+                    .with_context(|| {
+                        format!("failed to canonicalize input path {}", input_path.display())
+                    })?;
+            anyhow::ensure!(
+                canonical_input_path.starts_with(&canonical_project_root),
+                "input path {path:?} escapes project root {}",
+                project_root.display(),
+            );
+
             let artifact = crate::input::create_input(
                 brioche,
                 crate::input::InputOptions {

--- a/crates/brioche/src/project.rs
+++ b/crates/brioche/src/project.rs
@@ -4,7 +4,7 @@ use std::{
     sync::Arc,
 };
 
-use analyze::StaticAnalysis;
+use analyze::StaticQuery;
 use anyhow::Context as _;
 use relative_path::{PathExt as _, RelativePath, RelativePathBuf};
 use tokio::io::AsyncWriteExt as _;
@@ -288,7 +288,7 @@ impl Projects {
     pub fn get_static(
         &self,
         specifier: &super::script::specifier::BriocheModuleSpecifier,
-        static_: &StaticAnalysis,
+        static_: &StaticQuery,
     ) -> anyhow::Result<Option<RecipeHash>> {
         let projects = self
             .inner
@@ -465,7 +465,7 @@ impl ProjectsInner {
     pub fn get_static(
         &self,
         specifier: &super::script::specifier::BriocheModuleSpecifier,
-        static_: &StaticAnalysis,
+        static_: &StaticQuery,
     ) -> anyhow::Result<Option<RecipeHash>> {
         let path = match specifier {
             super::script::specifier::BriocheModuleSpecifier::File { path } => path,
@@ -1108,10 +1108,10 @@ async fn resolve_static(
     brioche: &Brioche,
     project_root: &Path,
     module: &analyze::ModuleAnalysis,
-    static_: &analyze::StaticAnalysis,
+    static_: &analyze::StaticQuery,
 ) -> anyhow::Result<RecipeHash> {
     match static_ {
-        analyze::StaticAnalysis::Get { path } => {
+        analyze::StaticQuery::Get { path } => {
             let module_path = module.project_subpath.to_path(project_root);
             let module_dir_path = module_path
                 .parent()
@@ -1147,7 +1147,7 @@ pub struct Project {
     pub modules: HashMap<RelativePathBuf, FileId>,
     #[serde_as(as = "HashMap<_, Vec<(_, _)>>")]
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    pub statics: HashMap<RelativePathBuf, BTreeMap<StaticAnalysis, Option<RecipeHash>>>,
+    pub statics: HashMap<RelativePathBuf, BTreeMap<StaticQuery, Option<RecipeHash>>>,
 }
 
 impl Project {

--- a/crates/brioche/src/project.rs
+++ b/crates/brioche/src/project.rs
@@ -340,7 +340,7 @@ impl ProjectsInner {
     fn project(&self, project_hash: ProjectHash) -> anyhow::Result<&Arc<Project>> {
         self.projects
             .get(&project_hash)
-            .with_context(|| format!("project not found for hash {}", project_hash))
+            .with_context(|| format!("project not found for hash {project_hash}"))
     }
 
     fn local_paths(&self, project_hash: ProjectHash) -> Option<impl Iterator<Item = &Path> + '_> {
@@ -381,12 +381,12 @@ impl ProjectsInner {
         let project = self
             .projects
             .get(&project_hash)
-            .with_context(|| format!("project not found for hash {}", project_hash))?;
+            .with_context(|| format!("project not found for hash {project_hash}"))?;
         let project_root = self
             .projects_to_paths
             .get(&project_hash)
             .and_then(|paths| paths.first())
-            .with_context(|| format!("project root not found for hash {}", project_hash))?;
+            .with_context(|| format!("project root not found for hash {project_hash}"))?;
 
         let root_relative_path = RelativePath::new("project.bri");
         anyhow::ensure!(
@@ -420,19 +420,18 @@ impl ProjectsInner {
         let project = self
             .projects
             .get(&project_hash)
-            .with_context(|| format!("project not found for hash {}", project_hash))?;
+            .with_context(|| format!("project not found for hash {project_hash}"))?;
         let project_root = self
             .projects_to_paths
             .get(&project_hash)
             .and_then(|paths| paths.first())
-            .with_context(|| format!("project root not found for hash {}", project_hash))?;
+            .with_context(|| format!("project root not found for hash {project_hash}"))?;
 
         let paths = project.modules.keys().map(move |module_path| {
             let path = module_path.to_logical_path(project_root);
             assert!(
                 path.starts_with(project_root),
-                "module path {} escapes project root {}",
-                module_path,
+                "module path {module_path} escapes project root {}",
                 project_root.display()
             );
             path

--- a/crates/brioche/src/project/analyze.rs
+++ b/crates/brioche/src/project/analyze.rs
@@ -36,7 +36,9 @@ pub enum ImportAnalysis {
     LocalModule(BriocheModuleSpecifier),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "type")]
+#[serde(rename_all = "snake_case")]
 pub enum StaticAnalysis {
     Get { path: String },
 }

--- a/crates/brioche/src/project/analyze.rs
+++ b/crates/brioche/src/project/analyze.rs
@@ -27,7 +27,7 @@ pub struct ModuleAnalysis {
     pub project_subpath: RelativePathBuf,
     pub specifier: BriocheModuleSpecifier,
     pub imports: HashMap<BriocheImportSpecifier, ImportAnalysis>,
-    pub statics: BTreeSet<StaticAnalysis>,
+    pub statics: BTreeSet<StaticQuery>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -39,7 +39,7 @@ pub enum ImportAnalysis {
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize)]
 #[serde(tag = "type")]
 #[serde(rename_all = "snake_case")]
-pub enum StaticAnalysis {
+pub enum StaticQuery {
     Get { path: String },
 }
 
@@ -327,7 +327,7 @@ where
 pub fn find_statics<'a, D>(
     module: &'a biome_js_syntax::JsModule,
     mut display_location: impl FnMut(usize) -> D + 'a,
-) -> impl Iterator<Item = anyhow::Result<StaticAnalysis>> + 'a
+) -> impl Iterator<Item = anyhow::Result<StaticQuery>> + 'a
 where
     D: std::fmt::Display,
 {
@@ -410,7 +410,7 @@ where
                 }
             };
 
-            Ok(Some(StaticAnalysis::Get {
+            Ok(Some(StaticQuery::Get {
                 path: get_path.to_string(),
             }))
         })

--- a/crates/brioche/src/project/analyze.rs
+++ b/crates/brioche/src/project/analyze.rs
@@ -1,4 +1,7 @@
-use std::{collections::HashMap, path::Path};
+use std::{
+    collections::{BTreeSet, HashMap},
+    path::Path,
+};
 
 use anyhow::Context as _;
 use biome_rowan::{AstNode as _, AstNodeList as _, AstSeparatedList as _};
@@ -24,12 +27,18 @@ pub struct ModuleAnalysis {
     pub project_subpath: RelativePathBuf,
     pub specifier: BriocheModuleSpecifier,
     pub imports: HashMap<BriocheImportSpecifier, ImportAnalysis>,
+    pub statics: BTreeSet<StaticAnalysis>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ImportAnalysis {
     ExternalProject(String),
     LocalModule(BriocheModuleSpecifier),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum StaticAnalysis {
+    Get { path: String },
 }
 
 pub async fn analyze_project(vfs: &Vfs, project_path: &Path) -> anyhow::Result<ProjectAnalysis> {
@@ -169,6 +178,7 @@ pub async fn analyze_module(
                 project_subpath,
                 specifier: module_specifier.clone(),
                 imports: HashMap::new(),
+                statics: BTreeSet::new(),
             });
 
             contents
@@ -198,12 +208,14 @@ pub async fn analyze_module(
         }
     };
 
-    let mut imports = HashMap::new();
-
-    let import_specifiers = find_imports(module, |offset| {
+    let display_location = |offset| {
         let line = contents[..offset].lines().count();
         format!("{module_specifier}:{line}")
-    });
+    };
+
+    let mut imports = HashMap::new();
+
+    let import_specifiers = find_imports(module, display_location);
     for import_specifier in import_specifiers {
         let import_specifier = import_specifier?;
 
@@ -236,10 +248,14 @@ pub async fn analyze_module(
         imports.insert(import_specifier, import_analysis);
     }
 
+    let statics =
+        find_statics(module, display_location).collect::<anyhow::Result<BTreeSet<_>>>()?;
+
     let local_module = local_modules
         .get_mut(&module_specifier)
         .expect("module not found in local_modules after analyzing imports");
     local_module.imports = imports;
+    local_module.statics = statics;
 
     Ok(module_specifier)
 }
@@ -302,6 +318,99 @@ where
                 .parse()
                 .with_context(|| format!("{location}: invalid import specifier"))?;
             Ok(Some(import_specifier))
+        })
+        .filter_map(|result| result.transpose())
+}
+
+pub fn find_statics<'a, D>(
+    module: &'a biome_js_syntax::JsModule,
+    mut display_location: impl FnMut(usize) -> D + 'a,
+) -> impl Iterator<Item = anyhow::Result<StaticAnalysis>> + 'a
+where
+    D: std::fmt::Display,
+{
+    module
+        .syntax()
+        .descendants()
+        .map(move |node| {
+            // Get a call expression (e.g. `Brioche.get(...)`)
+            let Some(call_expr) = biome_js_syntax::JsCallExpression::cast(node) else {
+                return Ok(None);
+            };
+
+            let Ok(callee) = call_expr.callee() else {
+                return Ok(None);
+            };
+            let Some(callee) = callee.as_js_static_member_expression() else {
+                return Ok(None);
+            };
+
+            // Filter down to call expressions accessing a member from `Brioche`
+            let Ok(callee_object) = callee.object() else {
+                return Ok(None);
+            };
+            let Some(callee_object) = callee_object.as_js_identifier_expression() else {
+                return Ok(None);
+            };
+            let Ok(callee_object_name) = callee_object.name() else {
+                return Ok(None);
+            };
+            if !callee_object_name.has_name("Brioche") {
+                return Ok(None);
+            }
+
+            // Filter down to calls to the `.get()` method
+            let Ok(callee_member) = callee.member() else {
+                return Ok(None);
+            };
+            let Some(callee_member) = callee_member.as_js_name() else {
+                return Ok(None);
+            };
+            let Ok(callee_member_text) = callee_member.value_token() else {
+                return Ok(None);
+            };
+            let callee_member_text = callee_member_text.text_trimmed();
+
+            if callee_member_text != "get" {
+                return Ok(None);
+            }
+
+            let location = display_location(call_expr.syntax().text_range().start().into());
+
+            // Get the arguments
+            let args = call_expr.arguments()?.args();
+            let args = args
+                .iter()
+                .map(|arg| {
+                    let arg = arg?;
+                    let arg = arg
+                        .as_any_js_expression()
+                        .context("spread arguments are not supported")?;
+                    let arg = arg
+                        .as_any_js_literal_expression()
+                        .context("argument must be a string literal")?;
+                    let arg = arg
+                        .as_js_string_literal_expression()
+                        .context("argument must be a string literal")?;
+                    let arg = arg
+                        .inner_string_text()
+                        .context("invalid string literal argument")?;
+
+                    anyhow::Ok(arg)
+                })
+                .map(|arg| arg.with_context(|| format!("{location}: invalid arg to Brioche.get")))
+                .collect::<anyhow::Result<Vec<_>>>()?;
+
+            let get_path = match &*args {
+                [path] => path.text(),
+                _ => {
+                    anyhow::bail!("{location}: Brioche.get() must take exactly one argument",);
+                }
+            };
+
+            Ok(Some(StaticAnalysis::Get {
+                path: get_path.to_string(),
+            }))
         })
         .filter_map(|result| result.transpose())
 }

--- a/crates/brioche/src/script.rs
+++ b/crates/brioche/src/script.rs
@@ -9,7 +9,7 @@ use anyhow::Context as _;
 use deno_core::OpState;
 use specifier::BriocheModuleSpecifier;
 
-use crate::{bake::BakeScope, project::analyze::StaticAnalysis};
+use crate::{bake::BakeScope, project::analyze::StaticQuery};
 
 use super::{
     blob::BlobHash,
@@ -235,7 +235,7 @@ pub async fn op_brioche_read_blob(
 pub async fn op_brioche_get_static(
     state: Rc<RefCell<OpState>>,
     url: String,
-    static_: StaticAnalysis,
+    static_: StaticQuery,
 ) -> anyhow::Result<Recipe> {
     let (brioche, projects) = {
         let state = state.try_borrow()?;
@@ -255,7 +255,7 @@ pub async fn op_brioche_get_static(
     let recipe_hash = projects
         .get_static(&specifier, &static_)?
         .with_context(|| match static_ {
-            StaticAnalysis::Get { path } => {
+            StaticQuery::Get { path } => {
                 format!("failed to resolve Brioche.get({path:?}) from {specifier}, was the path passed in as a string literal?")
             }
         })?;

--- a/crates/brioche/src/script.rs
+++ b/crates/brioche/src/script.rs
@@ -9,7 +9,7 @@ use anyhow::Context as _;
 use deno_core::OpState;
 use specifier::BriocheModuleSpecifier;
 
-use crate::bake::BakeScope;
+use crate::{bake::BakeScope, project::analyze::StaticAnalysis};
 
 use super::{
     blob::BlobHash,
@@ -150,13 +150,16 @@ deno_core::extension!(brioche_rt,
         op_brioche_bake_all,
         op_brioche_create_proxy,
         op_brioche_read_blob,
+        op_brioche_get_static,
     ],
     options = {
         brioche: Brioche,
+        projects: Projects,
         bake_scope: BakeScope,
     },
     state = |state, options| {
         state.put(options.brioche);
+        state.put(options.projects);
         state.put(options.bake_scope);
     },
 );
@@ -226,4 +229,36 @@ pub async fn op_brioche_read_blob(
         .with_context(|| format!("failed to read blob {blob_hash}"))?;
 
     Ok(crate::encoding::TickEncode(bytes))
+}
+
+#[deno_core::op]
+pub async fn op_brioche_get_static(
+    state: Rc<RefCell<OpState>>,
+    url: String,
+    static_: StaticAnalysis,
+) -> anyhow::Result<Recipe> {
+    let (brioche, projects) = {
+        let state = state.try_borrow()?;
+        let brioche = state
+            .try_borrow::<Brioche>()
+            .context("failed to get brioche instance")?
+            .clone();
+        let projects = state
+            .try_borrow::<Projects>()
+            .context("failed to get projects instance")?
+            .clone();
+        (brioche, projects)
+    };
+
+    let specifier: BriocheModuleSpecifier = url.parse()?;
+
+    let recipe_hash = projects
+        .get_static(&specifier, &static_)?
+        .with_context(|| match static_ {
+            StaticAnalysis::Get { path } => {
+                format!("failed to resolve Brioche.get({path:?}) from {specifier}, was the path passed in as a string literal?")
+            }
+        })?;
+    let recipe = crate::recipe::get_recipe(&brioche, recipe_hash).await?;
+    Ok(recipe)
 }

--- a/crates/brioche/src/script/evaluate.rs
+++ b/crates/brioche/src/script/evaluate.rs
@@ -27,7 +27,7 @@ pub async fn evaluate(
         module_loader: Some(Rc::new(module_loader.clone())),
         source_map_getter: Some(Box::new(module_loader.clone())),
         extensions: vec![
-            super::brioche_rt::init_ops(brioche.clone(), bake_scope),
+            super::brioche_rt::init_ops(brioche.clone(), projects.clone(), bake_scope),
             super::js::brioche_js::init_ops(),
         ],
         ..Default::default()

--- a/crates/brioche/tests/script_eval.rs
+++ b/crates/brioche/tests/script_eval.rs
@@ -1,4 +1,3 @@
-use assert_matches::assert_matches;
 use brioche::script::evaluate::evaluate;
 
 mod brioche_test;

--- a/crates/brioche/tests/script_eval.rs
+++ b/crates/brioche/tests/script_eval.rs
@@ -1,3 +1,4 @@
+use assert_matches::assert_matches;
 use brioche::script::evaluate::evaluate;
 
 mod brioche_test;

--- a/crates/brioche/tests/script_project_analyze.rs
+++ b/crates/brioche/tests/script_project_analyze.rs
@@ -3,7 +3,7 @@ use std::collections::{BTreeSet, HashMap};
 use assert_matches::assert_matches;
 use brioche::{
     project::{
-        analyze::{analyze_project, ImportAnalysis, ProjectAnalysis, StaticAnalysis},
+        analyze::{analyze_project, ImportAnalysis, ProjectAnalysis, StaticQuery},
         DependencyDefinition, ProjectDefinition, Version,
     },
     script::specifier::{BriocheImportSpecifier, BriocheModuleSpecifier},
@@ -309,10 +309,10 @@ async fn test_analyze_static_brioche_get() -> anyhow::Result<()> {
     assert_eq!(
         root_module.statics,
         BTreeSet::from_iter([
-            StaticAnalysis::Get {
+            StaticQuery::Get {
                 path: "foo".to_string()
             },
-            StaticAnalysis::Get {
+            StaticQuery::Get {
                 path: "bar".to_string()
             },
         ]),

--- a/crates/brioche/tests/script_project_analyze.rs
+++ b/crates/brioche/tests/script_project_analyze.rs
@@ -1,9 +1,9 @@
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 
 use assert_matches::assert_matches;
 use brioche::{
     project::{
-        analyze::{analyze_project, ImportAnalysis, ProjectAnalysis},
+        analyze::{analyze_project, ImportAnalysis, ProjectAnalysis, StaticAnalysis},
         DependencyDefinition, ProjectDefinition, Version,
     },
     script::specifier::{BriocheImportSpecifier, BriocheModuleSpecifier},
@@ -280,6 +280,67 @@ async fn test_analyze_external_dep() -> anyhow::Result<()> {
         foo_module,
         &ImportAnalysis::ExternalProject("foo".to_string())
     );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_analyze_static_brioche_get() -> anyhow::Result<()> {
+    let (brioche, context) = brioche_test::brioche_test().await;
+
+    let project_dir = context.mkdir("myproject").await;
+    context
+        .write_file(
+            "myproject/project.bri",
+            r#"
+                Brioche.get("foo");
+
+                export function () {
+                    return Brioche.get("bar");
+                }
+            "#,
+        )
+        .await;
+
+    let project = analyze_project(&brioche.vfs, &project_dir).await?;
+
+    let root_module = &project.local_modules[&project.root_module];
+
+    assert_eq!(
+        root_module.statics,
+        BTreeSet::from_iter([
+            StaticAnalysis::Get {
+                path: "foo".to_string()
+            },
+            StaticAnalysis::Get {
+                path: "bar".to_string()
+            },
+        ]),
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_analyze_static_brioche_get_invalid() -> anyhow::Result<()> {
+    let (brioche, context) = brioche_test::brioche_test().await;
+
+    let project_dir = context.mkdir("myproject").await;
+    context
+        .write_file(
+            "myproject/project.bri",
+            r#"
+                const x = Brioche.get(`${123}`);
+
+                export function () {
+                    return x;
+                }
+            "#,
+        )
+        .await;
+
+    let result = analyze_project(&brioche.vfs, &project_dir).await;
+    assert_matches!(result, Err(_));
 
     Ok(())
 }


### PR DESCRIPTION
This PR implements support for `Brioche.get`, which creates a recipe by reading a file or directory from the current project. Or, more specifically, it makes three changes needed to implement this function:

1. Update project analysis to find invocations of `Brioche.get("...")` and add them to the module analysis. This is called a "static", because it's a special invocation that's recognized and parsed statically (trying to call it with a non-string literal will fail). There will be other kinds of statics besides `Brioche.get` in the future.
2. Update project loader to load statics: in this case, we use `create_input` to create an artifact from the file path, then add the artifact hash to the `Project` type
3. Add new `op_brioche_get_static` Deno op. It takes a module URL and a JSON representation of the static (e.g. `{type: "get", path: "foo"}`) and returns a JSON serialization of the static's recipe.

The implementation for this function doesn't need to live in Brioche itself, but can live in any package that provides a proper global implementation (`std` will provide the standard implementation)