### PR TITLE
Replace `Brioche.get` with `Brioche.includeFile` / `Brioche.includeDirectory`

### DIFF
--- a/crates/brioche/src/script.rs
+++ b/crates/brioche/src/script.rs
@@ -9,7 +9,10 @@ use anyhow::Context as _;
 use deno_core::OpState;
 use specifier::BriocheModuleSpecifier;
 
-use crate::{bake::BakeScope, project::analyze::StaticQuery};
+use crate::{
+    bake::BakeScope,
+    project::analyze::{StaticInclude, StaticQuery},
+};
 
 use super::{
     blob::BlobHash,
@@ -255,8 +258,11 @@ pub async fn op_brioche_get_static(
     let recipe_hash = projects
         .get_static(&specifier, &static_)?
         .with_context(|| match static_ {
-            StaticQuery::Get { path } => {
-                format!("failed to resolve Brioche.get({path:?}) from {specifier}, was the path passed in as a string literal?")
+            StaticQuery::Include(StaticInclude::File { path }) => {
+                format!("failed to resolve Brioche.includeFile({path:?}) from {specifier}, was the path passed in as a string literal?")
+            }
+            StaticQuery::Include(StaticInclude::Directory { path }) => {
+                format!("failed to resolve Brioche.includeDirectory({path:?}) from {specifier}, was the path passed in as a string literal?")
             }
         })?;
     let recipe = crate::recipe::get_recipe(&brioche, recipe_hash).await?;


### PR DESCRIPTION
This PR follows up on #34, replacing the `Brioche.get(...)` function two functions instead: `Brioche.includeFile` and `Brioche.includeDirectory`. I wasn't really happy with the term "get" for this functionality. I also ended up splitting it into two functions so that the TypeScript definitions can return more specific types (useful for e.g. the `workDir` option in `std.process`)

The semantics of these new functions are exactly the same as the semantics of `Brioche.get` from #34, except the type of artifact is validated as either a `File` or `Directory` artifact.