### PR TITLE
Fix imports getting excluded when they shouldn't be

### DIFF
--- a/crates/brioche/src/script.rs
+++ b/crates/brioche/src/script.rs
@@ -97,6 +97,7 @@ impl deno_core::ModuleLoader for BriocheModuleLoader {
             let transpiled = parsed.transpile(&deno_ast::EmitOptions {
                 source_map: true,
                 inline_source_map: false,
+                imports_not_used_as_values: deno_ast::ImportsNotUsedAsValues::Preserve,
                 ..deno_ast::EmitOptions::default()
             })?;
 


### PR DESCRIPTION
This PR fixes a bug related to how imports are handled when transpiling TypeScript to JavaScript. Consider this Brioche project:

```ts
import * as std from "std";

export default async (): Promise<std.Recipe> => {
  return Brioche.includeFile("hello.txt");
};
```

When transpiled, the `import "std";` line would get completely dropped because `std` is imported as a value, but is only used at the type level. In this case, this would break global functions like `Brioche.includeFile` and `console.log`, which are supplied by `std`.

The fix is to tweak the transpiler options so imports never get excluded, even if they are only used at the type level.