### PR TITLE
Use a semaphore to limit the max number of blobs that can be saved at once

### DIFF
--- a/crates/brioche-core/benches/brioche_bench/mod.rs
+++ b/crates/brioche-core/benches/brioche_bench/mod.rs
@@ -34,9 +34,15 @@ pub async fn brioche_test() -> (Brioche, TestContext) {
 }
 
 pub async fn blob(brioche: &Brioche, content: impl AsRef<[u8]> + std::marker::Unpin) -> BlobHash {
-    brioche_core::blob::save_blob(brioche, content.as_ref(), SaveBlobOptions::default())
-        .await
-        .unwrap()
+    let permit = brioche_core::blob::get_save_blob_permit().await.unwrap();
+    brioche_core::blob::save_blob(
+        brioche,
+        permit,
+        content.as_ref(),
+        SaveBlobOptions::default(),
+    )
+    .await
+    .unwrap()
 }
 
 pub fn lazy_file(blob: BlobHash, executable: bool) -> brioche_core::recipe::Recipe {

--- a/crates/brioche-core/src/bake.rs
+++ b/crates/brioche-core/src/bake.rs
@@ -380,9 +380,16 @@ async fn run_bake(brioche: &Brioche, recipe: Recipe, meta: &Arc<Meta>) -> anyhow
             executable,
             resources,
         } => {
-            let blob_hash =
-                super::blob::save_blob(brioche, &content, super::blob::SaveBlobOptions::default())
-                    .await?;
+            let blob_hash = {
+                let permit = super::blob::get_save_blob_permit().await?;
+                super::blob::save_blob(
+                    brioche,
+                    permit,
+                    &content,
+                    super::blob::SaveBlobOptions::default(),
+                )
+                .await?
+            };
 
             let resources = bake(brioche, *resources, &scope).await?;
             let Artifact::Directory(resources) = resources.value else {

--- a/crates/brioche-core/src/input.rs
+++ b/crates/brioche-core/src/input.rs
@@ -171,12 +171,16 @@ pub async fn create_input_inner(
             Directory::default()
         };
 
-        let blob_hash = super::blob::save_blob_from_file(
-            brioche,
-            options.input_path,
-            super::blob::SaveBlobOptions::default().remove_input(options.remove_input),
-        )
-        .await?;
+        let blob_hash = {
+            let permit = super::blob::get_save_blob_permit().await?;
+            super::blob::save_blob_from_file(
+                brioche,
+                permit,
+                options.input_path,
+                super::blob::SaveBlobOptions::default().remove_input(options.remove_input),
+            )
+            .await
+        }?;
         let permissions = metadata.permissions();
         let executable = is_executable(&permissions);
 

--- a/crates/brioche-core/src/registry.rs
+++ b/crates/brioche-core/src/registry.rs
@@ -370,7 +370,8 @@ pub async fn fetch_bake_references(
         .try_for_each_concurrent(25, |blob| {
             let brioche = brioche.clone();
             async move {
-                super::blob::blob_path(&brioche, blob).await?;
+                let permit = crate::blob::get_save_blob_permit().await?;
+                super::blob::blob_path(&brioche, permit, blob).await?;
 
                 brioche.reporter.update_job(
                     job_id,
@@ -563,7 +564,8 @@ pub async fn fetch_blobs(brioche: Brioche, blobs: &HashSet<BlobHash>) -> anyhow:
         .try_for_each_concurrent(25, |blob| {
             let brioche = brioche.clone();
             async move {
-                super::blob::blob_path(&brioche, blob).await?;
+                let permit = crate::blob::get_save_blob_permit().await?;
+                super::blob::blob_path(&brioche, permit, blob).await?;
 
                 brioche.reporter.update_job(
                     job_id,

--- a/crates/brioche-core/src/script.rs
+++ b/crates/brioche-core/src/script.rs
@@ -228,7 +228,8 @@ pub async fn op_brioche_read_blob(
             .clone()
     };
 
-    let path = crate::blob::blob_path(&brioche, blob_hash).await?;
+    let permit = crate::blob::get_save_blob_permit().await?;
+    let path = crate::blob::blob_path(&brioche, permit, blob_hash).await?;
     let bytes = tokio::fs::read(path)
         .await
         .with_context(|| format!("failed to read blob {blob_hash}"))?;

--- a/crates/brioche-core/src/sync.rs
+++ b/crates/brioche-core/src/sync.rs
@@ -138,7 +138,10 @@ pub async fn sync_recipe_references(
             let brioche = brioche.clone();
             async move {
                 tokio::spawn(async move {
-                    let blob_path = crate::blob::blob_path(&brioche, blob_hash).await?;
+                    let blob_path = {
+                        let permit = crate::blob::get_save_blob_permit().await?;
+                        crate::blob::blob_path(&brioche, permit, blob_hash).await?
+                    };
 
                     // TODO: Figure out if we can stream the blob (this
                     // will error out due to `reqwest-retry`)

--- a/crates/brioche-core/tests/brioche_test/mod.rs
+++ b/crates/brioche-core/tests/brioche_test/mod.rs
@@ -86,9 +86,15 @@ pub async fn bake_without_meta(
 }
 
 pub async fn blob(brioche: &Brioche, content: impl AsRef<[u8]> + std::marker::Unpin) -> BlobHash {
-    brioche_core::blob::save_blob_from_reader(brioche, content.as_ref(), SaveBlobOptions::default())
-        .await
-        .unwrap()
+    let permit = brioche_core::blob::get_save_blob_permit().await.unwrap();
+    brioche_core::blob::save_blob_from_reader(
+        brioche,
+        permit,
+        content.as_ref(),
+        SaveBlobOptions::default(),
+    )
+    .await
+    .unwrap()
 }
 
 pub fn lazy_file(blob: BlobHash, executable: bool) -> brioche_core::recipe::Recipe {

--- a/crates/brioche-core/tests/output.rs
+++ b/crates/brioche-core/tests/output.rs
@@ -739,7 +739,7 @@ async fn test_output_with_links() -> anyhow::Result<()> {
     let (brioche, context) = brioche_test::brioche_test().await;
 
     let hello_blob = brioche_test::blob(&brioche, b"hello").await;
-    let hello_blob_path = brioche_core::blob::blob_path(&brioche, hello_blob).await?;
+    let hello_blob_path = brioche_core::blob::local_blob_path(&brioche, hello_blob);
 
     let hello = brioche_test::file(hello_blob, false);
     let hello_exe = brioche_test::file(hello_blob, true);


### PR DESCRIPTION
After a fresh install of Brioche, running `brioche build -r curl` would fail with an error message like `Error: Error: failed to open temp file: Too many open files (os error 24)`. Re-running the command several times would eventually work (because each iteration would make a little more progress), but it's not a great first-time experience.

This PR works around the problem by updating all the functions that save blobs to take a `SaveBlobPermit` type, which wraps a global semaphore (currently set to 10 permits). This prevents trying to open too many file descriptors at once, and this seems to work around the issue on a fairly vanilla Ubuntu setup.

I tried giving it 20 permits as well, but this failed with the same error as before. I'm not sure why trying to save 20+ blobs at a time would be causing issues (I couldn't imagine that saving a blob would use more than 2-4 file descriptors, so saving 20 would seem completely reasonable... but I haven't looked into this in depth yet).