### PR TITLE
[Breaking] Implement support for resolving transitive dependencies in dynamic libraries

### DIFF
--- a/crates/brioche-core/tests/bake_process.rs
+++ b/crates/brioche-core/tests/bake_process.rs
@@ -1057,12 +1057,10 @@ async fn test_bake_process_output_with_resources(
     let mut dummy_packed_contents = dummy_packed_contents.into_bytes();
     brioche_pack::inject_pack(
         &mut dummy_packed_contents,
-        &brioche_pack::Pack {
+        &brioche_pack::Pack::LdLinux {
             program: "program".into(),
-            interpreter: Some(brioche_pack::Interpreter::LdLinux {
-                path: "ld-linux.so".into(),
-                library_paths: vec![],
-            }),
+            interpreter: "ld-linux.so".into(),
+            library_dirs: vec![],
         },
     )?;
 

--- a/crates/brioche-core/tests/input.rs
+++ b/crates/brioche-core/tests/input.rs
@@ -208,9 +208,10 @@ async fn test_input_dir_treat_pack_normally() -> anyhow::Result<()> {
     let mut packed_file = b"test".to_vec();
     brioche_pack::inject_pack(
         &mut packed_file,
-        &brioche_pack::Pack {
+        &brioche_pack::Pack::LdLinux {
             program: b"test".into(),
-            interpreter: None,
+            interpreter: b"test".into(),
+            library_dirs: vec![],
         },
     )?;
 
@@ -260,9 +261,10 @@ async fn test_input_dir_use_resource_dir() -> anyhow::Result<()> {
     let mut packed_file = b"test".to_vec();
     brioche_pack::inject_pack(
         &mut packed_file,
-        &brioche_pack::Pack {
+        &brioche_pack::Pack::LdLinux {
             program: b"test".into(),
-            interpreter: None,
+            interpreter: b"test".into(),
+            library_dirs: vec![],
         },
     )?;
 
@@ -310,9 +312,10 @@ async fn test_input_dir_use_input_resource_dir() -> anyhow::Result<()> {
     let mut packed_file = b"test".to_vec();
     brioche_pack::inject_pack(
         &mut packed_file,
-        &brioche_pack::Pack {
+        &brioche_pack::Pack::LdLinux {
             program: b"test".into(),
-            interpreter: None,
+            interpreter: b"test".into(),
+            library_dirs: vec![],
         },
     )?;
 
@@ -365,9 +368,10 @@ async fn test_input_dir_use_only_input_resource_dir() -> anyhow::Result<()> {
     let mut packed_file = b"test".to_vec();
     brioche_pack::inject_pack(
         &mut packed_file,
-        &brioche_pack::Pack {
+        &brioche_pack::Pack::LdLinux {
             program: b"test".into(),
-            interpreter: None,
+            interpreter: b"test".into(),
+            library_dirs: vec![],
         },
     )?;
 
@@ -414,9 +418,10 @@ async fn test_input_dir_with_symlink_resources() -> anyhow::Result<()> {
     let mut packed_file = b"test".to_vec();
     brioche_pack::inject_pack(
         &mut packed_file,
-        &brioche_pack::Pack {
+        &brioche_pack::Pack::LdLinux {
             program: b"test".into(),
-            interpreter: None,
+            interpreter: b"test".into(),
+            library_dirs: vec![],
         },
     )?;
 
@@ -470,9 +475,10 @@ async fn test_input_dir_broken_symlink() -> anyhow::Result<()> {
     let mut packed_file = b"test".to_vec();
     brioche_pack::inject_pack(
         &mut packed_file,
-        &brioche_pack::Pack {
+        &brioche_pack::Pack::LdLinux {
             program: b"test".into(),
-            interpreter: None,
+            interpreter: b"test".into(),
+            library_dirs: vec![],
         },
     )?;
 
@@ -516,9 +522,10 @@ async fn test_input_dir_with_dir_resources() -> anyhow::Result<()> {
     let mut packed_file = b"test".to_vec();
     brioche_pack::inject_pack(
         &mut packed_file,
-        &brioche_pack::Pack {
+        &brioche_pack::Pack::LdLinux {
             program: b"test".into(),
-            interpreter: None,
+            interpreter: b"test".into(),
+            library_dirs: vec![],
         },
     )?;
 
@@ -591,9 +598,10 @@ async fn test_input_dir_omits_unused_resources() -> anyhow::Result<()> {
     let mut packed_file = b"test".to_vec();
     brioche_pack::inject_pack(
         &mut packed_file,
-        &brioche_pack::Pack {
+        &brioche_pack::Pack::LdLinux {
             program: b"test".into(),
-            interpreter: None,
+            interpreter: b"test".into(),
+            library_dirs: vec![],
         },
     )?;
 

--- a/crates/brioche-pack/src/autowrap.rs
+++ b/crates/brioche-pack/src/autowrap.rs
@@ -116,34 +116,12 @@ fn dynamic_ld_linux_elf_pack(
         .into();
 
     let find_library_options = FindLibraryOptions {
+        resource_dir: options.resource_dir,
         library_search_paths: options.library_search_paths,
         input_paths: options.input_paths,
     };
 
-    let mut resource_library_dirs = vec![];
-    for original_library_name in &options.elf.libraries {
-        let library_path = find_library(&find_library_options, original_library_name)?;
-
-        let library = std::fs::File::open(&library_path)?;
-        let library_name = std::path::PathBuf::from(original_library_name);
-        let library_name = library_name
-            .file_name()
-            .ok_or_else(|| AutowrapError::InvalidPath)?;
-        let resource_library_path = crate::resources::add_named_blob(
-            options.resource_dir,
-            library,
-            is_path_executable(&library_path)?,
-            Path::new(library_name),
-        )?;
-        let resource_library_dir = resource_library_path
-            .parent()
-            .expect("no parent dir for library path");
-        let resource_library_dir = <[u8]>::from_path(resource_library_dir)
-            .ok_or_else(|| AutowrapError::InvalidPath)?
-            .into();
-
-        resource_library_dirs.push(resource_library_dir);
-    }
+    let resource_library_dirs = collect_all_library_dirs(&find_library_options, options.elf)?;
 
     let resource_program_path = <[u8]>::from_path(&resource_program_path)
         .ok_or_else(|| AutowrapError::InvalidPath)?
@@ -166,13 +144,33 @@ struct StaticElfPackOptions<'a> {
 
 fn static_elf_pack(options: StaticElfPackOptions) -> Result<crate::Pack, AutowrapError> {
     let find_library_options = FindLibraryOptions {
+        resource_dir: options.resource_dir,
         library_search_paths: options.library_search_paths,
         input_paths: options.input_paths,
     };
 
+    let resource_library_dirs = collect_all_library_dirs(&find_library_options, options.elf)?;
+
+    let pack = crate::Pack::Static {
+        library_dirs: resource_library_dirs,
+    };
+
+    Ok(pack)
+}
+
+struct FindLibraryOptions<'a> {
+    resource_dir: &'a Path,
+    library_search_paths: &'a [PathBuf],
+    input_paths: &'a [PathBuf],
+}
+
+fn collect_all_library_dirs(
+    options: &FindLibraryOptions,
+    elf: &goblin::elf::Elf,
+) -> Result<Vec<Vec<u8>>, AutowrapError> {
     let mut resource_library_dirs = vec![];
-    for original_library_name in &options.elf.libraries {
-        let library_path = find_library(&find_library_options, original_library_name)?;
+    for original_library_name in &elf.libraries {
+        let library_path = find_library(options, original_library_name)?;
 
         let library = std::fs::File::open(&library_path)?;
         let library_name = std::path::PathBuf::from(original_library_name);
@@ -195,16 +193,7 @@ fn static_elf_pack(options: StaticElfPackOptions) -> Result<crate::Pack, Autowra
         resource_library_dirs.push(resource_library_dir);
     }
 
-    let pack = crate::Pack::Static {
-        library_dirs: resource_library_dirs,
-    };
-
-    Ok(pack)
-}
-
-struct FindLibraryOptions<'a> {
-    library_search_paths: &'a [PathBuf],
-    input_paths: &'a [PathBuf],
+    Ok(resource_library_dirs)
 }
 
 fn find_library(

--- a/crates/brioche-pack/src/autowrap.rs
+++ b/crates/brioche-pack/src/autowrap.rs
@@ -104,10 +104,14 @@ fn dynamic_ld_linux_elf_pack(
         .into();
 
     let mut resource_library_dirs = vec![];
-    for library_name in &options.elf.libraries {
-        let library_path = find_library(&options, library_name)?;
+    for original_library_name in &options.elf.libraries {
+        let library_path = find_library(&options, original_library_name)?;
 
         let library = std::fs::File::open(&library_path)?;
+        let library_name = std::path::PathBuf::from(original_library_name);
+        let library_name = library_name
+            .file_name()
+            .ok_or_else(|| AutowrapError::InvalidPath)?;
         let resource_library_path = crate::resources::add_named_blob(
             options.resource_dir,
             library,

--- a/crates/brioche-pack/src/autowrap.rs
+++ b/crates/brioche-pack/src/autowrap.rs
@@ -128,16 +128,13 @@ fn dynamic_ld_linux_elf_pack(
         resource_library_dirs.push(resource_library_dir);
     }
 
-    let interpreter = crate::Interpreter::LdLinux {
-        path: resource_interpreter_path,
-        library_paths: resource_library_dirs,
-    };
     let resource_program_path = <[u8]>::from_path(&resource_program_path)
         .ok_or_else(|| AutowrapError::InvalidPath)?
         .into();
-    let pack = crate::Pack {
+    let pack = crate::Pack::LdLinux {
         program: resource_program_path,
-        interpreter: Some(interpreter),
+        interpreter: resource_interpreter_path,
+        library_dirs: resource_library_dirs,
     };
 
     Ok(pack)

--- a/crates/brioche-pack/src/autowrap.rs
+++ b/crates/brioche-pack/src/autowrap.rs
@@ -85,7 +85,7 @@ fn dynamic_ld_linux_elf_pack(
         options.resource_dir,
         std::io::Cursor::new(&options.program_contents),
         is_path_executable(options.program_path)?,
-        program_name,
+        Path::new(program_name),
     )?;
 
     let interpreter_name = options
@@ -97,7 +97,7 @@ fn dynamic_ld_linux_elf_pack(
         options.resource_dir,
         interpreter,
         is_path_executable(options.interpreter_path)?,
-        interpreter_name,
+        Path::new(interpreter_name),
     )?;
     let resource_interpreter_path = <[u8]>::from_path(&resource_interpreter_path)
         .ok_or_else(|| AutowrapError::InvalidPath)?
@@ -116,7 +116,7 @@ fn dynamic_ld_linux_elf_pack(
             options.resource_dir,
             library,
             is_path_executable(&library_path)?,
-            library_name,
+            Path::new(library_name),
         )?;
         let resource_library_dir = resource_library_path
             .parent()

--- a/crates/brioche-pack/src/bin/brioche-packer.rs
+++ b/crates/brioche-pack/src/bin/brioche-packer.rs
@@ -67,10 +67,18 @@ fn run() -> Result<(), PackerError> {
                             error,
                         }
                     })?;
+                let all_resource_dirs =
+                    brioche_pack::find_resource_dirs(program, true).map_err(|error| {
+                        PackerError::PackResourceDir {
+                            program: program.clone(),
+                            error,
+                        }
+                    })?;
                 brioche_pack::autowrap::autowrap(brioche_pack::autowrap::AutowrapOptions {
                     program_path: program,
                     packed_exec_path: &packed_exec,
                     resource_dir: &resource_dir,
+                    all_resource_dirs: &all_resource_dirs,
                     library_search_paths: &lib_dirs,
                     input_paths: &[],
                     sysroot: &sysroot,

--- a/crates/brioche-pack/src/lib.rs
+++ b/crates/brioche-pack/src/lib.rs
@@ -16,51 +16,38 @@ type LengthInt = u32;
 
 #[serde_with::serde_as]
 #[derive(Debug, bincode::Encode, bincode::Decode, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct Pack {
-    #[serde_as(as = "TickEncoded")]
-    pub program: Vec<u8>,
-    pub interpreter: Option<Interpreter>,
+#[serde(tag = "type")]
+#[serde(rename_all = "snake_case")]
+pub enum Pack {
+    #[serde(rename_all = "camelCase")]
+    LdLinux {
+        #[serde_as(as = "TickEncoded")]
+        program: Vec<u8>,
+        #[serde_as(as = "TickEncoded")]
+        interpreter: Vec<u8>,
+        #[serde_as(as = "Vec<TickEncoded>")]
+        library_dirs: Vec<Vec<u8>>,
+    },
 }
 
 impl Pack {
     pub fn paths(&self) -> Vec<bstr::BString> {
-        let Self {
-            program,
-            interpreter,
-        } = self;
-
         let mut paths = vec![];
 
-        paths.push(bstr::BString::from(program.clone()));
-        if let Some(interpreter) = interpreter {
-            match interpreter {
-                Interpreter::LdLinux {
-                    path,
-                    library_paths,
-                } => {
-                    paths.push(bstr::BString::from(path.clone()));
-                    paths.extend(library_paths.iter().cloned().map(bstr::BString::from));
-                }
+        match self {
+            Self::LdLinux {
+                program,
+                interpreter,
+                library_dirs,
+            } => {
+                paths.push(bstr::BString::from(program.clone()));
+                paths.push(bstr::BString::from(interpreter.clone()));
+                paths.extend(library_dirs.iter().cloned().map(bstr::BString::from));
             }
         }
 
         paths
     }
-}
-
-#[serde_with::serde_as]
-#[derive(Debug, bincode::Encode, bincode::Decode, serde::Serialize, serde::Deserialize)]
-#[serde(tag = "type")]
-#[serde(rename_all = "snake_case")]
-pub enum Interpreter {
-    #[serde(rename_all = "camelCase")]
-    LdLinux {
-        #[serde_as(as = "TickEncoded")]
-        path: Vec<u8>,
-        #[serde_as(as = "Vec<TickEncoded>")]
-        library_paths: Vec<Vec<u8>>,
-    },
 }
 
 pub fn find_resource_dirs(

--- a/crates/brioche-pack/src/resources.rs
+++ b/crates/brioche-pack/src/resources.rs
@@ -7,7 +7,7 @@ pub fn add_named_blob(
     resource_dir: &Path,
     mut contents: impl std::io::Seek + std::io::Read,
     executable: bool,
-    name: impl AsRef<Path>,
+    name: &Path,
 ) -> Result<PathBuf, AddBlobError> {
     let mut hasher = blake3::Hasher::new();
     std::io::copy(&mut contents, &mut hasher)?;
@@ -34,7 +34,7 @@ pub fn add_named_blob(
     drop(blob_file);
     std::fs::rename(&blob_temp_path, &blob_path)?;
 
-    let alias_dir = resource_dir.join("aliases").join(&blob_name);
+    let alias_dir = resource_dir.join("aliases").join(name).join(&blob_name);
     std::fs::create_dir_all(&alias_dir)?;
 
     let alias_path = alias_dir.join(name);

--- a/crates/brioche-packed-exec/src/main.rs
+++ b/crates/brioche-packed-exec/src/main.rs
@@ -87,6 +87,9 @@ fn run() -> Result<(), PackedError> {
             let error = command.exec();
             Err(PackedError::IoError(error))
         }
+        brioche_pack::Pack::Static { .. } => {
+            unimplemented!("execution of a static executable");
+        }
     }
 }
 

--- a/crates/brioche-packed-userland-exec/src/linux.rs
+++ b/crates/brioche-packed-userland-exec/src/linux.rs
@@ -131,6 +131,9 @@ fn run(args: &[&CStr], env_vars: &[&CStr]) -> Result<(), PackedError> {
 
             userland_execve::exec_with_options(exec);
         }
+        brioche_pack::Pack::Static { .. } => {
+            unimplemented!("execution of a static executable");
+        }
     }
 }
 

--- a/crates/brioche-packed-userland-exec/src/linux.rs
+++ b/crates/brioche-packed-userland-exec/src/linux.rs
@@ -55,21 +55,19 @@ fn run(args: &[&CStr], env_vars: &[&CStr]) -> Result<(), PackedError> {
     let mut program = std::fs::File::open(&path)?;
     let pack = brioche_pack::extract_pack(&mut program)?;
 
-    match pack.interpreter {
-        Some(brioche_pack::Interpreter::LdLinux {
-            path: interpreter,
-            library_paths,
-        }) => {
+    match pack {
+        brioche_pack::Pack::LdLinux {
+            program,
+            interpreter,
+            library_dirs,
+        } => {
             let interpreter = interpreter
                 .to_path()
                 .map_err(|_| PackedError::InvalidPath)?;
             let interpreter = brioche_pack::find_in_resource_dirs(&resource_dirs, interpreter)
                 .ok_or(PackedError::ResourceNotFound)?;
 
-            let program = pack
-                .program
-                .to_path()
-                .map_err(|_| PackedError::InvalidPath)?;
+            let program = program.to_path().map_err(|_| PackedError::InvalidPath)?;
             let program = brioche_pack::find_in_resource_dirs(&resource_dirs, program)
                 .ok_or(PackedError::ResourceNotFound)?;
             let program = program.canonicalize()?;
@@ -82,14 +80,14 @@ fn run(args: &[&CStr], env_vars: &[&CStr]) -> Result<(), PackedError> {
             // Add argv0
             exec.arg(interpreter);
 
-            if !library_paths.is_empty() {
+            if !library_dirs.is_empty() {
                 let mut ld_library_path = bstr::BString::default();
-                for (n, library_path) in library_paths.iter().enumerate() {
-                    let library_path = library_path
+                for (n, library_dir) in library_dirs.iter().enumerate() {
+                    let library_dir = library_dir
                         .to_path()
                         .map_err(|_| PackedError::InvalidPath)?;
-                    let library_path =
-                        brioche_pack::find_in_resource_dirs(&resource_dirs, library_path)
+                    let library_dir =
+                        brioche_pack::find_in_resource_dirs(&resource_dirs, library_dir)
                             .ok_or(PackedError::ResourceNotFound)?;
 
                     if n > 0 {
@@ -97,7 +95,7 @@ fn run(args: &[&CStr], env_vars: &[&CStr]) -> Result<(), PackedError> {
                     }
 
                     let path =
-                        <[u8]>::from_path(&library_path).ok_or_else(|| PackedError::InvalidPath)?;
+                        <[u8]>::from_path(&library_dir).ok_or_else(|| PackedError::InvalidPath)?;
                     ld_library_path.extend(path);
                 }
 
@@ -132,9 +130,6 @@ fn run(args: &[&CStr], env_vars: &[&CStr]) -> Result<(), PackedError> {
             exec.env_pairs(env_vars);
 
             userland_execve::exec_with_options(exec);
-        }
-        None => {
-            unimplemented!("execution without an interpreter");
         }
     }
 }


### PR DESCRIPTION
> **Breaking**: This PR changes the schema of the "brioche pack" format for attaching metadata to files. Rather than incrementing the version, this PR updates the `brioche_pack_v0` schema in place, which will change which resources get attached from a process recipe

This PR updates the Brioche pack tools (`brioche-ld`, `brioche-packer`, etc) with a new metadata format, which allows for attaching metadata to ELF files that don't have an interpreter set via the `PT_INTERP` header (e.g. statically-linked ELF files or dynamically linked libraries). This new metadata is specifically used for attaching resources for dependencies of dynamically-linked libraries. So for example, `libcurl.so` has a dependency on `libzstd.so` (among others), so `libzstd.so` would be added in the resources for `libcurl.so`.

`brioche-ld` will now also look for transitive dependencies when resolving libraries, and it will resolve transitive dependencies from `$BRIOCHE_RESOURCE_DIR` / `$BRIOCHE_INPUT_RESOURCE_DIRS`. This means that, when `curl` is linked against `libcurl.so`, it too will include `libzstd.so` in its resources even though it doesn't _directly_ link against `libzstd.so`. This also means other dependencies linking against `libcurl.so` shouldn't need to directly include `zstd` as a dependency.