### PR TITLE
Overhaul project publishing

### DIFF
--- a/crates/brioche/src/lib.rs
+++ b/crates/brioche/src/lib.rs
@@ -214,7 +214,7 @@ impl BriocheBuilder {
         // even if the overall build fails.
         let sync_enabled = self.sync;
         tokio::spawn(async move {
-            let mut sync_results = sync::SyncResults::default();
+            let mut sync_results = sync::SyncBakesResults::default();
 
             while let Some(sync_message) = sync_rx.recv().await {
                 match sync_message {
@@ -275,7 +275,7 @@ pub enum SyncMessage {
         artifact: recipe::Artifact,
     },
     Flush {
-        completed: tokio::sync::oneshot::Sender<sync::SyncResults>,
+        completed: tokio::sync::oneshot::Sender<sync::SyncBakesResults>,
     },
 }
 

--- a/crates/brioche/src/lib.rs
+++ b/crates/brioche/src/lib.rs
@@ -18,6 +18,7 @@ pub mod input;
 pub mod output;
 pub mod platform;
 pub mod project;
+pub mod publish;
 pub mod recipe;
 pub mod references;
 pub mod registry;

--- a/crates/brioche/src/main.rs
+++ b/crates/brioche/src/main.rs
@@ -1,10 +1,9 @@
-use std::{path::PathBuf, process::ExitCode};
+use std::{collections::HashMap, path::PathBuf, process::ExitCode, sync::Arc};
 
 use anyhow::Context as _;
 use brioche::{fs_utils, reporter::ConsoleReporterKind, sandbox::SandboxExecutionConfig};
 use clap::Parser;
 use human_repr::HumanDuration;
-use joinery::JoinableIterator as _;
 use tracing::Instrument;
 
 #[derive(Debug, Parser)]
@@ -240,7 +239,7 @@ async fn build(args: BuildArgs) -> anyhow::Result<ExitCode> {
                     completed: sync_complete_tx,
                 })
                 .await?;
-            let brioche::sync::SyncResults {
+            let brioche::sync::SyncBakesResults {
                 num_new_blobs,
                 num_new_recipes,
                 num_new_bakes,
@@ -569,23 +568,24 @@ async fn publish(args: PublishArgs) -> anyhow::Result<ExitCode> {
         }
     }
 
-    let response = brioche::publish::publish_project(&brioche, &projects, project_hash).await?;
-
     guard.shutdown_console().await;
 
-    if response.is_no_op() {
+    let response =
+        brioche::publish::publish_project(&brioche, &projects, project_hash, true).await?;
+
+    if response.tags.is_empty() {
         println!("Project already up to date: {} {}", name, version);
     } else {
         println!("🚀 Published project {} {}", name, version);
-        println!("Project hash: {}", project_hash);
-        println!("Uploaded files: {}", response.new_files);
-        println!("Uploaded projects: {}", response.new_projects);
-
-        if response.tags.is_empty() {
-            let tags = response.tags.iter().map(|tag| &tag.name);
-            println!("Updated tags: {}", tags.join_with(", "));
-        } else {
-            println!("No updated tags");
+        println!();
+        println!("Updated tags:");
+        for tag in &response.tags {
+            let status = if tag.previous_hash.is_some() {
+                "updated"
+            } else {
+                "new"
+            };
+            println!("  {} {} ({status})", tag.name, tag.tag);
         }
     }
 
@@ -651,19 +651,39 @@ struct ExportProjectArgs {
 }
 
 async fn export_project(args: ExportProjectArgs) -> anyhow::Result<()> {
+    #[derive(Debug, serde::Serialize, serde::Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct ExportedProject {
+        project_hash: brioche::project::ProjectHash,
+        project: Arc<brioche::project::Project>,
+        referenced_projects: HashMap<brioche::project::ProjectHash, Arc<brioche::project::Project>>,
+    }
+
     let (reporter, mut guard) =
         brioche::reporter::start_console_reporter(ConsoleReporterKind::Plain)?;
 
     let brioche = brioche::BriocheBuilder::new(reporter).build().await?;
     let projects = brioche::project::Projects::default();
     let project_hash = projects.load(&brioche, &args.project, true).await?;
-    let project_listing = projects
-        .export_listing(&brioche, project_hash)
-        .context("failed to export listing")?;
+    let project = projects.project(project_hash)?;
+    let mut project_references = brioche::references::ProjectReferences::default();
+    brioche::references::project_references(
+        &brioche,
+        &projects,
+        &mut project_references,
+        [project_hash],
+    )
+    .await?;
+
+    let exported = ExportedProject {
+        project,
+        project_hash,
+        referenced_projects: project_references.projects.clone(),
+    };
+    let serialized = serde_json::to_string_pretty(&exported)?;
 
     guard.shutdown_console().await;
 
-    let serialized = serde_json::to_string_pretty(&project_listing)?;
     println!("{}", serialized);
     Ok(())
 }

--- a/crates/brioche/src/main.rs
+++ b/crates/brioche/src/main.rs
@@ -569,11 +569,7 @@ async fn publish(args: PublishArgs) -> anyhow::Result<ExitCode> {
         }
     }
 
-    let project_listing = projects.export_listing(&brioche, project_hash)?;
-    let response = brioche
-        .registry_client
-        .publish_project(&project_listing)
-        .await?;
+    let response = brioche::publish::publish_project(&brioche, &projects, project_hash).await?;
 
     guard.shutdown_console().await;
 

--- a/crates/brioche/src/publish.rs
+++ b/crates/brioche/src/publish.rs
@@ -1,0 +1,19 @@
+use crate::{
+    project::{ProjectHash, Projects},
+    registry::PublishProjectResponse,
+    Brioche,
+};
+
+pub async fn publish_project(
+    brioche: &Brioche,
+    projects: &Projects,
+    project_hash: ProjectHash,
+) -> anyhow::Result<PublishProjectResponse> {
+    let project_listing = projects.export_listing(brioche, project_hash)?;
+    let response = brioche
+        .registry_client
+        .publish_project(&project_listing)
+        .await?;
+
+    Ok(response)
+}

--- a/crates/brioche/src/publish.rs
+++ b/crates/brioche/src/publish.rs
@@ -1,6 +1,9 @@
+use anyhow::Context as _;
+
 use crate::{
     project::{ProjectHash, Projects},
-    registry::PublishProjectResponse,
+    references::ProjectReferences,
+    registry::CreateProjectTagsResponse,
     Brioche,
 };
 
@@ -8,11 +11,42 @@ pub async fn publish_project(
     brioche: &Brioche,
     projects: &Projects,
     project_hash: ProjectHash,
-) -> anyhow::Result<PublishProjectResponse> {
-    let project_listing = projects.export_listing(brioche, project_hash)?;
+    verbose: bool,
+) -> anyhow::Result<CreateProjectTagsResponse> {
+    // Validate the project has a name to publish with
+    let project = projects
+        .project(project_hash)
+        .context("project not found")?;
+    let project_name = project.definition.name.clone().context("project must have a name to be published (does the root module have `export const project = { ... }`?")?;
+
+    // Get all project references (project dependencies / blobs / recipes)
+    let mut project_references = ProjectReferences::default();
+    crate::references::project_references(
+        brioche,
+        projects,
+        &mut project_references,
+        [project_hash],
+    )
+    .await?;
+
+    // Sync the project and all references
+    crate::sync::sync_project_references(brioche, &project_references, verbose).await?;
+
+    // Push new project tags ("latest" plus the version number)
+    let project_tags = ["latest"]
+        .into_iter()
+        .chain(project.definition.version.as_deref());
+    let project_tags = project_tags
+        .map(|tag| crate::registry::CreateProjectTagsRequestTag {
+            project_name: project_name.clone(),
+            tag: tag.to_string(),
+            project_hash,
+        })
+        .collect();
+    let project_tags_request = crate::registry::CreateProjectTagsRequest { tags: project_tags };
     let response = brioche
         .registry_client
-        .publish_project(&project_listing)
+        .create_project_tags(&project_tags_request)
         .await?;
 
     Ok(response)

--- a/crates/brioche/tests/project_load.rs
+++ b/crates/brioche/tests/project_load.rs
@@ -525,6 +525,72 @@ async fn test_project_load_with_remote_registry_dep() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+async fn test_project_load_with_remote_registry_dep_with_brioche_include() -> anyhow::Result<()> {
+    let (brioche, mut context) = brioche_test::brioche_test().await;
+
+    let foo_hash = context
+        .remote_registry_project(|path| async move {
+            tokio::fs::write(path.join("fizz"), "fizz!").await.unwrap();
+            tokio::fs::create_dir_all(path.join("buzz")).await.unwrap();
+            tokio::fs::write(path.join("buzz/hello.txt"), "buzz!")
+                .await
+                .unwrap();
+            tokio::fs::write(
+                path.join("project.bri"),
+                r#"
+                    export const project = {
+                        name: "foo",
+                    };
+
+                    export const foo = Brioche.includeFile("fizz");
+                    export const bar = Brioche.includeDirectory("buzz");
+                "#,
+            )
+            .await
+            .unwrap();
+        })
+        .await;
+    let mock_foo_latest = context
+        .mock_registry_publish_tag("foo", "latest", foo_hash)
+        .create_async()
+        .await;
+
+    let project_dir = context.mkdir("myproject").await;
+    context
+        .write_file(
+            "myproject/project.bri",
+            r#"
+                export const project = {
+                    dependencies: {
+                        foo: "*",
+                    },
+                };
+            "#,
+        )
+        .await;
+
+    let (projects, project_hash) = brioche_test::load_project(&brioche, &project_dir).await?;
+    let project = projects.project(project_hash).unwrap();
+    assert!(projects
+        .local_paths(project_hash)
+        .unwrap()
+        .contains(&project_dir));
+
+    let foo_dep_hash = project.dependency_hash("foo").unwrap();
+    let foo_dep = projects.project(foo_dep_hash).unwrap();
+    let foo_path = brioche.home.join("projects").join(foo_dep_hash.to_string());
+    assert!(projects
+        .local_paths(foo_dep_hash)
+        .unwrap()
+        .contains(&foo_path));
+    assert_eq!(foo_dep.dependencies().count(), 0);
+
+    mock_foo_latest.assert_async().await;
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_project_load_with_remote_workspace_registry_dep() -> anyhow::Result<()> {
     let (brioche, mut context) = brioche_test::brioche_test().await;
 

--- a/crates/brioche/tests/project_load.rs
+++ b/crates/brioche/tests/project_load.rs
@@ -570,8 +570,7 @@ async fn test_project_load_with_remote_workspace_registry_dep() -> anyhow::Resul
 
     assert_eq!(bar_project.dependencies.get("foo"), Some(&foo_hash));
 
-    let bar_listing = projects.export_listing(&brioche, bar_hash)?;
-    let bar_mocks = context.mock_registry_listing(&bar_listing);
+    let bar_mocks = context.mock_registry_listing(&projects, bar_hash).await;
     for mock in bar_mocks {
         mock.create_async().await;
     }


### PR DESCRIPTION
This PR massively overhauls project publishing: instead of building and uploading a massive JSON representation of all published projects, it now uploads blobs / recipes, then the project JSON, then publishes project tags, in discrete steps. This new implementation also handles the statics included in projects (introduced in #34 / #35).

As part of this change, fetching a project from the registry also now correctly fetches statics for the project.