### PR TITLE
Update peel error logs, and constrain its arguments

### DIFF
--- a/crates/brioche-core/src/bake.rs
+++ b/crates/brioche-core/src/bake.rs
@@ -427,6 +427,10 @@ async fn run_bake(brioche: &Brioche, recipe: Recipe, meta: &Arc<Meta>) -> anyhow
         Recipe::Peel { directory, depth } => {
             let mut result = bake(brioche, *directory, &scope).await?;
 
+            if depth == 0 {
+                anyhow::bail!("must peel at least 1 layer");
+            }
+
             for _ in 0..depth {
                 let Artifact::Directory(dir) = result.value else {
                     anyhow::bail!("tried peeling non-directory artifact");

--- a/crates/brioche-core/src/bake.rs
+++ b/crates/brioche-core/src/bake.rs
@@ -438,7 +438,11 @@ async fn run_bake(brioche: &Brioche, recipe: Recipe, meta: &Arc<Meta>) -> anyhow
                 };
 
                 if entries.next().is_some() {
-                    anyhow::bail!("tried peeling directory with multiple entries");
+                    anyhow::bail!(
+                        "tried peeling {} entries of {:?}",
+                        entries.len() + 2,
+                        dir
+                    );
                 }
 
                 result = peeled;

--- a/crates/brioche-core/src/bake.rs
+++ b/crates/brioche-core/src/bake.rs
@@ -442,11 +442,7 @@ async fn run_bake(brioche: &Brioche, recipe: Recipe, meta: &Arc<Meta>) -> anyhow
                 };
 
                 if entries.next().is_some() {
-                    anyhow::bail!(
-                        "tried peeling {} entries of {:?}",
-                        entries.len() + 2,
-                        dir
-                    );
+                    anyhow::bail!("tried peeling {} entries of {:?}", entries.len() + 2, dir);
                 }
 
                 result = peeled;


### PR DESCRIPTION
Part of https://github.com/brioche-dev/brioche/issues/103

I had these changes locally to investigate why the Ruff folder was containing more than one element:

```bash
Error: tried peeling 2 entries of Directory { entries: {"64f43441c8d3a0e9315e5de1d5e644b0d097e7cc.data": WithMeta { value: RecipeHash(Hash("0fda9b496eb36343c511b5caf5339a8dfcb6a1626586425fdd2daa67f796b2c3")), meta: Meta { source: None } }, "ruff-0.5.3": WithMeta { value: RecipeHash(Hash("545ec949c9a242c508a690a5f2a14b63361008417cba1ff67cdaa6692c815ccd")), meta: Meta { source: None } }} }
```

The first commit is opinionated, since I wanted to print the number of entries inside the directory and the directory itself.
My second commit is maybe not necessary, the user should be aware that peeling with a depth of 0 will output nothing.