### PR TITLE
Even more resource tweaks

### DIFF
--- a/crates/brioche-pack/src/resources.rs
+++ b/crates/brioche-pack/src/resources.rs
@@ -37,11 +37,12 @@ pub fn add_named_blob(
     let alias_dir = resource_dir.join("aliases").join(name).join(&blob_name);
     std::fs::create_dir_all(&alias_dir)?;
 
+    let temp_alias_path = alias_dir.join(format!("{}-{blob_temp_id}", name.display()));
     let alias_path = alias_dir.join(name);
-    let _ = std::fs::remove_file(&alias_path);
     let blob_pack_relative_path = pathdiff::diff_paths(&blob_path, &alias_dir)
         .expect("blob path is not a prefix of alias path");
-    std::os::unix::fs::symlink(blob_pack_relative_path, &alias_path)?;
+    std::os::unix::fs::symlink(blob_pack_relative_path, &temp_alias_path)?;
+    std::fs::rename(&temp_alias_path, &alias_path)?;
 
     let alias_path = alias_path
         .strip_prefix(resource_dir)


### PR DESCRIPTION
This PR continues the theme of changes from #42 / #43 / #44: some more changes to how resources are handled. This one is smaller and should basically be backwards compatible. Here are the changes:

- Tweak `add_named_blob` function to replace existing symlinks atomically. This led to spooky compiler errors when running highly parallel builds, since these symlinks are used for loading dynamic libraries.
- Update Brioche to error out if a resource in the pack metadata isn't found. Previously, this would only lead to a warning, but I think a hard error is more appropriate. I don't think this errors out if the format is invalid, so there's still some room to tighten it down even more in the future.