### PR TITLE
Fetch fetching a project form registry failing when project uses includes

### DIFF
--- a/crates/brioche-core/src/project.rs
+++ b/crates/brioche-core/src/project.rs
@@ -975,7 +975,7 @@ async fn fetch_project_from_registry(
         .values()
         .flat_map(|module_statics| module_statics.values().filter_map(|recipe| *recipe))
         .collect::<HashSet<_>>();
-    crate::registry::fetch_recipes(brioche, &statics_recipes).await?;
+    crate::registry::fetch_recipes_deep(brioche, statics_recipes).await?;
 
     for (module_path, statics) in &project.statics {
         for (static_, recipe_hash) in statics {

--- a/crates/brioche-core/src/project.rs
+++ b/crates/brioche-core/src/project.rs
@@ -772,10 +772,10 @@ async fn try_load_path_dependency_with_errors(
 
             Some(dep_hash)
         }
-        Err(err) => {
+        Err(error) => {
             errors.push(LoadProjectError::FailedToLoadDependency {
                 name: name.to_owned(),
-                cause: err.to_string(),
+                cause: format!("{error:#}"),
             });
             None
         }
@@ -807,10 +807,10 @@ async fn try_load_registry_dependency_with_errors(
     .await;
     let resolved_dep = match resolved_dep_result {
         Ok(resolved_dep) => resolved_dep,
-        Err(err) => {
+        Err(error) => {
             errors.push(LoadProjectError::FailedToLoadDependency {
                 name: name.to_owned(),
-                cause: err.to_string(),
+                cause: format!("{error:#}"),
             });
             return None;
         }
@@ -827,10 +827,10 @@ async fn try_load_registry_dependency_with_errors(
     .await;
     let (actual_hash, _, dep_errors) = match result {
         Ok(dep) => dep,
-        Err(err) => {
+        Err(error) => {
             errors.push(LoadProjectError::FailedToLoadDependency {
                 name: name.to_owned(),
-                cause: err.to_string(),
+                cause: format!("{error:#}"),
             });
             return None;
         }

--- a/crates/brioche-core/src/reporter.rs
+++ b/crates/brioche-core/src/reporter.rs
@@ -336,6 +336,7 @@ impl ConsoleReporter {
                     }
                 }
                 UpdateJob::RegistryFetchAdd { .. } => {}
+                UpdateJob::RegistryFetchUpdate { .. } => {}
                 UpdateJob::RegistryFetchFinish => {
                     eprintln!("Finished fetching from registry");
                 }
@@ -543,6 +544,12 @@ pub enum UpdateJob {
         blobs_fetched: usize,
         recipes_fetched: usize,
     },
+    RegistryFetchUpdate {
+        total_blobs: Option<usize>,
+        total_recipes: Option<usize>,
+        complete_blobs: Option<usize>,
+        complete_recipes: Option<usize>,
+    },
     RegistryFetchFinish,
 }
 
@@ -654,6 +661,37 @@ impl Job {
 
                 *complete_blobs += blobs_fetched;
                 *complete_recipes += recipes_fetched;
+            }
+            UpdateJob::RegistryFetchUpdate {
+                total_blobs: new_total_blobs,
+                total_recipes: new_total_recipes,
+                complete_blobs: new_complete_blobs,
+                complete_recipes: new_complete_recipes,
+            } => {
+                let Self::RegistryFetch {
+                    total_blobs,
+                    total_recipes,
+                    complete_blobs,
+                    complete_recipes,
+                } = self
+                else {
+                    anyhow::bail!(
+                        "tried to update a non-registry-fetch job with a registry-fetch update"
+                    );
+                };
+
+                if let Some(new_total_blobs) = new_total_blobs {
+                    *total_blobs = new_total_blobs;
+                }
+                if let Some(new_total_recipes) = new_total_recipes {
+                    *total_recipes = new_total_recipes;
+                }
+                if let Some(new_complete_blobs) = new_complete_blobs {
+                    *complete_blobs = new_complete_blobs;
+                }
+                if let Some(new_complete_recipes) = new_complete_recipes {
+                    *complete_recipes = new_complete_recipes;
+                }
             }
             UpdateJob::RegistryFetchFinish => {
                 let Self::RegistryFetch {


### PR DESCRIPTION
To fetch a project from the registry, we need to fetch all included `.bri` module files, plus any static includes (`Brioche.glob`, etc.). This PR fixes a case where static includes wouldn't be fetched recursively, causing resolve errors like this:

```sh-session
$ brioche run -r hello_world
[100%] Fetched 1 recipe from registry
Error: failed to fetch 'hello_world' from registry

Caused by:
    recipes not found: {RecipeHash(Hash("fc51c96ac044e3fb1b6c170146a4df37c4991552f7e99bfe85011358d0456ed8"))}
```

This happened because `hello_world` uses `Brioche.glob`. The top-level globbed directory gets fetched, but the entries for the directory were not being fetched. This PR fixes this bug by doing a deep fetch of recipes from the registry.