### PR TITLE
Improve utils in `brioche-pack`

### DIFF
--- a/crates/brioche-core/src/input.rs
+++ b/crates/brioche-core/src/input.rs
@@ -68,7 +68,8 @@ pub async fn create_input_inner(
                 move || {
                     let input_file = std::fs::File::open(&input_path)
                         .with_context(|| format!("failed to open file {}", input_path.display()))?;
-                    let pack = brioche_pack::extract_pack(input_file).ok();
+                    let extracted = brioche_pack::extract_pack(input_file).ok();
+                    let pack = extracted.map(|extracted| extracted.pack);
                     anyhow::Ok(pack)
                 }
             })

--- a/crates/brioche-pack/src/lib.rs
+++ b/crates/brioche-pack/src/lib.rs
@@ -80,7 +80,7 @@ impl Pack {
     }
 }
 
-pub fn inject_pack(mut writer: impl std::io::Write, pack: &Pack) -> Result<(), InjectPackError> {
+pub fn inject_pack(mut writer: impl std::io::Write, pack: &Pack) -> Result<usize, InjectPackError> {
     // Encode the pack
     let pack_bytes = bincode::encode_to_vec(pack, bincode::config::standard())
         .map_err(InjectPackError::SerializeError)?;
@@ -102,7 +102,9 @@ pub fn inject_pack(mut writer: impl std::io::Write, pack: &Pack) -> Result<(), I
     writer.write_all(&length_bytes)?;
     writer.write_all(MARKER)?;
 
-    Ok(())
+    // Return the total length of the marker, length, and pack data appended
+    let pack_length = (MARKER.len() + LENGTH_BYTES) * 2 + pack_bytes.len();
+    Ok(pack_length)
 }
 
 pub struct ExtractedPack {


### PR DESCRIPTION
This PR makes some breaking changes to the functions in the `brioche_pack` crate:

- `brioche_pack::extract_pack` now requires a reader that implements [`std::io::Seek`](https://doc.rust-lang.org/stable/std/io/trait.Seek.html). The implementation also no longer needs to read the full file into memory to extract the pack
- `brioche_pack::extract_pack` now returns a new `ExtractedPack` data type, which includes both the pack plus the length of the unpacked data
- `brioche_pack::inject_pack` now returns the number of bytes appended to the reader

The lengths returned will allow callers to manipulate the pack data more directly, such as by stripping the packed data from a file using [`std::fs::File::set_len()`](https://doc.rust-lang.org/stable/std/fs/struct.File.html#method.set_len)