### PR TITLE
[Rust] Resolve Clippy warnings

### DIFF
--- a/crates/brioche-core/src/script/compiler_host.rs
+++ b/crates/brioche-core/src/script/compiler_host.rs
@@ -162,7 +162,7 @@ impl BriocheCompilerHost {
                         doc.version += 1;
 
                         let doc_contents = Arc::make_mut(&mut doc.contents);
-                        *doc_contents = contents.to_owned();
+                        contents.clone_into(doc_contents);
                     }
                 })
                 .or_insert_with(|| {

--- a/crates/brioche-pack/src/encoding.rs
+++ b/crates/brioche-pack/src/encoding.rs
@@ -1,6 +1,4 @@
-use std::{borrow::Cow, path::PathBuf};
-
-use bstr::{ByteSlice, ByteVec as _};
+use std::borrow::Cow;
 
 pub enum TickEncoded {}
 
@@ -31,37 +29,5 @@ where
             tick_encoding::decode(encoded.as_bytes()).map_err(serde::de::Error::custom)?;
         let deserialized = T::try_from(decoded.into_owned()).map_err(serde::de::Error::custom)?;
         Ok(deserialized)
-    }
-}
-
-pub struct AsPath<T>(std::marker::PhantomData<T>);
-
-impl<T> serde_with::SerializeAs<PathBuf> for AsPath<T>
-where
-    T: serde_with::SerializeAs<Vec<u8>>,
-{
-    fn serialize_as<S>(source: &PathBuf, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        let bytes = Vec::<u8>::from_path_buf(source.clone())
-            .map_err(|_| serde::ser::Error::custom("invalid path"))?;
-        T::serialize_as(&bytes, serializer)
-    }
-}
-
-impl<'de, T> serde_with::DeserializeAs<'de, PathBuf> for AsPath<T>
-where
-    T: serde_with::DeserializeAs<'de, Vec<u8>>,
-{
-    fn deserialize_as<D>(deserializer: D) -> Result<PathBuf, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let bytes: Vec<u8> = T::deserialize_as(deserializer)?;
-        let path = bytes
-            .to_path()
-            .map_err(|_| serde::de::Error::custom("invalid path"))?;
-        Ok(path.to_owned())
     }
 }


### PR DESCRIPTION
Fix the two following warnings with clippy 1.79.0:

```bash
warning: struct `AsPath` is never constructed
  --> crates/brioche-pack/src/encoding.rs:37:12
   |
37 | pub struct AsPath<T>(std::marker::PhantomData<T>);
   |            ^^^^^^
   |
   = note: `#[warn(dead_code)]` on by default

warning: assigning the result of `ToOwned::to_owned()` may be inefficient
   --> crates/brioche-core/src/script/compiler_host.rs:165:25
    |
165 |                         *doc_contents = contents.to_owned();
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `clone_into()`: `contents.clone_into(doc_contents)`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#assigning_clones
    = note: `#[warn(clippy::assigning_clones)]` on by default
```