### PR TITLE
Add new "metadata" pack format

### DIFF
--- a/crates/brioche-pack/src/autowrap.rs
+++ b/crates/brioche-pack/src/autowrap.rs
@@ -287,8 +287,9 @@ fn collect_all_library_dirs(
 
         if let Ok(library_pack) = crate::extract_pack(&library_file[..]) {
             let library_dirs = match &library_pack {
-                crate::Pack::LdLinux { library_dirs, .. } => library_dirs,
-                crate::Pack::Static { library_dirs } => library_dirs,
+                crate::Pack::LdLinux { library_dirs, .. } => &library_dirs[..],
+                crate::Pack::Static { library_dirs } => &library_dirs[..],
+                crate::Pack::Metadata { .. } => &[],
             };
 
             for library_dir in library_dirs {

--- a/crates/brioche-pack/src/lib.rs
+++ b/crates/brioche-pack/src/lib.rs
@@ -35,6 +35,14 @@ pub enum Pack {
         #[serde_as(as = "Vec<TickEncoded>")]
         library_dirs: Vec<Vec<u8>>,
     },
+    #[serde(rename_all = "camelCase")]
+    Metadata {
+        #[serde_as(as = "Vec<TickEncoded>")]
+        resource_paths: Vec<Vec<u8>>,
+        format: String,
+        #[serde_as(as = "TickEncoded")]
+        metadata: Vec<u8>,
+    },
 }
 
 impl Pack {
@@ -55,6 +63,9 @@ impl Pack {
             Self::Static { library_dirs } => {
                 paths.extend(library_dirs.iter().cloned().map(bstr::BString::from));
             }
+            Self::Metadata { resource_paths, .. } => {
+                paths.extend(resource_paths.iter().cloned().map(bstr::BString::from));
+            }
         }
 
         paths
@@ -69,6 +80,7 @@ impl Pack {
                 // add it to the executable
                 !library_dirs.is_empty()
             }
+            Pack::Metadata { .. } => true,
         }
     }
 }

--- a/crates/brioche-packed-plain-exec/src/main.rs
+++ b/crates/brioche-packed-plain-exec/src/main.rs
@@ -105,6 +105,9 @@ fn run() -> Result<(), PackedError> {
         brioche_pack::Pack::Static { .. } => {
             unimplemented!("execution of a static executable");
         }
+        brioche_pack::Pack::Metadata { .. } => {
+            unimplemented!("execution of a metadata pack");
+        }
     }
 }
 

--- a/crates/brioche-packed-userland-exec/src/linux.rs
+++ b/crates/brioche-packed-userland-exec/src/linux.rs
@@ -148,6 +148,9 @@ fn run(args: &[&CStr], env_vars: &[&CStr]) -> Result<(), PackedError> {
         brioche_pack::Pack::Static { .. } => {
             unimplemented!("execution of a static executable");
         }
+        brioche_pack::Pack::Metadata { .. } => {
+            unimplemented!("execution of a metadata pack");
+        }
     }
 }
 


### PR DESCRIPTION
This PR adds a new "metadata" variant to the enum of pack formats (used for storing resources, etc.).

For context, the pack format is produced by `brioche-ld` and is used for two purposes:

- It's used by Brioche to attach resources to files
- It's used by `brioche-packed-userland-exec` to determine what libraries, etc. to pass to the program

Since the pack format uses Bincode, adding new fields has been a headache because each side stops understanding the format each time new fields are added. But, I've had to iterate on the format a few times to change how packed executables work, so basically this meant any improvements to packed executables effectively needed to be a breaking change. My reading of the Bincode spec is that enum variants are assigned a variant ID based on their index, meaning this change should be backwards-compatible since the existing enum variants keep the same index and didn't change otherwise.

This new pack format is meant to be really simple: it includes an explicit list of resource paths, a format name, and arbitrary extra metadata. This lets us separate out the two purposes of the data above:

- Brioche only cares about the resource paths, so the underlying metadata format can change and Brioche will still know how to attach resources properly
- `brioche-ld` and `brioche-packed-userland-exec` are shipped together, so they can both evolve the metadata format without affecting how resources are attached

Neither `brioche-ld` nor `brioche-packed-userland-exec` use the new metadata format for now, but I thought it was worth getting this change in so they could evolve to do so while still supporting versions of Brioche beyond this point.