### PR TITLE
Fix print issue with reporter

### DIFF
--- a/crates/brioche/src/publish.rs
+++ b/crates/brioche/src/publish.rs
@@ -36,6 +36,9 @@ pub async fn publish(args: PublishArgs) -> anyhow::Result<ExitCode> {
     }
 
     let checked = brioche_core::script::check::check(&brioche, &projects, project_hash).await?;
+
+    guard.shutdown_console().await;
+
     let check_results = checked.ensure_ok(brioche_core::script::check::DiagnosticLevel::Warning);
     match check_results {
         Ok(()) => {


### PR DESCRIPTION
Resolve #87.

To be reviewed one commit at a time. The last commit could be removed from this PR, since it has no impact on resolving the issue #87. I just found a quick refactoring which led to suppressing a return statement.

Before the fix, reformatting multiple projects at once was printing:

```bash
[826µs] 0 / 0 jobs complete
[102.8ms] 0 / 0 jobs complete
All files of project '../brioche-packages/packages/biome' are formatted
```

After the fix, the command is now correctly printing its output:

```bash
All files of project '../brioche-packages/packages/go' are formatted
All files of project '../brioche-packages/packages/biome' are formatted
Error occurred while formatting project '../brioche-packages/packages/g': failed to canonicalize path ../brioche-packages/packages/g
```