### PR TITLE
[CLI] Check with multiple arguments

### DIFF
--- a/crates/brioche/src/check.rs
+++ b/crates/brioche/src/check.rs
@@ -1,6 +1,5 @@
 use std::path::PathBuf;
 use std::process::ExitCode;
-use std::vec;
 
 use brioche_core::project::ProjectHash;
 use brioche_core::project::Projects;

--- a/crates/brioche/src/check.rs
+++ b/crates/brioche/src/check.rs
@@ -1,51 +1,109 @@
+use std::path::PathBuf;
 use std::process::ExitCode;
+use std::vec;
 
+use brioche_core::project::ProjectHash;
+use brioche_core::project::Projects;
 use brioche_core::reporter::ConsoleReporterKind;
+use brioche_core::Brioche;
 use clap::Parser;
 use tracing::Instrument;
+
+use crate::consolidate_result;
 
 #[derive(Debug, Parser)]
 pub struct CheckArgs {
     #[command(flatten)]
-    project: super::ProjectArgs,
+    project: super::MultipleProjectArgs,
 }
 
 pub async fn check(args: CheckArgs) -> anyhow::Result<ExitCode> {
     let (reporter, mut guard) =
         brioche_core::reporter::start_console_reporter(ConsoleReporterKind::Auto)?;
 
-    let brioche = brioche_core::BriocheBuilder::new(reporter).build().await?;
+    let brioche = brioche_core::BriocheBuilder::new(reporter.clone())
+        .build()
+        .await?;
     let projects = brioche_core::project::Projects::default();
 
-    let check_future = async {
-        let project_hash = super::load_project(&brioche, &projects, &args.project).await?;
+    let mut error_result = Option::None;
 
-        let num_lockfiles_updated = projects.commit_dirty_lockfiles().await?;
-        if num_lockfiles_updated > 0 {
-            tracing::info!(num_lockfiles_updated, "updated lockfiles");
-        }
-
-        let checked = brioche_core::script::check::check(&brioche, &projects, project_hash).await?;
-
-        guard.shutdown_console().await;
-
-        let result = checked.ensure_ok(brioche_core::script::check::DiagnosticLevel::Message);
-
-        match result {
-            Ok(()) => {
-                println!("No errors found 🎉");
-                anyhow::Ok(ExitCode::SUCCESS)
-            }
-            Err(diagnostics) => {
-                diagnostics.write(&brioche.vfs, &mut std::io::stdout())?;
-                anyhow::Ok(ExitCode::FAILURE)
-            }
-        }
+    // Handle the case where no projects and no registries are specified
+    let projects_path = if args.project.project.is_empty() && args.project.registry.is_empty() {
+        vec![PathBuf::from(".")]
+    } else {
+        args.project.project
     };
 
-    let exit_code = check_future
-        .instrument(tracing::info_span!("check"))
-        .await?;
+    // Loop over the projects
+    for project_path in projects_path {
+        let project_name = format!("project '{name}'", name = project_path.display());
+
+        match projects.load(&brioche, &project_path, true).await {
+            Ok(project_hash) => {
+                let result = run_check(&brioche, &projects, project_hash, &project_name).await;
+                consolidate_result(&project_name, result, &mut error_result);
+            }
+            Err(e) => {
+                consolidate_result(&project_name, Err(e), &mut error_result);
+            }
+        }
+    }
+
+    // Loop over the registries
+    for registry in args.project.registry {
+        let registry_name = format!("registry '{registry}'");
+
+        match projects
+            .load_from_registry(&brioche, &registry, &brioche_core::project::Version::Any)
+            .await
+        {
+            Ok(project_hash) => {
+                let result = run_check(&brioche, &projects, project_hash, &registry_name).await;
+                consolidate_result(&registry_name, result, &mut error_result);
+            }
+            Err(e) => {
+                consolidate_result(&registry_name, Err(e), &mut error_result);
+            }
+        }
+    }
+
+    guard.shutdown_console().await;
+
+    let exit_code = if error_result.is_some() {
+        ExitCode::FAILURE
+    } else {
+        ExitCode::SUCCESS
+    };
 
     Ok(exit_code)
+}
+
+async fn run_check(
+    brioche: &Brioche,
+    projects: &Projects,
+    project_hash: ProjectHash,
+    project_name: &String,
+) -> Result<bool, anyhow::Error> {
+    let num_lockfiles_updated = projects.commit_dirty_lockfiles().await?;
+    if num_lockfiles_updated > 0 {
+        tracing::info!(num_lockfiles_updated, "updated lockfiles");
+    }
+
+    let result =
+        async { brioche_core::script::check::check(brioche, projects, project_hash).await }
+            .instrument(tracing::info_span!("check"))
+            .await?
+            .ensure_ok(brioche_core::script::check::DiagnosticLevel::Message);
+
+    match result {
+        Ok(()) => {
+            println!("No errors found on {project_name} 🎉");
+            Ok(true)
+        }
+        Err(diagnostics) => {
+            diagnostics.write(&brioche.vfs, &mut std::io::stdout())?;
+            Ok(false)
+        }
+    }
 }

--- a/crates/brioche/src/main.rs
+++ b/crates/brioche/src/main.rs
@@ -237,8 +237,8 @@ struct MultipleProjectArgs {
     project: Vec<PathBuf>,
 
     /// The name of a registry project to build
-    #[clap(short, long)]
-    registry: Vec<String>,
+    #[clap(id = "registry", short, long)]
+    registry_project: Vec<String>,
 }
 
 async fn load_project(

--- a/crates/brioche/src/main.rs
+++ b/crates/brioche/src/main.rs
@@ -229,6 +229,18 @@ struct ProjectArgs {
     registry: Option<String>,
 }
 
+#[derive(Debug, clap::Args)]
+#[group(required = false, multiple = false)]
+struct MultipleProjectArgs {
+    /// The path of the project directory to build [default: .]
+    #[clap(short, long)]
+    project: Vec<PathBuf>,
+
+    /// The name of a registry project to build
+    #[clap(short, long)]
+    registry: Vec<String>,
+}
+
 async fn load_project(
     brioche: &brioche_core::Brioche,
     projects: &brioche_core::project::Projects,
@@ -252,4 +264,22 @@ async fn load_project(
     };
 
     Ok(project_hash)
+}
+
+fn consolidate_result(
+    project_name: &String,
+    result: Result<bool, anyhow::Error>,
+    error_result: &mut Option<()>,
+) {
+    match result {
+        Err(err) => {
+            println!("Error occurred with {project_name}: {err}",);
+
+            *error_result = Some(());
+        }
+        Ok(false) => {
+            *error_result = Some(());
+        }
+        _ => {}
+    }
 }

--- a/crates/brioche/src/main.rs
+++ b/crates/brioche/src/main.rs
@@ -267,13 +267,20 @@ async fn load_project(
 }
 
 fn consolidate_result(
+    reporter: &brioche_core::reporter::Reporter,
     project_name: &String,
     result: Result<bool, anyhow::Error>,
     error_result: &mut Option<()>,
 ) {
     match result {
         Err(err) => {
-            println!("Error occurred with {project_name}: {err}",);
+            reporter.emit(superconsole::Lines::from_multiline_string(
+                &format!("Error occurred with {project_name}: {err}", err = err),
+                superconsole::style::ContentStyle {
+                    foreground_color: Some(superconsole::style::Color::Red),
+                    ..superconsole::style::ContentStyle::default()
+                },
+            ));
 
             *error_result = Some(());
         }


### PR DESCRIPTION
Part of https://github.com/brioche-dev/brioche/issues/75

I added the ability to set more than one registry and project when calling `brioche check` command. This is separated in two commits. The first updates the check command, while the second commit refactor the code of the format command to mimic what was done with the check.

This has been done to extend more easily the next commands, cited in https://github.com/brioche-dev/brioche/issues/75.