### PR TITLE
CLI improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -727,14 +727,19 @@ dependencies = [
  "cfg-if 1.0.0",
  "clap",
  "futures",
+ "hex",
  "human-repr",
+ "reqwest",
  "serde",
  "serde_json",
+ "sha2 0.10.8",
  "superconsole",
  "tokio",
  "tokio-util",
  "tower-lsp",
  "tracing",
+ "ulid",
+ "url",
 ]
 
 [[package]]
@@ -5664,7 +5669,7 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-subscriber",
- "web-time",
+ "web-time 0.2.3",
 ]
 
 [[package]]
@@ -5734,11 +5739,13 @@ checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 
 [[package]]
 name = "ulid"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e37c4b6cbcc59a8dcd09a6429fbc7890286bcbb79215cea7b38a3c4c0921d93"
+checksum = "34778c17965aa2a08913b57e1f34db9b4a63f5de31768b55bf20d2795f921259"
 dependencies = [
+ "getrandom",
  "rand 0.8.5",
+ "web-time 1.1.0",
 ]
 
 [[package]]
@@ -6041,6 +6048,16 @@ name = "web-time"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57099a701fb3a8043f993e8228dc24229c7b942e2b009a1b962e54489ba1d3bf"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/crates/brioche-core/src/script/evaluate.rs
+++ b/crates/brioche-core/src/script/evaluate.rs
@@ -11,7 +11,7 @@ use crate::{
 
 use super::BriocheModuleLoader;
 
-#[tracing::instrument(skip(brioche, projects), err)]
+#[tracing::instrument(skip(brioche, projects, project_hash), fields(%project_hash), err)]
 pub async fn evaluate(
     brioche: &Brioche,
     projects: &Projects,

--- a/crates/brioche/Cargo.toml
+++ b/crates/brioche/Cargo.toml
@@ -10,14 +10,19 @@ brioche-core = { path = "../brioche-core" }
 cfg-if = "1.0.0"
 clap = { version = "4.4.11", features = ["derive"] }
 futures = "0.3.29"
+hex = "0.4.3"
 human-repr = "1.1.0"
+reqwest = { version = "0.11.22", default-features = false, features = ["rustls-tls"] }
 serde = { version = "1.0.193", features = ["derive"] }
 serde_json = "1.0.108"
+sha2 = "0.10.8"
 superconsole = "0.2.0"
 tokio = { version = "1.35.0", features = ["full", "tracing"] }
 tokio-util = { version = "0.7.10", features = ["compat", "full"] }
 tower-lsp = "0.20.0"
 tracing = "0.1.40"
+ulid = "1.1.2"
+url = { version = "2.5.0", features = ["serde"] }
 
 [lints.clippy]
 # Temporarily ignore false positives from `tracing::instrument`, see:

--- a/crates/brioche/src/build.rs
+++ b/crates/brioche/src/build.rs
@@ -1,0 +1,176 @@
+use std::{path::PathBuf, process::ExitCode};
+
+use anyhow::Context as _;
+use brioche_core::{fs_utils, reporter::ConsoleReporterKind};
+use clap::Parser;
+use human_repr::HumanDuration;
+use tracing::Instrument;
+
+#[derive(Debug, Parser)]
+pub struct BuildArgs {
+    #[arg(short, long)]
+    project: Option<PathBuf>,
+    #[arg(short, long)]
+    registry: Option<String>,
+    #[arg(short, long, default_value = "default")]
+    export: String,
+    #[arg(short, long)]
+    output: Option<PathBuf>,
+    #[arg(long)]
+    check: bool,
+    #[arg(long)]
+    replace: bool,
+    #[arg(long)]
+    merge: bool,
+    #[arg(long)]
+    keep_temps: bool,
+    #[arg(long)]
+    sync: bool,
+}
+
+pub async fn build(args: BuildArgs) -> anyhow::Result<ExitCode> {
+    let (reporter, mut guard) =
+        brioche_core::reporter::start_console_reporter(ConsoleReporterKind::Auto)?;
+    reporter.set_is_evaluating(true);
+
+    let brioche = brioche_core::BriocheBuilder::new(reporter.clone())
+        .keep_temps(args.keep_temps)
+        .sync(args.sync)
+        .build()
+        .await?;
+    let projects = brioche_core::project::Projects::default();
+
+    let build_future = async {
+        let project_hash = super::load_project(
+            &brioche,
+            &projects,
+            args.project.as_deref(),
+            args.registry.as_deref(),
+        )
+        .await?;
+
+        let num_lockfiles_updated = projects.commit_dirty_lockfiles().await?;
+        if num_lockfiles_updated > 0 {
+            tracing::info!(num_lockfiles_updated, "updated lockfiles");
+        }
+
+        if args.check {
+            let checked =
+                brioche_core::script::check::check(&brioche, &projects, project_hash).await?;
+
+            let result = checked.ensure_ok(brioche_core::script::check::DiagnosticLevel::Error);
+
+            match result {
+                Ok(()) => reporter.emit(superconsole::Lines::from_multiline_string(
+                    "No errors found",
+                    superconsole::style::ContentStyle {
+                        foreground_color: Some(superconsole::style::Color::Green),
+                        ..superconsole::style::ContentStyle::default()
+                    },
+                )),
+                Err(diagnostics) => {
+                    guard.shutdown_console().await;
+
+                    diagnostics.write(&brioche.vfs, &mut std::io::stdout())?;
+                    return anyhow::Ok(ExitCode::FAILURE);
+                }
+            }
+        }
+
+        let recipe = brioche_core::script::evaluate::evaluate(
+            &brioche,
+            &projects,
+            project_hash,
+            &args.export,
+        )
+        .await?;
+
+        reporter.set_is_evaluating(false);
+        let artifact = brioche_core::bake::bake(
+            &brioche,
+            recipe,
+            &brioche_core::bake::BakeScope::Project {
+                project_hash,
+                export: args.export.to_string(),
+            },
+        )
+        .await?;
+
+        guard.shutdown_console().await;
+
+        let elapsed = reporter.elapsed().human_duration();
+        let num_jobs = reporter.num_jobs();
+        let jobs_message = match num_jobs {
+            0 => "(no new jobs)".to_string(),
+            1 => "1 job".to_string(),
+            n => format!("{n} jobs"),
+        };
+        println!("Build finished, completed {jobs_message} in {elapsed}");
+
+        let artifact_hash = artifact.value.hash();
+        println!("Result: {artifact_hash}");
+
+        if let Some(output) = &args.output {
+            if args.replace {
+                fs_utils::try_remove(output)
+                    .await
+                    .with_context(|| format!("Failed to remove path {}", output.display()))?;
+            }
+
+            println!("Writing output");
+            brioche_core::output::create_output(
+                &brioche,
+                &artifact.value,
+                brioche_core::output::OutputOptions {
+                    output_path: output,
+                    merge: args.merge,
+                    resource_dir: None,
+                    mtime: Some(std::time::SystemTime::now()),
+                    link_locals: false,
+                },
+            )
+            .await?;
+            println!("Wrote output to {}", output.display());
+        }
+
+        if args.sync {
+            println!("Waiting for in-progress syncs to finish...");
+            let wait_start = std::time::Instant::now();
+
+            let (sync_complete_tx, sync_complete_rx) = tokio::sync::oneshot::channel();
+
+            brioche
+                .sync_tx
+                .send(brioche_core::SyncMessage::Flush {
+                    completed: sync_complete_tx,
+                })
+                .await?;
+            let brioche_core::sync::SyncBakesResults {
+                num_new_blobs,
+                num_new_recipes,
+                num_new_bakes,
+            } = sync_complete_rx.await?;
+
+            let wait_duration = wait_start.elapsed().human_duration();
+            println!("In-progress sync waited for {wait_duration} and synced:");
+            println!("  {num_new_blobs} blobs");
+            println!("  {num_new_recipes} recipes");
+            println!("  {num_new_bakes} bakes");
+
+            println!("Syncing project...");
+
+            let sync_start = std::time::Instant::now();
+            brioche_core::sync::sync_project(&brioche, project_hash, &args.export).await?;
+            let sync_duration = sync_start.elapsed().human_duration();
+            println!("Finished sync in {sync_duration}");
+        }
+
+        anyhow::Ok(ExitCode::SUCCESS)
+    };
+
+    let exit_code = build_future
+        .instrument(tracing::info_span!("build"))
+        .await?;
+
+    Ok(exit_code)
+}

--- a/crates/brioche/src/check.rs
+++ b/crates/brioche/src/check.rs
@@ -1,0 +1,59 @@
+use std::{path::PathBuf, process::ExitCode};
+
+use brioche_core::reporter::ConsoleReporterKind;
+use clap::Parser;
+use tracing::Instrument;
+
+#[derive(Debug, Parser)]
+pub struct CheckArgs {
+    #[arg(short, long)]
+    project: Option<PathBuf>,
+    #[arg(short, long)]
+    registry: Option<String>,
+}
+
+pub async fn check(args: CheckArgs) -> anyhow::Result<ExitCode> {
+    let (reporter, mut guard) =
+        brioche_core::reporter::start_console_reporter(ConsoleReporterKind::Auto)?;
+
+    let brioche = brioche_core::BriocheBuilder::new(reporter).build().await?;
+    let projects = brioche_core::project::Projects::default();
+
+    let check_future = async {
+        let project_hash = super::load_project(
+            &brioche,
+            &projects,
+            args.project.as_deref(),
+            args.registry.as_deref(),
+        )
+        .await?;
+
+        let num_lockfiles_updated = projects.commit_dirty_lockfiles().await?;
+        if num_lockfiles_updated > 0 {
+            tracing::info!(num_lockfiles_updated, "updated lockfiles");
+        }
+
+        let checked = brioche_core::script::check::check(&brioche, &projects, project_hash).await?;
+
+        guard.shutdown_console().await;
+
+        let result = checked.ensure_ok(brioche_core::script::check::DiagnosticLevel::Message);
+
+        match result {
+            Ok(()) => {
+                println!("No errors found 🎉");
+                anyhow::Ok(ExitCode::SUCCESS)
+            }
+            Err(diagnostics) => {
+                diagnostics.write(&brioche.vfs, &mut std::io::stdout())?;
+                anyhow::Ok(ExitCode::FAILURE)
+            }
+        }
+    };
+
+    let exit_code = check_future
+        .instrument(tracing::info_span!("check"))
+        .await?;
+
+    Ok(exit_code)
+}

--- a/crates/brioche/src/check.rs
+++ b/crates/brioche/src/check.rs
@@ -1,4 +1,4 @@
-use std::{path::PathBuf, process::ExitCode};
+use std::process::ExitCode;
 
 use brioche_core::reporter::ConsoleReporterKind;
 use clap::Parser;
@@ -6,10 +6,8 @@ use tracing::Instrument;
 
 #[derive(Debug, Parser)]
 pub struct CheckArgs {
-    #[arg(short, long)]
-    project: Option<PathBuf>,
-    #[arg(short, long)]
-    registry: Option<String>,
+    #[command(flatten)]
+    project: super::ProjectArgs,
 }
 
 pub async fn check(args: CheckArgs) -> anyhow::Result<ExitCode> {
@@ -20,13 +18,7 @@ pub async fn check(args: CheckArgs) -> anyhow::Result<ExitCode> {
     let projects = brioche_core::project::Projects::default();
 
     let check_future = async {
-        let project_hash = super::load_project(
-            &brioche,
-            &projects,
-            args.project.as_deref(),
-            args.registry.as_deref(),
-        )
-        .await?;
+        let project_hash = super::load_project(&brioche, &projects, &args.project).await?;
 
         let num_lockfiles_updated = projects.commit_dirty_lockfiles().await?;
         if num_lockfiles_updated > 0 {

--- a/crates/brioche/src/format.rs
+++ b/crates/brioche/src/format.rs
@@ -6,10 +6,13 @@ use tracing::Instrument;
 
 #[derive(Debug, Parser)]
 pub struct FormatArgs {
-    #[arg(long)]
-    check: bool,
+    /// The path to the project directory to format
     #[arg(short, long)]
     project: PathBuf,
+
+    /// Check formatting without writing changes
+    #[arg(long)]
+    check: bool,
 }
 
 pub async fn format(args: FormatArgs) -> anyhow::Result<ExitCode> {

--- a/crates/brioche/src/format.rs
+++ b/crates/brioche/src/format.rs
@@ -1,0 +1,57 @@
+use std::{path::PathBuf, process::ExitCode};
+
+use brioche_core::reporter::ConsoleReporterKind;
+use clap::Parser;
+use tracing::Instrument;
+
+#[derive(Debug, Parser)]
+pub struct FormatArgs {
+    #[arg(long)]
+    check: bool,
+    #[arg(short, long)]
+    project: PathBuf,
+}
+
+pub async fn format(args: FormatArgs) -> anyhow::Result<ExitCode> {
+    let (reporter, mut guard) =
+        brioche_core::reporter::start_console_reporter(ConsoleReporterKind::Auto)?;
+
+    let brioche = brioche_core::BriocheBuilder::new(reporter).build().await?;
+    let projects = brioche_core::project::Projects::default();
+
+    let format_future = async {
+        let project_hash = projects.load(&brioche, &args.project, true).await?;
+
+        if args.check {
+            let mut unformatted_files =
+                brioche_core::script::format::check_format(&projects, project_hash).await?;
+            unformatted_files.sort();
+
+            guard.shutdown_console().await;
+
+            if unformatted_files.is_empty() {
+                println!("All files formatted");
+                Ok(ExitCode::SUCCESS)
+            } else {
+                println!("The following files are not formatted:");
+                for file in unformatted_files {
+                    println!("- {}", file.display());
+                }
+
+                Ok(ExitCode::FAILURE)
+            }
+        } else {
+            brioche_core::script::format::format(&projects, project_hash).await?;
+
+            guard.shutdown_console().await;
+
+            anyhow::Ok(ExitCode::SUCCESS)
+        }
+    };
+
+    let exit_code = format_future
+        .instrument(tracing::info_span!("format"))
+        .await?;
+
+    Ok(exit_code)
+}

--- a/crates/brioche/src/install.rs
+++ b/crates/brioche/src/install.rs
@@ -1,0 +1,161 @@
+use std::{path::PathBuf, process::ExitCode};
+
+use anyhow::Context as _;
+use brioche_core::reporter::ConsoleReporterKind;
+use clap::Parser;
+use human_repr::HumanDuration;
+use tracing::Instrument;
+
+#[derive(Debug, Parser)]
+pub struct InstallArgs {
+    #[arg(short, long)]
+    project: Option<PathBuf>,
+    #[arg(short, long)]
+    registry: Option<String>,
+    #[arg(short, long, default_value = "default")]
+    export: String,
+    #[arg(long)]
+    check: bool,
+}
+
+pub async fn install(args: InstallArgs) -> anyhow::Result<ExitCode> {
+    let (reporter, mut guard) =
+        brioche_core::reporter::start_console_reporter(ConsoleReporterKind::Auto)?;
+    reporter.set_is_evaluating(true);
+
+    let brioche = brioche_core::BriocheBuilder::new(reporter.clone())
+        .build()
+        .await?;
+    let projects = brioche_core::project::Projects::default();
+
+    let install_future = async {
+        let project_hash = super::load_project(
+            &brioche,
+            &projects,
+            args.project.as_deref(),
+            args.registry.as_deref(),
+        )
+        .await?;
+
+        let num_lockfiles_updated = projects.commit_dirty_lockfiles().await?;
+        if num_lockfiles_updated > 0 {
+            tracing::info!(num_lockfiles_updated, "updated lockfiles");
+        }
+
+        if args.check {
+            let checked =
+                brioche_core::script::check::check(&brioche, &projects, project_hash).await?;
+
+            let result = checked.ensure_ok(brioche_core::script::check::DiagnosticLevel::Error);
+
+            match result {
+                Ok(()) => reporter.emit(superconsole::Lines::from_multiline_string(
+                    "No errors found",
+                    superconsole::style::ContentStyle {
+                        foreground_color: Some(superconsole::style::Color::Green),
+                        ..superconsole::style::ContentStyle::default()
+                    },
+                )),
+                Err(diagnostics) => {
+                    guard.shutdown_console().await;
+
+                    diagnostics.write(&brioche.vfs, &mut std::io::stdout())?;
+                    anyhow::bail!("checks failed");
+                }
+            }
+        }
+
+        let recipe = brioche_core::script::evaluate::evaluate(
+            &brioche,
+            &projects,
+            project_hash,
+            &args.export,
+        )
+        .await?;
+
+        reporter.set_is_evaluating(false);
+        let artifact = brioche_core::bake::bake(
+            &brioche,
+            recipe,
+            &brioche_core::bake::BakeScope::Project {
+                project_hash,
+                export: args.export.to_string(),
+            },
+        )
+        .await?;
+
+        guard.shutdown_console().await;
+
+        let elapsed = reporter.elapsed().human_duration();
+        let num_jobs = reporter.num_jobs();
+        let jobs_message = match num_jobs {
+            0 => "(no new jobs)".to_string(),
+            1 => "1 job".to_string(),
+            n => format!("{n} jobs"),
+        };
+        eprintln!("Build finished, completed {jobs_message} in {elapsed}");
+
+        // Ensure the artifact is a directory
+        let mut directory = match artifact.value {
+            brioche_core::recipe::Artifact::File(_) => {
+                anyhow::bail!("artifact returned a file, expected a directory");
+            }
+            brioche_core::recipe::Artifact::Symlink { .. } => {
+                anyhow::bail!("artifact returned a symlink, expected a directory");
+            }
+            brioche_core::recipe::Artifact::Directory(dir) => dir,
+        };
+
+        // Remove the top-level `brioche-run` file if it exists
+        directory.insert(&brioche, b"brioche-run", None).await?;
+
+        // Create the installation directory if it doesn't exist
+        let install_dir = brioche.home.join("installed");
+        tokio::fs::create_dir_all(&install_dir)
+            .await
+            .with_context(|| {
+                format!(
+                    "failed to create installation directory {}",
+                    install_dir.display()
+                )
+            })?;
+
+        println!("Writing output");
+        brioche_core::output::create_output(
+            &brioche,
+            &brioche_core::recipe::Artifact::Directory(directory),
+            brioche_core::output::OutputOptions {
+                output_path: &install_dir,
+                merge: true,
+                resource_dir: None,
+                mtime: Some(std::time::SystemTime::now()),
+                link_locals: false,
+            },
+        )
+        .await?;
+        println!("Wrote output to {}", install_dir.display());
+
+        let install_bin_dir = install_dir.join("bin");
+        let install_bin_dir_exists = tokio::fs::try_exists(&install_bin_dir).await?;
+        let is_on_path = match std::env::var_os("PATH") {
+            Some(env_path) => {
+                let mut paths = std::env::split_paths(&env_path);
+                paths.any(|path| path == install_bin_dir)
+            }
+            None => false,
+        };
+
+        if install_bin_dir_exists && !is_on_path {
+            println!("Note: installation directory not detected in $PATH! Consider adding it:");
+            println!("  {}", install_bin_dir.display());
+        }
+
+        Ok(ExitCode::SUCCESS)
+    };
+
+    let exit_code = install_future
+        .instrument(tracing::info_span!("run_install"))
+        .await?;
+
+    Ok(exit_code)
+}

--- a/crates/brioche/src/lsp.rs
+++ b/crates/brioche/src/lsp.rs
@@ -1,0 +1,41 @@
+use clap::Parser;
+
+#[derive(Debug, Parser)]
+pub struct LspArgs {
+    /// Use stdio for LSP transport
+    #[arg(long)]
+    stdio: bool,
+}
+
+pub async fn lsp(_args: LspArgs) -> anyhow::Result<()> {
+    let stdin = tokio::io::stdin();
+    let stdout = tokio::io::stdout();
+
+    let local_pool = tokio_util::task::LocalPoolHandle::new(5);
+
+    let (service, socket) = tower_lsp::LspService::new(move |client| {
+        let local_pool = &local_pool;
+        futures::executor::block_on(async move {
+            let (reporter, _guard) = brioche_core::reporter::start_lsp_reporter(client.clone());
+            let brioche = brioche_core::BriocheBuilder::new(reporter)
+                .registry_client(brioche_core::registry::RegistryClient::disabled())
+                .vfs(brioche_core::vfs::Vfs::mutable())
+                .build()
+                .await?;
+            let projects = brioche_core::project::Projects::default();
+            let lsp_server = brioche_core::script::lsp::BriocheLspServer::new(
+                local_pool, brioche, projects, client,
+            )
+            .await?;
+            anyhow::Ok(lsp_server)
+        })
+        .expect("failed to build LSP")
+    });
+
+    // Note: For now, we always use stdio for the LSP
+    tower_lsp::Server::new(stdin, stdout, socket)
+        .serve(service)
+        .await;
+
+    Ok(())
+}

--- a/crates/brioche/src/main.rs
+++ b/crates/brioche/src/main.rs
@@ -5,38 +5,42 @@ use std::{
     sync::Arc,
 };
 
-use anyhow::Context as _;
-use brioche_core::{fs_utils, reporter::ConsoleReporterKind, sandbox::SandboxExecutionConfig};
+use brioche_core::reporter::ConsoleReporterKind;
 use clap::Parser;
-use human_repr::HumanDuration;
-use tracing::Instrument;
+
+mod build;
+mod check;
+mod format;
+mod install;
+mod lsp;
+mod publish;
+mod run;
+mod run_sandbox;
 
 #[derive(Debug, Parser)]
 #[command(version)]
 enum Args {
-    Build(BuildArgs),
+    Build(build::BuildArgs),
 
-    Run(RunArgs),
+    Run(run::RunArgs),
 
-    Install(InstallArgs),
+    Install(install::InstallArgs),
 
-    Check(CheckArgs),
+    Check(check::CheckArgs),
 
     #[command(name = "fmt")]
-    Format(FormatArgs),
+    Format(format::FormatArgs),
 
-    Publish(PublishArgs),
+    Publish(publish::PublishArgs),
 
-    Lsp(LspArgs),
+    Lsp(lsp::LspArgs),
 
     Analyze(AnalyzeArgs),
 
     ExportProject(ExportProjectArgs),
 
-    RunSandbox(RunSandboxArgs),
+    RunSandbox(run_sandbox::RunSandboxArgs),
 }
-
-const BRIOCHE_SANDBOX_ERROR_CODE: u8 = 122;
 
 fn main() -> anyhow::Result<ExitCode> {
     let args = Args::parse();
@@ -47,7 +51,7 @@ fn main() -> anyhow::Result<ExitCode> {
                 .enable_all()
                 .build()?;
 
-            let exit_code = rt.block_on(build(args))?;
+            let exit_code = rt.block_on(build::build(args))?;
 
             Ok(exit_code)
         }
@@ -56,7 +60,7 @@ fn main() -> anyhow::Result<ExitCode> {
                 .enable_all()
                 .build()?;
 
-            let exit_code = rt.block_on(run(args))?;
+            let exit_code = rt.block_on(run::run(args))?;
 
             Ok(exit_code)
         }
@@ -65,7 +69,7 @@ fn main() -> anyhow::Result<ExitCode> {
                 .enable_all()
                 .build()?;
 
-            let exit_code = rt.block_on(install(args))?;
+            let exit_code = rt.block_on(install::install(args))?;
 
             Ok(exit_code)
         }
@@ -74,7 +78,7 @@ fn main() -> anyhow::Result<ExitCode> {
                 .enable_all()
                 .build()?;
 
-            let exit_code = rt.block_on(check(args))?;
+            let exit_code = rt.block_on(check::check(args))?;
 
             Ok(exit_code)
         }
@@ -83,7 +87,7 @@ fn main() -> anyhow::Result<ExitCode> {
                 .enable_all()
                 .build()?;
 
-            let exit_code = rt.block_on(format(args))?;
+            let exit_code = rt.block_on(format::format(args))?;
 
             Ok(exit_code)
         }
@@ -92,7 +96,7 @@ fn main() -> anyhow::Result<ExitCode> {
                 .enable_all()
                 .build()?;
 
-            let exit_code = rt.block_on(publish(args))?;
+            let exit_code = rt.block_on(publish::publish(args))?;
 
             Ok(exit_code)
         }
@@ -101,7 +105,7 @@ fn main() -> anyhow::Result<ExitCode> {
                 .enable_all()
                 .build()?;
 
-            rt.block_on(lsp(args))?;
+            rt.block_on(lsp::lsp(args))?;
 
             Ok(ExitCode::SUCCESS)
         }
@@ -124,718 +128,11 @@ fn main() -> anyhow::Result<ExitCode> {
             Ok(ExitCode::SUCCESS)
         }
         Args::RunSandbox(args) => {
-            let exit_code = run_sandbox(args);
+            let exit_code = run_sandbox::run_sandbox(args);
 
             Ok(exit_code)
         }
     }
-}
-
-#[derive(Debug, Parser)]
-struct BuildArgs {
-    #[arg(short, long)]
-    project: Option<PathBuf>,
-    #[arg(short, long)]
-    registry: Option<String>,
-    #[arg(short, long, default_value = "default")]
-    export: String,
-    #[arg(short, long)]
-    output: Option<PathBuf>,
-    #[arg(long)]
-    check: bool,
-    #[arg(long)]
-    replace: bool,
-    #[arg(long)]
-    merge: bool,
-    #[arg(long)]
-    keep_temps: bool,
-    #[arg(long)]
-    sync: bool,
-}
-
-async fn build(args: BuildArgs) -> anyhow::Result<ExitCode> {
-    let (reporter, mut guard) =
-        brioche_core::reporter::start_console_reporter(ConsoleReporterKind::Auto)?;
-    reporter.set_is_evaluating(true);
-
-    let brioche = brioche_core::BriocheBuilder::new(reporter.clone())
-        .keep_temps(args.keep_temps)
-        .sync(args.sync)
-        .build()
-        .await?;
-    let projects = brioche_core::project::Projects::default();
-
-    let build_future = async {
-        let project_hash = load_project(
-            &brioche,
-            &projects,
-            args.project.as_deref(),
-            args.registry.as_deref(),
-        )
-        .await?;
-
-        let num_lockfiles_updated = projects.commit_dirty_lockfiles().await?;
-        if num_lockfiles_updated > 0 {
-            tracing::info!(num_lockfiles_updated, "updated lockfiles");
-        }
-
-        if args.check {
-            let checked =
-                brioche_core::script::check::check(&brioche, &projects, project_hash).await?;
-
-            let result = checked.ensure_ok(brioche_core::script::check::DiagnosticLevel::Error);
-
-            match result {
-                Ok(()) => reporter.emit(superconsole::Lines::from_multiline_string(
-                    "No errors found",
-                    superconsole::style::ContentStyle {
-                        foreground_color: Some(superconsole::style::Color::Green),
-                        ..superconsole::style::ContentStyle::default()
-                    },
-                )),
-                Err(diagnostics) => {
-                    guard.shutdown_console().await;
-
-                    diagnostics.write(&brioche.vfs, &mut std::io::stdout())?;
-                    return anyhow::Ok(ExitCode::FAILURE);
-                }
-            }
-        }
-
-        let recipe = brioche_core::script::evaluate::evaluate(
-            &brioche,
-            &projects,
-            project_hash,
-            &args.export,
-        )
-        .await?;
-
-        reporter.set_is_evaluating(false);
-        let artifact = brioche_core::bake::bake(
-            &brioche,
-            recipe,
-            &brioche_core::bake::BakeScope::Project {
-                project_hash,
-                export: args.export.to_string(),
-            },
-        )
-        .await?;
-
-        guard.shutdown_console().await;
-
-        let elapsed = reporter.elapsed().human_duration();
-        let num_jobs = reporter.num_jobs();
-        let jobs_message = match num_jobs {
-            0 => "(no new jobs)".to_string(),
-            1 => "1 job".to_string(),
-            n => format!("{n} jobs"),
-        };
-        println!("Build finished, completed {jobs_message} in {elapsed}");
-
-        let artifact_hash = artifact.value.hash();
-        println!("Result: {artifact_hash}");
-
-        if let Some(output) = &args.output {
-            if args.replace {
-                fs_utils::try_remove(output)
-                    .await
-                    .with_context(|| format!("Failed to remove path {}", output.display()))?;
-            }
-
-            println!("Writing output");
-            brioche_core::output::create_output(
-                &brioche,
-                &artifact.value,
-                brioche_core::output::OutputOptions {
-                    output_path: output,
-                    merge: args.merge,
-                    resource_dir: None,
-                    mtime: Some(std::time::SystemTime::now()),
-                    link_locals: false,
-                },
-            )
-            .await?;
-            println!("Wrote output to {}", output.display());
-        }
-
-        if args.sync {
-            println!("Waiting for in-progress syncs to finish...");
-            let wait_start = std::time::Instant::now();
-
-            let (sync_complete_tx, sync_complete_rx) = tokio::sync::oneshot::channel();
-
-            brioche
-                .sync_tx
-                .send(brioche_core::SyncMessage::Flush {
-                    completed: sync_complete_tx,
-                })
-                .await?;
-            let brioche_core::sync::SyncBakesResults {
-                num_new_blobs,
-                num_new_recipes,
-                num_new_bakes,
-            } = sync_complete_rx.await?;
-
-            let wait_duration = wait_start.elapsed().human_duration();
-            println!("In-progress sync waited for {wait_duration} and synced:");
-            println!("  {num_new_blobs} blobs");
-            println!("  {num_new_recipes} recipes");
-            println!("  {num_new_bakes} bakes");
-
-            println!("Syncing project...");
-
-            let sync_start = std::time::Instant::now();
-            brioche_core::sync::sync_project(&brioche, project_hash, &args.export).await?;
-            let sync_duration = sync_start.elapsed().human_duration();
-            println!("Finished sync in {sync_duration}");
-        }
-
-        anyhow::Ok(ExitCode::SUCCESS)
-    };
-
-    let exit_code = build_future
-        .instrument(tracing::info_span!("build"))
-        .await?;
-
-    Ok(exit_code)
-}
-
-#[derive(Debug, Parser)]
-struct RunArgs {
-    #[arg(short, long)]
-    project: Option<PathBuf>,
-    #[arg(short, long)]
-    registry: Option<String>,
-    #[arg(short, long, default_value = "default")]
-    export: String,
-    #[arg(short, long, default_value = "brioche-run")]
-    command: String,
-    #[arg(short, long)]
-    quiet: bool,
-    #[arg(long)]
-    check: bool,
-    #[arg(long)]
-    keep: bool,
-    #[arg(last = true)]
-    args: Vec<std::ffi::OsString>,
-}
-
-async fn run(args: RunArgs) -> anyhow::Result<ExitCode> {
-    let (reporter, mut guard) = if args.quiet {
-        brioche_core::reporter::start_null_reporter()
-    } else {
-        brioche_core::reporter::start_console_reporter(ConsoleReporterKind::Auto)?
-    };
-    reporter.set_is_evaluating(true);
-
-    let brioche = brioche_core::BriocheBuilder::new(reporter.clone())
-        .keep_temps(args.keep)
-        .build()
-        .await?;
-    let projects = brioche_core::project::Projects::default();
-
-    let build_future = async {
-        let project_hash = load_project(
-            &brioche,
-            &projects,
-            args.project.as_deref(),
-            args.registry.as_deref(),
-        )
-        .await?;
-
-        let num_lockfiles_updated = projects.commit_dirty_lockfiles().await?;
-        if num_lockfiles_updated > 0 {
-            tracing::info!(num_lockfiles_updated, "updated lockfiles");
-        }
-
-        if args.check {
-            let checked =
-                brioche_core::script::check::check(&brioche, &projects, project_hash).await?;
-
-            let result = checked.ensure_ok(brioche_core::script::check::DiagnosticLevel::Error);
-
-            match result {
-                Ok(()) => reporter.emit(superconsole::Lines::from_multiline_string(
-                    "No errors found",
-                    superconsole::style::ContentStyle {
-                        foreground_color: Some(superconsole::style::Color::Green),
-                        ..superconsole::style::ContentStyle::default()
-                    },
-                )),
-                Err(diagnostics) => {
-                    guard.shutdown_console().await;
-
-                    diagnostics.write(&brioche.vfs, &mut std::io::stdout())?;
-                    anyhow::bail!("checks failed");
-                }
-            }
-        }
-
-        let recipe = brioche_core::script::evaluate::evaluate(
-            &brioche,
-            &projects,
-            project_hash,
-            &args.export,
-        )
-        .await?;
-
-        reporter.set_is_evaluating(false);
-        let artifact = brioche_core::bake::bake(
-            &brioche,
-            recipe,
-            &brioche_core::bake::BakeScope::Project {
-                project_hash,
-                export: args.export.to_string(),
-            },
-        )
-        .await?;
-
-        guard.shutdown_console().await;
-
-        let elapsed = reporter.elapsed().human_duration();
-        let num_jobs = reporter.num_jobs();
-        let jobs_message = match num_jobs {
-            0 => "(no new jobs)".to_string(),
-            1 => "1 job".to_string(),
-            n => format!("{n} jobs"),
-        };
-        if !args.quiet {
-            eprintln!("Build finished, completed {jobs_message} in {elapsed}");
-        }
-
-        // Validate that the artifact is a directory that contains the
-        // command to run before returning
-        let command_artifact = match &artifact.value {
-            brioche_core::recipe::Artifact::File(_) => {
-                anyhow::bail!("artifact returned a file, expected a directory");
-            }
-            brioche_core::recipe::Artifact::Symlink { .. } => {
-                anyhow::bail!("artifact returned a symlink, expected a directory");
-            }
-            brioche_core::recipe::Artifact::Directory(dir) => dir
-                .get(&brioche, args.command.as_bytes())
-                .await
-                .with_context(|| {
-                    format!(
-                        "failed to retrieve {:?} from returned artifact",
-                        args.command
-                    )
-                })?,
-        };
-        anyhow::ensure!(
-            command_artifact.is_some(),
-            "{:?} not found in returned artifact",
-            args.command
-        );
-
-        let output = brioche_core::output::create_local_output(&brioche, &artifact.value).await?;
-
-        Ok(output)
-    };
-
-    let output = build_future
-        .instrument(tracing::info_span!("run_build"))
-        .await?;
-
-    let command_path = output.path.join(&args.command);
-
-    if !args.quiet {
-        eprintln!("Running {}", args.command);
-    }
-
-    let mut command = std::process::Command::new(command_path);
-    command.args(&args.args);
-
-    if let Some(resource_dir) = output.resource_dir {
-        command.env("BRIOCHE_RESOURCE_DIR", resource_dir);
-    }
-
-    cfg_if::cfg_if! {
-        if #[cfg(unix)] {
-            use std::os::unix::process::CommandExt as _;
-
-            let error = command.exec();
-            Err(error.into())
-        } else {
-            let result = command.status().context("failed to run process")?;
-            if result.success() {
-                Ok(ExitCode::SUCCESS)
-            } else {
-                let code = result
-                    .code()
-                    .and_then(|code| u8::try_from(code).ok())
-                    .map(ExitCode::from)
-                    .unwrap_or(ExitCode::FAILURE);
-                Ok(code)
-            }
-        }
-    }
-}
-
-#[derive(Debug, Parser)]
-struct InstallArgs {
-    #[arg(short, long)]
-    project: Option<PathBuf>,
-    #[arg(short, long)]
-    registry: Option<String>,
-    #[arg(short, long, default_value = "default")]
-    export: String,
-    #[arg(long)]
-    check: bool,
-}
-
-async fn install(args: InstallArgs) -> anyhow::Result<ExitCode> {
-    let (reporter, mut guard) =
-        brioche_core::reporter::start_console_reporter(ConsoleReporterKind::Auto)?;
-    reporter.set_is_evaluating(true);
-
-    let brioche = brioche_core::BriocheBuilder::new(reporter.clone())
-        .build()
-        .await?;
-    let projects = brioche_core::project::Projects::default();
-
-    let install_future = async {
-        let project_hash = load_project(
-            &brioche,
-            &projects,
-            args.project.as_deref(),
-            args.registry.as_deref(),
-        )
-        .await?;
-
-        let num_lockfiles_updated = projects.commit_dirty_lockfiles().await?;
-        if num_lockfiles_updated > 0 {
-            tracing::info!(num_lockfiles_updated, "updated lockfiles");
-        }
-
-        if args.check {
-            let checked =
-                brioche_core::script::check::check(&brioche, &projects, project_hash).await?;
-
-            let result = checked.ensure_ok(brioche_core::script::check::DiagnosticLevel::Error);
-
-            match result {
-                Ok(()) => reporter.emit(superconsole::Lines::from_multiline_string(
-                    "No errors found",
-                    superconsole::style::ContentStyle {
-                        foreground_color: Some(superconsole::style::Color::Green),
-                        ..superconsole::style::ContentStyle::default()
-                    },
-                )),
-                Err(diagnostics) => {
-                    guard.shutdown_console().await;
-
-                    diagnostics.write(&brioche.vfs, &mut std::io::stdout())?;
-                    anyhow::bail!("checks failed");
-                }
-            }
-        }
-
-        let recipe = brioche_core::script::evaluate::evaluate(
-            &brioche,
-            &projects,
-            project_hash,
-            &args.export,
-        )
-        .await?;
-
-        reporter.set_is_evaluating(false);
-        let artifact = brioche_core::bake::bake(
-            &brioche,
-            recipe,
-            &brioche_core::bake::BakeScope::Project {
-                project_hash,
-                export: args.export.to_string(),
-            },
-        )
-        .await?;
-
-        guard.shutdown_console().await;
-
-        let elapsed = reporter.elapsed().human_duration();
-        let num_jobs = reporter.num_jobs();
-        let jobs_message = match num_jobs {
-            0 => "(no new jobs)".to_string(),
-            1 => "1 job".to_string(),
-            n => format!("{n} jobs"),
-        };
-        eprintln!("Build finished, completed {jobs_message} in {elapsed}");
-
-        // Ensure the artifact is a directory
-        let mut directory = match artifact.value {
-            brioche_core::recipe::Artifact::File(_) => {
-                anyhow::bail!("artifact returned a file, expected a directory");
-            }
-            brioche_core::recipe::Artifact::Symlink { .. } => {
-                anyhow::bail!("artifact returned a symlink, expected a directory");
-            }
-            brioche_core::recipe::Artifact::Directory(dir) => dir,
-        };
-
-        // Remove the top-level `brioche-run` file if it exists
-        directory.insert(&brioche, b"brioche-run", None).await?;
-
-        // Create the installation directory if it doesn't exist
-        let install_dir = brioche.home.join("installed");
-        tokio::fs::create_dir_all(&install_dir)
-            .await
-            .with_context(|| {
-                format!(
-                    "failed to create installation directory {}",
-                    install_dir.display()
-                )
-            })?;
-
-        println!("Writing output");
-        brioche_core::output::create_output(
-            &brioche,
-            &brioche_core::recipe::Artifact::Directory(directory),
-            brioche_core::output::OutputOptions {
-                output_path: &install_dir,
-                merge: true,
-                resource_dir: None,
-                mtime: Some(std::time::SystemTime::now()),
-                link_locals: false,
-            },
-        )
-        .await?;
-        println!("Wrote output to {}", install_dir.display());
-
-        let install_bin_dir = install_dir.join("bin");
-        let install_bin_dir_exists = tokio::fs::try_exists(&install_bin_dir).await?;
-        let is_on_path = match std::env::var_os("PATH") {
-            Some(env_path) => {
-                let mut paths = std::env::split_paths(&env_path);
-                paths.any(|path| path == install_bin_dir)
-            }
-            None => false,
-        };
-
-        if install_bin_dir_exists && !is_on_path {
-            println!("Note: installation directory not detected in $PATH! Consider adding it:");
-            println!("  {}", install_bin_dir.display());
-        }
-
-        Ok(ExitCode::SUCCESS)
-    };
-
-    let exit_code = install_future
-        .instrument(tracing::info_span!("run_install"))
-        .await?;
-
-    Ok(exit_code)
-}
-
-#[derive(Debug, Parser)]
-struct CheckArgs {
-    #[arg(short, long)]
-    project: Option<PathBuf>,
-    #[arg(short, long)]
-    registry: Option<String>,
-}
-
-async fn check(args: CheckArgs) -> anyhow::Result<ExitCode> {
-    let (reporter, mut guard) =
-        brioche_core::reporter::start_console_reporter(ConsoleReporterKind::Auto)?;
-
-    let brioche = brioche_core::BriocheBuilder::new(reporter).build().await?;
-    let projects = brioche_core::project::Projects::default();
-
-    let check_future = async {
-        let project_hash = load_project(
-            &brioche,
-            &projects,
-            args.project.as_deref(),
-            args.registry.as_deref(),
-        )
-        .await?;
-
-        let num_lockfiles_updated = projects.commit_dirty_lockfiles().await?;
-        if num_lockfiles_updated > 0 {
-            tracing::info!(num_lockfiles_updated, "updated lockfiles");
-        }
-
-        let checked = brioche_core::script::check::check(&brioche, &projects, project_hash).await?;
-
-        guard.shutdown_console().await;
-
-        let result = checked.ensure_ok(brioche_core::script::check::DiagnosticLevel::Message);
-
-        match result {
-            Ok(()) => {
-                println!("No errors found 🎉");
-                anyhow::Ok(ExitCode::SUCCESS)
-            }
-            Err(diagnostics) => {
-                diagnostics.write(&brioche.vfs, &mut std::io::stdout())?;
-                anyhow::Ok(ExitCode::FAILURE)
-            }
-        }
-    };
-
-    let exit_code = check_future
-        .instrument(tracing::info_span!("check"))
-        .await?;
-
-    Ok(exit_code)
-}
-#[derive(Debug, Parser)]
-struct FormatArgs {
-    #[arg(long)]
-    check: bool,
-    #[arg(short, long)]
-    project: PathBuf,
-}
-
-async fn format(args: FormatArgs) -> anyhow::Result<ExitCode> {
-    let (reporter, mut guard) =
-        brioche_core::reporter::start_console_reporter(ConsoleReporterKind::Auto)?;
-
-    let brioche = brioche_core::BriocheBuilder::new(reporter).build().await?;
-    let projects = brioche_core::project::Projects::default();
-
-    let format_future = async {
-        let project_hash = projects.load(&brioche, &args.project, true).await?;
-
-        if args.check {
-            let mut unformatted_files =
-                brioche_core::script::format::check_format(&projects, project_hash).await?;
-            unformatted_files.sort();
-
-            guard.shutdown_console().await;
-
-            if unformatted_files.is_empty() {
-                println!("All files formatted");
-                Ok(ExitCode::SUCCESS)
-            } else {
-                println!("The following files are not formatted:");
-                for file in unformatted_files {
-                    println!("- {}", file.display());
-                }
-
-                Ok(ExitCode::FAILURE)
-            }
-        } else {
-            brioche_core::script::format::format(&projects, project_hash).await?;
-
-            guard.shutdown_console().await;
-
-            anyhow::Ok(ExitCode::SUCCESS)
-        }
-    };
-
-    let exit_code = format_future
-        .instrument(tracing::info_span!("format"))
-        .await?;
-
-    Ok(exit_code)
-}
-
-#[derive(Debug, Parser)]
-struct PublishArgs {
-    #[arg(short, long)]
-    project: PathBuf,
-}
-
-async fn publish(args: PublishArgs) -> anyhow::Result<ExitCode> {
-    let (reporter, mut guard) =
-        brioche_core::reporter::start_console_reporter(ConsoleReporterKind::Auto)?;
-
-    let brioche = brioche_core::BriocheBuilder::new(reporter).build().await?;
-    let projects = brioche_core::project::Projects::default();
-    let project_hash = projects.load(&brioche, &args.project, true).await?;
-
-    let project = projects.project(project_hash)?;
-    let name = project.definition.name.as_deref().unwrap_or("[unnamed]");
-    let version = project
-        .definition
-        .version
-        .as_deref()
-        .unwrap_or("[unversioned]");
-
-    let lockfile_result = projects.validate_no_dirty_lockfiles();
-    match lockfile_result {
-        Ok(()) => {}
-        Err(error) => {
-            eprintln!("{error:#}");
-            return Ok(ExitCode::FAILURE);
-        }
-    }
-
-    let checked = brioche_core::script::check::check(&brioche, &projects, project_hash).await?;
-    let check_results = checked.ensure_ok(brioche_core::script::check::DiagnosticLevel::Warning);
-    match check_results {
-        Ok(()) => {
-            println!("No errors found 🎉");
-        }
-        Err(diagnostics) => {
-            diagnostics.write(&brioche.vfs, &mut std::io::stdout())?;
-            return Ok(ExitCode::FAILURE);
-        }
-    }
-
-    guard.shutdown_console().await;
-
-    let response =
-        brioche_core::publish::publish_project(&brioche, &projects, project_hash, true).await?;
-
-    if response.tags.is_empty() {
-        println!("Project already up to date: {} {}", name, version);
-    } else {
-        println!("🚀 Published project {} {}", name, version);
-        println!();
-        println!("Updated tags:");
-        for tag in &response.tags {
-            let status = if tag.previous_hash.is_some() {
-                "updated"
-            } else {
-                "new"
-            };
-            println!("  {} {} ({status})", tag.name, tag.tag);
-        }
-    }
-
-    Ok(ExitCode::SUCCESS)
-}
-
-#[derive(Debug, Parser)]
-struct LspArgs {
-    /// Use stdio for LSP transport
-    #[arg(long)]
-    stdio: bool,
-}
-
-async fn lsp(_args: LspArgs) -> anyhow::Result<()> {
-    let stdin = tokio::io::stdin();
-    let stdout = tokio::io::stdout();
-
-    let local_pool = tokio_util::task::LocalPoolHandle::new(5);
-
-    let (service, socket) = tower_lsp::LspService::new(move |client| {
-        let local_pool = &local_pool;
-        futures::executor::block_on(async move {
-            let (reporter, _guard) = brioche_core::reporter::start_lsp_reporter(client.clone());
-            let brioche = brioche_core::BriocheBuilder::new(reporter)
-                .registry_client(brioche_core::registry::RegistryClient::disabled())
-                .vfs(brioche_core::vfs::Vfs::mutable())
-                .build()
-                .await?;
-            let projects = brioche_core::project::Projects::default();
-            let lsp_server = brioche_core::script::lsp::BriocheLspServer::new(
-                local_pool, brioche, projects, client,
-            )
-            .await?;
-            anyhow::Ok(lsp_server)
-        })
-        .expect("failed to build LSP")
-    });
-
-    // Note: For now, we always use stdio for the LSP
-    tower_lsp::Server::new(stdin, stdout, socket)
-        .serve(service)
-        .await;
-
-    Ok(())
 }
 
 #[derive(Debug, Parser)]
@@ -894,44 +191,6 @@ async fn export_project(args: ExportProjectArgs) -> anyhow::Result<()> {
 
     println!("{}", serialized);
     Ok(())
-}
-
-#[derive(Debug, Parser)]
-struct RunSandboxArgs {
-    #[arg(long)]
-    config: String,
-}
-
-fn run_sandbox(args: RunSandboxArgs) -> ExitCode {
-    let config = match serde_json::from_str::<SandboxExecutionConfig>(&args.config) {
-        Ok(config) => config,
-        Err(error) => {
-            eprintln!("brioche: failed to parse sandbox config: {error:#}");
-            return ExitCode::from(BRIOCHE_SANDBOX_ERROR_CODE);
-        }
-    };
-
-    let status = match brioche_core::sandbox::run_sandbox(config) {
-        Ok(status) => status,
-        Err(error) => {
-            eprintln!("brioche: failed to run sandbox: {error:#}");
-            return ExitCode::from(BRIOCHE_SANDBOX_ERROR_CODE);
-        }
-    };
-
-    status
-        .code()
-        .and_then(|code| {
-            let code: u8 = code.try_into().ok()?;
-            Some(ExitCode::from(code))
-        })
-        .unwrap_or_else(|| {
-            if status.success() {
-                ExitCode::SUCCESS
-            } else {
-                ExitCode::FAILURE
-            }
-        })
 }
 
 async fn load_project(

--- a/crates/brioche/src/main.rs
+++ b/crates/brioche/src/main.rs
@@ -1,9 +1,4 @@
-use std::{
-    collections::HashMap,
-    path::{Path, PathBuf},
-    process::ExitCode,
-    sync::Arc,
-};
+use std::{collections::HashMap, path::PathBuf, process::ExitCode, sync::Arc};
 
 use brioche_core::reporter::ConsoleReporterKind;
 use clap::Parser;
@@ -21,27 +16,41 @@ mod self_update;
 #[derive(Debug, Parser)]
 #[command(version)]
 enum Args {
+    /// Build a project
     Build(build::BuildArgs),
 
+    /// Build a project, then run the result
     Run(run::RunArgs),
 
+    /// Build a project, then install it globally
     Install(install::InstallArgs),
 
+    /// Check a project for type errors
     Check(check::CheckArgs),
 
+    /// Format the Brioche files in a project
     #[command(name = "fmt")]
     Format(format::FormatArgs),
 
+    /// Publish a project to a registry
     Publish(publish::PublishArgs),
 
+    /// Start the Language Server Protocol server
     Lsp(lsp::LspArgs),
 
+    /// Update Brioche itself
     SelfUpdate(self_update::SelfUpdateArgs),
 
+    /// Internal tool: analyze a project
+    #[command(hide = true)]
     Analyze(AnalyzeArgs),
 
+    /// Internal tool: serialize an entire project as JSON
+    #[command(hide = true)]
     ExportProject(ExportProjectArgs),
 
+    /// Used by Brioche itself to run a sandboxed process
+    #[command(hide = true)]
     RunSandbox(run_sandbox::RunSandboxArgs),
 }
 
@@ -209,13 +218,23 @@ async fn export_project(args: ExportProjectArgs) -> anyhow::Result<()> {
     Ok(())
 }
 
+#[derive(Debug, clap::Args)]
+struct ProjectArgs {
+    /// The path of the project directory to build [default: .]
+    #[clap(short, long)]
+    project: Option<PathBuf>,
+
+    /// The name of a registry project to build
+    #[clap(short, long)]
+    registry: Option<String>,
+}
+
 async fn load_project(
     brioche: &brioche_core::Brioche,
     projects: &brioche_core::project::Projects,
-    project_arg: Option<&Path>,
-    registry_arg: Option<&str>,
+    args: &ProjectArgs,
 ) -> anyhow::Result<brioche_core::project::ProjectHash> {
-    let project_hash = match (project_arg, registry_arg) {
+    let project_hash = match (&args.project, &args.registry) {
         (Some(project), None) => projects.load(brioche, project, true).await?,
         (None, Some(registry)) => {
             projects

--- a/crates/brioche/src/main.rs
+++ b/crates/brioche/src/main.rs
@@ -294,7 +294,7 @@ async fn build(args: BuildArgs) -> anyhow::Result<ExitCode> {
     };
 
     let exit_code = build_future
-        .instrument(tracing::info_span!("build", args = ?args))
+        .instrument(tracing::info_span!("build"))
         .await?;
 
     Ok(exit_code)
@@ -434,7 +434,7 @@ async fn run(args: RunArgs) -> anyhow::Result<ExitCode> {
     };
 
     let output = build_future
-        .instrument(tracing::info_span!("run_build", args = ?args))
+        .instrument(tracing::info_span!("run_build"))
         .await?;
 
     let command_path = output.path.join(&args.command);
@@ -620,7 +620,7 @@ async fn install(args: InstallArgs) -> anyhow::Result<ExitCode> {
     };
 
     let exit_code = install_future
-        .instrument(tracing::info_span!("run_install", args = ?args))
+        .instrument(tracing::info_span!("run_install"))
         .await?;
 
     Ok(exit_code)
@@ -674,7 +674,7 @@ async fn check(args: CheckArgs) -> anyhow::Result<ExitCode> {
     };
 
     let exit_code = check_future
-        .instrument(tracing::info_span!("check", args = ?args))
+        .instrument(tracing::info_span!("check"))
         .await?;
 
     Ok(exit_code)
@@ -725,7 +725,7 @@ async fn format(args: FormatArgs) -> anyhow::Result<ExitCode> {
     };
 
     let exit_code = format_future
-        .instrument(tracing::info_span!("format", args = ?args))
+        .instrument(tracing::info_span!("format"))
         .await?;
 
     Ok(exit_code)

--- a/crates/brioche/src/main.rs
+++ b/crates/brioche/src/main.rs
@@ -130,7 +130,7 @@ struct BuildArgs {
     #[arg(long)]
     merge: bool,
     #[arg(long)]
-    keep: bool,
+    keep_temps: bool,
     #[arg(long)]
     sync: bool,
 }
@@ -141,7 +141,7 @@ async fn build(args: BuildArgs) -> anyhow::Result<ExitCode> {
     reporter.set_is_evaluating(true);
 
     let brioche = brioche_core::BriocheBuilder::new(reporter.clone())
-        .keep_temps(args.keep)
+        .keep_temps(args.keep_temps)
         .sync(args.sync)
         .build()
         .await?;

--- a/crates/brioche/src/main.rs
+++ b/crates/brioche/src/main.rs
@@ -18,6 +18,8 @@ enum Args {
 
     Run(RunArgs),
 
+    Install(InstallArgs),
+
     Check(CheckArgs),
 
     #[command(name = "fmt")]
@@ -55,6 +57,15 @@ fn main() -> anyhow::Result<ExitCode> {
                 .build()?;
 
             let exit_code = rt.block_on(run(args))?;
+
+            Ok(exit_code)
+        }
+        Args::Install(args) => {
+            let rt = tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()?;
+
+            let exit_code = rt.block_on(install(args))?;
 
             Ok(exit_code)
         }
@@ -459,6 +470,160 @@ async fn run(args: RunArgs) -> anyhow::Result<ExitCode> {
             }
         }
     }
+}
+
+#[derive(Debug, Parser)]
+struct InstallArgs {
+    #[arg(short, long)]
+    project: Option<PathBuf>,
+    #[arg(short, long)]
+    registry: Option<String>,
+    #[arg(short, long, default_value = "default")]
+    export: String,
+    #[arg(long)]
+    check: bool,
+}
+
+async fn install(args: InstallArgs) -> anyhow::Result<ExitCode> {
+    let (reporter, mut guard) =
+        brioche_core::reporter::start_console_reporter(ConsoleReporterKind::Auto)?;
+    reporter.set_is_evaluating(true);
+
+    let brioche = brioche_core::BriocheBuilder::new(reporter.clone())
+        .build()
+        .await?;
+    let projects = brioche_core::project::Projects::default();
+
+    let install_future = async {
+        let project_hash = load_project(
+            &brioche,
+            &projects,
+            args.project.as_deref(),
+            args.registry.as_deref(),
+        )
+        .await?;
+
+        let num_lockfiles_updated = projects.commit_dirty_lockfiles().await?;
+        if num_lockfiles_updated > 0 {
+            tracing::info!(num_lockfiles_updated, "updated lockfiles");
+        }
+
+        if args.check {
+            let checked =
+                brioche_core::script::check::check(&brioche, &projects, project_hash).await?;
+
+            let result = checked.ensure_ok(brioche_core::script::check::DiagnosticLevel::Error);
+
+            match result {
+                Ok(()) => reporter.emit(superconsole::Lines::from_multiline_string(
+                    "No errors found",
+                    superconsole::style::ContentStyle {
+                        foreground_color: Some(superconsole::style::Color::Green),
+                        ..superconsole::style::ContentStyle::default()
+                    },
+                )),
+                Err(diagnostics) => {
+                    guard.shutdown_console().await;
+
+                    diagnostics.write(&brioche.vfs, &mut std::io::stdout())?;
+                    anyhow::bail!("checks failed");
+                }
+            }
+        }
+
+        let recipe = brioche_core::script::evaluate::evaluate(
+            &brioche,
+            &projects,
+            project_hash,
+            &args.export,
+        )
+        .await?;
+
+        reporter.set_is_evaluating(false);
+        let artifact = brioche_core::bake::bake(
+            &brioche,
+            recipe,
+            &brioche_core::bake::BakeScope::Project {
+                project_hash,
+                export: args.export.to_string(),
+            },
+        )
+        .await?;
+
+        guard.shutdown_console().await;
+
+        let elapsed = reporter.elapsed().human_duration();
+        let num_jobs = reporter.num_jobs();
+        let jobs_message = match num_jobs {
+            0 => "(no new jobs)".to_string(),
+            1 => "1 job".to_string(),
+            n => format!("{n} jobs"),
+        };
+        eprintln!("Build finished, completed {jobs_message} in {elapsed}");
+
+        // Ensure the artifact is a directory
+        let mut directory = match artifact.value {
+            brioche_core::recipe::Artifact::File(_) => {
+                anyhow::bail!("artifact returned a file, expected a directory");
+            }
+            brioche_core::recipe::Artifact::Symlink { .. } => {
+                anyhow::bail!("artifact returned a symlink, expected a directory");
+            }
+            brioche_core::recipe::Artifact::Directory(dir) => dir,
+        };
+
+        // Remove the top-level `brioche-run` file if it exists
+        directory.insert(&brioche, b"brioche-run", None).await?;
+
+        // Create the installation directory if it doesn't exist
+        let install_dir = brioche.home.join("installed");
+        tokio::fs::create_dir_all(&install_dir)
+            .await
+            .with_context(|| {
+                format!(
+                    "failed to create installation directory {}",
+                    install_dir.display()
+                )
+            })?;
+
+        println!("Writing output");
+        brioche_core::output::create_output(
+            &brioche,
+            &brioche_core::recipe::Artifact::Directory(directory),
+            brioche_core::output::OutputOptions {
+                output_path: &install_dir,
+                merge: true,
+                resource_dir: None,
+                mtime: Some(std::time::SystemTime::now()),
+                link_locals: false,
+            },
+        )
+        .await?;
+        println!("Wrote output to {}", install_dir.display());
+
+        let install_bin_dir = install_dir.join("bin");
+        let install_bin_dir_exists = tokio::fs::try_exists(&install_bin_dir).await?;
+        let is_on_path = match std::env::var_os("PATH") {
+            Some(env_path) => {
+                let mut paths = std::env::split_paths(&env_path);
+                paths.any(|path| path == install_bin_dir)
+            }
+            None => false,
+        };
+
+        if install_bin_dir_exists && !is_on_path {
+            println!("Note: installation directory not detected in $PATH! Consider adding it:");
+            println!("  {}", install_bin_dir.display());
+        }
+
+        Ok(ExitCode::SUCCESS)
+    };
+
+    let exit_code = install_future
+        .instrument(tracing::info_span!("run_install", args = ?args))
+        .await?;
+
+    Ok(exit_code)
 }
 
 #[derive(Debug, Parser)]

--- a/crates/brioche/src/main.rs
+++ b/crates/brioche/src/main.rs
@@ -16,6 +16,7 @@ mod lsp;
 mod publish;
 mod run;
 mod run_sandbox;
+mod self_update;
 
 #[derive(Debug, Parser)]
 #[command(version)]
@@ -34,6 +35,8 @@ enum Args {
     Publish(publish::PublishArgs),
 
     Lsp(lsp::LspArgs),
+
+    SelfUpdate(self_update::SelfUpdateArgs),
 
     Analyze(AnalyzeArgs),
 
@@ -108,6 +111,19 @@ fn main() -> anyhow::Result<ExitCode> {
             rt.block_on(lsp::lsp(args))?;
 
             Ok(ExitCode::SUCCESS)
+        }
+        Args::SelfUpdate(args) => {
+            let rt = tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()?;
+
+            let updated = rt.block_on(self_update::self_update(args))?;
+
+            if updated {
+                Ok(ExitCode::SUCCESS)
+            } else {
+                Ok(ExitCode::FAILURE)
+            }
         }
         Args::Analyze(args) => {
             let rt = tokio::runtime::Builder::new_multi_thread()

--- a/crates/brioche/src/main.rs
+++ b/crates/brioche/src/main.rs
@@ -128,6 +128,8 @@ struct BuildArgs {
     #[arg(long)]
     replace: bool,
     #[arg(long)]
+    merge: bool,
+    #[arg(long)]
     keep: bool,
     #[arg(long)]
     sync: bool,
@@ -222,7 +224,7 @@ async fn build(args: BuildArgs) -> anyhow::Result<ExitCode> {
                 &artifact.value,
                 brioche_core::output::OutputOptions {
                     output_path: output,
-                    merge: false,
+                    merge: args.merge,
                     resource_dir: None,
                     mtime: Some(std::time::SystemTime::now()),
                     link_locals: false,

--- a/crates/brioche/src/publish.rs
+++ b/crates/brioche/src/publish.rs
@@ -1,0 +1,71 @@
+use std::{path::PathBuf, process::ExitCode};
+
+use brioche_core::reporter::ConsoleReporterKind;
+use clap::Parser;
+
+#[derive(Debug, Parser)]
+pub struct PublishArgs {
+    #[arg(short, long)]
+    project: PathBuf,
+}
+
+pub async fn publish(args: PublishArgs) -> anyhow::Result<ExitCode> {
+    let (reporter, mut guard) =
+        brioche_core::reporter::start_console_reporter(ConsoleReporterKind::Auto)?;
+
+    let brioche = brioche_core::BriocheBuilder::new(reporter).build().await?;
+    let projects = brioche_core::project::Projects::default();
+    let project_hash = projects.load(&brioche, &args.project, true).await?;
+
+    let project = projects.project(project_hash)?;
+    let name = project.definition.name.as_deref().unwrap_or("[unnamed]");
+    let version = project
+        .definition
+        .version
+        .as_deref()
+        .unwrap_or("[unversioned]");
+
+    let lockfile_result = projects.validate_no_dirty_lockfiles();
+    match lockfile_result {
+        Ok(()) => {}
+        Err(error) => {
+            eprintln!("{error:#}");
+            return Ok(ExitCode::FAILURE);
+        }
+    }
+
+    let checked = brioche_core::script::check::check(&brioche, &projects, project_hash).await?;
+    let check_results = checked.ensure_ok(brioche_core::script::check::DiagnosticLevel::Warning);
+    match check_results {
+        Ok(()) => {
+            println!("No errors found 🎉");
+        }
+        Err(diagnostics) => {
+            diagnostics.write(&brioche.vfs, &mut std::io::stdout())?;
+            return Ok(ExitCode::FAILURE);
+        }
+    }
+
+    guard.shutdown_console().await;
+
+    let response =
+        brioche_core::publish::publish_project(&brioche, &projects, project_hash, true).await?;
+
+    if response.tags.is_empty() {
+        println!("Project already up to date: {} {}", name, version);
+    } else {
+        println!("🚀 Published project {} {}", name, version);
+        println!();
+        println!("Updated tags:");
+        for tag in &response.tags {
+            let status = if tag.previous_hash.is_some() {
+                "updated"
+            } else {
+                "new"
+            };
+            println!("  {} {} ({status})", tag.name, tag.tag);
+        }
+    }
+
+    Ok(ExitCode::SUCCESS)
+}

--- a/crates/brioche/src/publish.rs
+++ b/crates/brioche/src/publish.rs
@@ -5,6 +5,7 @@ use clap::Parser;
 
 #[derive(Debug, Parser)]
 pub struct PublishArgs {
+    /// The path to the project directory to publish
     #[arg(short, long)]
     project: PathBuf,
 }

--- a/crates/brioche/src/run.rs
+++ b/crates/brioche/src/run.rs
@@ -1,0 +1,179 @@
+use std::{path::PathBuf, process::ExitCode};
+
+use anyhow::Context as _;
+use brioche_core::reporter::ConsoleReporterKind;
+use clap::Parser;
+use human_repr::HumanDuration;
+use tracing::Instrument;
+
+#[derive(Debug, Parser)]
+pub struct RunArgs {
+    #[arg(short, long)]
+    project: Option<PathBuf>,
+    #[arg(short, long)]
+    registry: Option<String>,
+    #[arg(short, long, default_value = "default")]
+    export: String,
+    #[arg(short, long, default_value = "brioche-run")]
+    command: String,
+    #[arg(short, long)]
+    quiet: bool,
+    #[arg(long)]
+    check: bool,
+    #[arg(long)]
+    keep: bool,
+    #[arg(last = true)]
+    args: Vec<std::ffi::OsString>,
+}
+
+pub async fn run(args: RunArgs) -> anyhow::Result<ExitCode> {
+    let (reporter, mut guard) = if args.quiet {
+        brioche_core::reporter::start_null_reporter()
+    } else {
+        brioche_core::reporter::start_console_reporter(ConsoleReporterKind::Auto)?
+    };
+    reporter.set_is_evaluating(true);
+
+    let brioche = brioche_core::BriocheBuilder::new(reporter.clone())
+        .keep_temps(args.keep)
+        .build()
+        .await?;
+    let projects = brioche_core::project::Projects::default();
+
+    let build_future = async {
+        let project_hash = super::load_project(
+            &brioche,
+            &projects,
+            args.project.as_deref(),
+            args.registry.as_deref(),
+        )
+        .await?;
+
+        let num_lockfiles_updated = projects.commit_dirty_lockfiles().await?;
+        if num_lockfiles_updated > 0 {
+            tracing::info!(num_lockfiles_updated, "updated lockfiles");
+        }
+
+        if args.check {
+            let checked =
+                brioche_core::script::check::check(&brioche, &projects, project_hash).await?;
+
+            let result = checked.ensure_ok(brioche_core::script::check::DiagnosticLevel::Error);
+
+            match result {
+                Ok(()) => reporter.emit(superconsole::Lines::from_multiline_string(
+                    "No errors found",
+                    superconsole::style::ContentStyle {
+                        foreground_color: Some(superconsole::style::Color::Green),
+                        ..superconsole::style::ContentStyle::default()
+                    },
+                )),
+                Err(diagnostics) => {
+                    guard.shutdown_console().await;
+
+                    diagnostics.write(&brioche.vfs, &mut std::io::stdout())?;
+                    anyhow::bail!("checks failed");
+                }
+            }
+        }
+
+        let recipe = brioche_core::script::evaluate::evaluate(
+            &brioche,
+            &projects,
+            project_hash,
+            &args.export,
+        )
+        .await?;
+
+        reporter.set_is_evaluating(false);
+        let artifact = brioche_core::bake::bake(
+            &brioche,
+            recipe,
+            &brioche_core::bake::BakeScope::Project {
+                project_hash,
+                export: args.export.to_string(),
+            },
+        )
+        .await?;
+
+        guard.shutdown_console().await;
+
+        let elapsed = reporter.elapsed().human_duration();
+        let num_jobs = reporter.num_jobs();
+        let jobs_message = match num_jobs {
+            0 => "(no new jobs)".to_string(),
+            1 => "1 job".to_string(),
+            n => format!("{n} jobs"),
+        };
+        if !args.quiet {
+            eprintln!("Build finished, completed {jobs_message} in {elapsed}");
+        }
+
+        // Validate that the artifact is a directory that contains the
+        // command to run before returning
+        let command_artifact = match &artifact.value {
+            brioche_core::recipe::Artifact::File(_) => {
+                anyhow::bail!("artifact returned a file, expected a directory");
+            }
+            brioche_core::recipe::Artifact::Symlink { .. } => {
+                anyhow::bail!("artifact returned a symlink, expected a directory");
+            }
+            brioche_core::recipe::Artifact::Directory(dir) => dir
+                .get(&brioche, args.command.as_bytes())
+                .await
+                .with_context(|| {
+                    format!(
+                        "failed to retrieve {:?} from returned artifact",
+                        args.command
+                    )
+                })?,
+        };
+        anyhow::ensure!(
+            command_artifact.is_some(),
+            "{:?} not found in returned artifact",
+            args.command
+        );
+
+        let output = brioche_core::output::create_local_output(&brioche, &artifact.value).await?;
+
+        Ok(output)
+    };
+
+    let output = build_future
+        .instrument(tracing::info_span!("run_build"))
+        .await?;
+
+    let command_path = output.path.join(&args.command);
+
+    if !args.quiet {
+        eprintln!("Running {}", args.command);
+    }
+
+    let mut command = std::process::Command::new(command_path);
+    command.args(&args.args);
+
+    if let Some(resource_dir) = output.resource_dir {
+        command.env("BRIOCHE_RESOURCE_DIR", resource_dir);
+    }
+
+    cfg_if::cfg_if! {
+        if #[cfg(unix)] {
+            use std::os::unix::process::CommandExt as _;
+
+            let error = command.exec();
+            Err(error.into())
+        } else {
+            let result = command.status().context("failed to run process")?;
+            if result.success() {
+                Ok(ExitCode::SUCCESS)
+            } else {
+                let code = result
+                    .code()
+                    .and_then(|code| u8::try_from(code).ok())
+                    .map(ExitCode::from)
+                    .unwrap_or(ExitCode::FAILURE);
+                Ok(code)
+            }
+        }
+    }
+}

--- a/crates/brioche/src/run_sandbox.rs
+++ b/crates/brioche/src/run_sandbox.rs
@@ -1,0 +1,44 @@
+use std::process::ExitCode;
+
+use brioche_core::sandbox::SandboxExecutionConfig;
+use clap::Parser;
+
+const BRIOCHE_SANDBOX_ERROR_CODE: u8 = 122;
+
+#[derive(Debug, Parser)]
+pub struct RunSandboxArgs {
+    #[arg(long)]
+    config: String,
+}
+
+pub fn run_sandbox(args: RunSandboxArgs) -> ExitCode {
+    let config = match serde_json::from_str::<SandboxExecutionConfig>(&args.config) {
+        Ok(config) => config,
+        Err(error) => {
+            eprintln!("brioche: failed to parse sandbox config: {error:#}");
+            return ExitCode::from(BRIOCHE_SANDBOX_ERROR_CODE);
+        }
+    };
+
+    let status = match brioche_core::sandbox::run_sandbox(config) {
+        Ok(status) => status,
+        Err(error) => {
+            eprintln!("brioche: failed to run sandbox: {error:#}");
+            return ExitCode::from(BRIOCHE_SANDBOX_ERROR_CODE);
+        }
+    };
+
+    status
+        .code()
+        .and_then(|code| {
+            let code: u8 = code.try_into().ok()?;
+            Some(ExitCode::from(code))
+        })
+        .unwrap_or_else(|| {
+            if status.success() {
+                ExitCode::SUCCESS
+            } else {
+                ExitCode::FAILURE
+            }
+        })
+}

--- a/crates/brioche/src/self_update.rs
+++ b/crates/brioche/src/self_update.rs
@@ -9,6 +9,7 @@ use sha2::Digest as _;
 
 #[derive(Debug, Parser)]
 pub struct SelfUpdateArgs {
+    /// Confirm the update without prompting
     #[arg(short = 'y', long)]
     confirm: bool,
 }

--- a/crates/brioche/src/self_update.rs
+++ b/crates/brioche/src/self_update.rs
@@ -1,0 +1,211 @@
+use std::{
+    collections::HashMap,
+    io::{IsTerminal, Write as _},
+};
+
+use anyhow::Context as _;
+use clap::Parser;
+use sha2::Digest as _;
+
+#[derive(Debug, Parser)]
+pub struct SelfUpdateArgs {
+    #[arg(short = 'y', long)]
+    confirm: bool,
+}
+
+const MANIFEST_URL: &str = "https://releases.brioche.dev/updates/update-manifest-v1.json";
+
+const CURRENT_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+pub async fn self_update(args: SelfUpdateArgs) -> anyhow::Result<bool> {
+    let brioche_path = std::env::current_exe().context("failed to get current executable path")?;
+    let brioche_path_temp = brioche_path.with_extension(format!("{}.tmp", ulid::Ulid::new()));
+
+    let platform = brioche_core::platform::current_platform();
+    let update_manifest = get_update_platform_manifest(platform).await?;
+
+    let Some(update_manifest) = update_manifest else {
+        println!("No updates available for {}", CURRENT_VERSION);
+        return Ok(false);
+    };
+
+    println!("Update available");
+    println!("  Version: {}", update_manifest.version);
+    println!("  URL: {}", update_manifest.url);
+    println!("  SHA-256: {}", update_manifest.sha256);
+    println!("  Platform: {platform}");
+    println!("  Path: {}", brioche_path.display());
+
+    let should_update = if args.confirm {
+        true
+    } else {
+        confirm_update().await?
+    };
+
+    if !should_update {
+        println!("Aborting update");
+        return Ok(false);
+    }
+
+    println!("Downloading update...");
+
+    let new_update = reqwest::get(&update_manifest.url)
+        .await?
+        .error_for_status()?
+        .bytes()
+        .await?;
+    let actual_hash = sha2::Sha256::digest(&new_update);
+    let actual_hash_string = hex::encode(actual_hash);
+
+    if actual_hash_string.to_lowercase() != update_manifest.sha256.to_lowercase() {
+        println!("Downloaded update does not match expected hash");
+        println!("  Expected: {}", update_manifest.sha256);
+        println!("  Actual:   {}", actual_hash_string);
+        anyhow::bail!("hash mismatch");
+    }
+
+    println!("Downloaded update");
+
+    tokio::fs::write(&brioche_path_temp, new_update)
+        .await
+        .with_context(|| format!("failed to write update to {}", brioche_path_temp.display()))?;
+    tokio::fs::rename(&brioche_path_temp, &brioche_path)
+        .await
+        .with_context(|| {
+            format!(
+                "failed to rename {} to {}",
+                brioche_path_temp.display(),
+                brioche_path.display()
+            )
+        })?;
+
+    Ok(true)
+}
+
+async fn get_update_version_manifest() -> anyhow::Result<Option<SelfUpdateVersionManifest>> {
+    // Download the manifest
+    let client = reqwest::Client::new();
+    let response = client
+        .get(MANIFEST_URL)
+        .timeout(std::time::Duration::from_secs(10))
+        .send()
+        .await
+        .context("failed to fetch update manifest")?;
+    let mut manifest: SelfUpdateManifest = response
+        .error_for_status()?
+        .json()
+        .await
+        .context("failed to get update manifest")?;
+
+    // Get the manifest for the current version
+    let Some(version) = manifest.versions.remove(CURRENT_VERSION) else {
+        return Ok(None);
+    };
+
+    // Parse the manifest
+    let manifest: SelfUpdateVersionManifest =
+        serde_json::from_value(version).context("failed to parse update manifest")?;
+    Ok(Some(manifest))
+}
+
+async fn get_update_platform_manifest(
+    platform: brioche_core::platform::Platform,
+) -> anyhow::Result<Option<SelfUpdatePlatformManifest>> {
+    let update_manifest = get_update_version_manifest().await?;
+    let Some(update_manifest) = update_manifest else {
+        return Ok(None);
+    };
+
+    let platform_manifest = match update_manifest {
+        SelfUpdateVersionManifest::Update { platforms, message } => {
+            if let Some(message) = message {
+                println!("The update server returned the following message:");
+                println!("  {message:?}");
+            }
+
+            let Some(platform_manifest) = platforms.get(&platform.to_string()) else {
+                println!("No update returned for platform {platform}");
+                return Ok(None);
+            };
+
+            platform_manifest.clone()
+        }
+        SelfUpdateVersionManifest::Notice { message } => {
+            if let Some(message) = message {
+                println!("The update server returned the following message:");
+                println!("  {message:?}");
+            }
+
+            return Ok(None);
+        }
+    };
+
+    Ok(Some(platform_manifest))
+}
+
+async fn confirm_update() -> anyhow::Result<bool> {
+    let (tx, rx) = tokio::sync::oneshot::channel();
+
+    std::thread::spawn(move || {
+        print!("Install update? [y/N] ");
+        match std::io::stdout().flush() {
+            Ok(_) => {}
+            Err(error) => {
+                let _ = tx.send(Err(error));
+                return;
+            }
+        }
+
+        let stdin = std::io::stdin();
+
+        if !stdin.is_terminal() {
+            println!();
+            println!("Pass `--confirm` to install update non-interactively");
+            let _ = tx.send(Ok(false));
+            return;
+        }
+
+        let mut line = String::new();
+        match stdin.read_line(&mut line) {
+            Ok(_) => {}
+            Err(error) => {
+                let _ = tx.send(Err(error));
+                return;
+            }
+        }
+
+        let input = line.trim().to_lowercase();
+        let confirmed = matches!(input.as_str(), "y" | "yes");
+        let _ = tx.send(Ok(confirmed));
+    });
+
+    let response = rx.await??;
+    Ok(response)
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SelfUpdateManifest {
+    versions: HashMap<String, serde_json::Value>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "type")]
+#[serde(rename_all = "snake_case")]
+enum SelfUpdateVersionManifest {
+    #[serde(rename_all = "camelCase")]
+    Update {
+        message: Option<String>,
+        platforms: HashMap<String, SelfUpdatePlatformManifest>,
+    },
+    #[serde(rename_all = "camelCase")]
+    Notice { message: Option<String> },
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SelfUpdatePlatformManifest {
+    url: String,
+    sha256: String,
+    version: String,
+}


### PR DESCRIPTION
This PR makes lots of little quality-of-life tweaks to the CLI:

- Add `brioche install` subcommand. This will install an artifact to `~/.local/share/brioche/installed` (right now, it just outputs to the folder and merges, and also removes the `brioche-run` file from the artifact)
- Add `-r` / `--registry` flag for `build` / `install` / `check`. This allows for using a registry project rather than a local project (meaning you can now run `brioche install -r curl` to install Curl!)
- Add `brioche self-update` subcommand. As the name implies, this updates Brioche itself
- Add help text for all commands / arguments
- Rename `--keep` flag to `--keep-temps` for clarity
- Restructure all CLI commands into separate submodules