### PR TITLE
Fix Deno ops not including `op_brioche_version`

### DIFF
--- a/crates/brioche-core/src/script/js.rs
+++ b/crates/brioche-core/src/script/js.rs
@@ -26,9 +26,10 @@ pub enum ConsoleLevel {
     Error,
 }
 
-#[deno_core::op]
-fn op_brioche_version() -> &'static str {
-    crate::VERSION
+#[deno_core::op2]
+#[string]
+fn op_brioche_version() -> String {
+    crate::VERSION.to_string()
 }
 
 #[deno_core::op]

--- a/crates/brioche-core/tests/script_ops.rs
+++ b/crates/brioche-core/tests/script_ops.rs
@@ -1,0 +1,46 @@
+use brioche_core::script::evaluate::evaluate;
+
+mod brioche_test;
+
+#[tokio::test]
+async fn test_script_ops_version() -> anyhow::Result<()> {
+    let (brioche, context) = brioche_test::brioche_test().await;
+
+    let project_dir = context.mkdir("myproject").await;
+
+    context
+        .write_file(
+            "myproject/project.bri",
+            r#"
+                const BRIOCHE_VERSION = (globalThis as any).Deno.core.ops.op_brioche_version();
+                export default () => {
+                    return {
+                        briocheSerialize: () => {
+                            return {
+                                type: "create_file",
+                                content: BRIOCHE_VERSION,
+                                executable: false,
+                                resources: {
+                                    type: "directory",
+                                    entries: {},
+                                },
+                            };
+                        },
+                    };
+                };
+            "#,
+        )
+        .await;
+
+    let (projects, project_hash) = brioche_test::load_project(&brioche, &project_dir).await?;
+
+    let recipe = evaluate(&brioche, &projects, project_hash, "default")
+        .await?
+        .value;
+    let artifact = brioche_test::bake_without_meta(&brioche, recipe).await?;
+
+    let version_blob = brioche_test::blob(&brioche, brioche_core::VERSION).await;
+    assert_eq!(artifact, brioche_test::file(version_blob, false));
+
+    Ok(())
+}


### PR DESCRIPTION
This PR is a followup to #59. For some reason, the op as previously defined wasn't showing up in `Deno.core.ops`. I have no clue why, but the `#[deno_core::op]` attribute has been deprecated anyway, so I don't think it's worth investigating what went wrong here. There is a test now to make sure the op works.