### PR TITLE
Add new JS op to get current Brioche version

### DIFF
--- a/crates/brioche-core/src/script/js.rs
+++ b/crates/brioche-core/src/script/js.rs
@@ -6,6 +6,7 @@ use crate::recipe::StackFrame;
 deno_core::extension!(
     brioche_js,
     ops = [
+        op_brioche_version,
         op_brioche_console,
         op_brioche_stack_frames_from_exception,
         op_brioche_utf8_encode,
@@ -23,6 +24,11 @@ pub enum ConsoleLevel {
     Info,
     Warn,
     Error,
+}
+
+#[deno_core::op]
+fn op_brioche_version() -> &'static str {
+    crate::VERSION
 }
 
 #[deno_core::op]


### PR DESCRIPTION
This PR adds a new op named `Deno.core.ops.op_brioche_version`, which just returns the version of the `brioche-core` crate. This is primarily meant to be used to start using new recipes in `std` without breaking backwards compatibility. Of course, proper feature detection would be better long-term, but this is a quick-and-easy option for the time being.