### PR TITLE
Implement `Brioche.glob` global function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -754,10 +754,12 @@ dependencies = [
  "directories",
  "fs_extra",
  "futures",
+ "globset",
  "hex",
  "human-repr",
  "joinery",
  "json-canon",
+ "lazy_format",
  "libmount",
  "mockito",
  "nix 0.27.1",
@@ -797,6 +799,7 @@ dependencies = [
  "unshare",
  "url",
  "urlencoding",
+ "walkdir",
  "zstd",
 ]
 
@@ -2375,6 +2378,12 @@ dependencies = [
  "regex",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "lazy_format"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e479e99b287d578ed5f6cd4c92cdf48db219088adb9c5b14f7c155b71dfba792"
 
 [[package]]
 name = "lazy_static"
@@ -6045,9 +6054,9 @@ dependencies = [
 
 [[package]]
 name = "walkdir"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",

--- a/crates/brioche/Cargo.toml
+++ b/crates/brioche/Cargo.toml
@@ -26,10 +26,12 @@ deno_core = "0.201.0"
 directories = "5.0.1"
 fs_extra = "1.3.0"
 futures = "0.3.29"
+globset = "0.4.14"
 hex = "0.4.3"
 human-repr = "1.1.0"
 joinery = "3.1.0"
 json-canon = "0.1.3"
+lazy_format = "2.0.3"
 nix = { version = "0.27.1", features = ["user"] }
 opentelemetry = "0.21.0"
 opentelemetry-http = { version = "0.10.0", features = ["reqwest"] }
@@ -64,6 +66,7 @@ tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json", "tr
 ulid = "1.1.0"
 url = { version = "2.5.0", features = ["serde"] }
 urlencoding = "2.1.3"
+walkdir = "2.5.0"
 
 [dev-dependencies]
 assert_matches = "1.5.0"

--- a/crates/brioche/src/script.rs
+++ b/crates/brioche/src/script.rs
@@ -7,6 +7,7 @@ use std::{
 
 use anyhow::Context as _;
 use deno_core::OpState;
+use joinery::JoinableIterator as _;
 use specifier::BriocheModuleSpecifier;
 
 use crate::{
@@ -264,6 +265,10 @@ pub async fn op_brioche_get_static(
             }
             StaticQuery::Include(StaticInclude::Directory { path }) => {
                 format!("failed to resolve Brioche.includeDirectory({path:?}) from {specifier}, was the path passed in as a string literal?")
+            }
+            StaticQuery::Glob { patterns } => {
+                let patterns = patterns.iter().map(|pattern| lazy_format::lazy_format!("{pattern:?}")).join_with(", ");
+                format!("failed to resolve Brioche.glob({patterns}) from {specifier}, were the patterns passed in as string literals?")
             }
         })?;
     let recipe = crate::recipe::get_recipe(&brioche, recipe_hash).await?;

--- a/crates/brioche/tests/project_load.rs
+++ b/crates/brioche/tests/project_load.rs
@@ -591,6 +591,80 @@ async fn test_project_load_with_remote_registry_dep_with_brioche_include() -> an
 }
 
 #[tokio::test]
+async fn test_project_load_with_remote_registry_dep_with_brioche_glob() -> anyhow::Result<()> {
+    let (brioche, mut context) = brioche_test::brioche_test().await;
+
+    let foo_hash = context
+        .remote_registry_project(|path| async move {
+            tokio::fs::create_dir_all(path.join("fizz")).await.unwrap();
+            tokio::fs::write(path.join("fizz/hello.md"), "fizz!")
+                .await
+                .unwrap();
+            tokio::fs::create_dir_all(path.join("buzz")).await.unwrap();
+            tokio::fs::write(path.join("buzz/hello.txt"), "buzz!")
+                .await
+                .unwrap();
+            tokio::fs::write(path.join("buzz/hello.secret"), "buzz!")
+                .await
+                .unwrap();
+            tokio::fs::write(
+                path.join("project.bri"),
+                r#"
+                    export const project = {
+                        name: "foo",
+                    };
+
+                    export const globbed = Brioche.glob("fizz", "**/*.txt");
+                "#,
+            )
+            .await
+            .unwrap();
+        })
+        .await;
+    let mock_foo_latest = context
+        .mock_registry_publish_tag("foo", "latest", foo_hash)
+        .create_async()
+        .await;
+
+    let project_dir = context.mkdir("myproject").await;
+    context
+        .write_file(
+            "myproject/project.bri",
+            r#"
+                export const project = {
+                    dependencies: {
+                        foo: "*",
+                    },
+                };
+            "#,
+        )
+        .await;
+
+    let (projects, project_hash) = brioche_test::load_project(&brioche, &project_dir).await?;
+    let project = projects.project(project_hash).unwrap();
+    assert!(projects
+        .local_paths(project_hash)
+        .unwrap()
+        .contains(&project_dir));
+
+    let foo_dep_hash = project.dependency_hash("foo").unwrap();
+    let foo_dep = projects.project(foo_dep_hash).unwrap();
+    let foo_path = brioche.home.join("projects").join(foo_dep_hash.to_string());
+    assert!(projects
+        .local_paths(foo_dep_hash)
+        .unwrap()
+        .contains(&foo_path));
+    assert_eq!(foo_dep.dependencies().count(), 0);
+
+    assert!(foo_path.join("fizz/hello.md").exists());
+    assert!(foo_path.join("buzz/hello.txt").exists());
+
+    mock_foo_latest.assert_async().await;
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_project_load_with_remote_workspace_registry_dep() -> anyhow::Result<()> {
     let (brioche, mut context) = brioche_test::brioche_test().await;
 


### PR DESCRIPTION
This PR adds support for a new `Brioche.glob` global function. The core idea is very similar to `Brioche.includeFile` / `Brioche.includeDirectory` (#34 / #35): the project analyzer recognizes calls to `Brioche.glob`, looks at the local filesystem, then builds a recipe that can be retrieved with a special op from the JS side. See brioche-dev/brioche-packages#10 for the implementation in `std`

Here's an example:

```ts
// myproject/
//   project.bri
//   Cargo.toml
//   Cargo.lock
//   src/
//     main.rs
import * as std from "std";

// Returns a directory artifact with these entries:
//   Cargo.toml
//   Cargo.lock
//   src/
//     main.rs
export default async () => {
  return Brioche.glob("Cargo.lock", "Cargo.toml", "src");
};
```

Glob patterns are matched using the [`walkdir`](https://docs.rs/walkdir/2.5.0/walkdir/index.html) and [`globset`](https://docs.rs/globset/0.4.14/globset/index.html) crates (glob patterns are built with the options `literal_separator`, `backslash_escape`, and `empty_alternates`)