### PR TITLE
Bump default timeouts

### DIFF
--- a/crates/brioche-core/src/registry.rs
+++ b/crates/brioche-core/src/registry.rs
@@ -15,9 +15,9 @@ use crate::{
     Brioche,
 };
 
-const GET_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
-const CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
-const READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+const GET_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
+const CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
+const READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
 
 #[derive(Clone)]
 pub enum RegistryClient {


### PR DESCRIPTION
Although in the steady state 10 second timeout is reasonable, in practice p100 was observed to be much higher than that (if, for example, the machine you are supposed to talk to needs to cold boot).

Given that just _one_ timeout terminates the entire process, it feels like we can benefit from being quiet a bit more conservative here for the time being.