### PR TITLE
Update deno crates to latest version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1501,9 +1501,9 @@ dependencies = [
 
 [[package]]
 name = "deno_core"
-version = "0.300.0"
+version = "0.303.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb79d0494b8c15f97761645f4afca5d52a414d4dc8f8aef8ca3b3ca82240ab55"
+checksum = "a9cd2cc931f61dee2db67ce9d032d229dda981be29d68dfd530a3dc1187ddd6b"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -1550,9 +1550,9 @@ dependencies = [
 
 [[package]]
 name = "deno_ops"
-version = "0.176.0"
+version = "0.179.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecb75c43c9441f413f0595f694746f90d8ffd292337287da309dbd93773928c"
+checksum = "1dbb9802b8b976e73872ae6e03303532e6056236467053aa6df02f7deb33488c"
 dependencies = [
  "proc-macro-rules",
  "proc-macro2",
@@ -4284,9 +4284,9 @@ dependencies = [
 
 [[package]]
 name = "serde_v8"
-version = "0.209.0"
+version = "0.212.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15d9095a8a725125fff1706f940af182e2a8ca01da8b0cd019aa47da93b28b94"
+checksum = "bf9a8693e4e54bf21fe51b953b10f98a0e32040671f18c4065f6014f0317ae80"
 dependencies = [
  "num-bigint",
  "serde",
@@ -6005,9 +6005,9 @@ dependencies = [
 
 [[package]]
 name = "v8"
-version = "0.101.0"
+version = "0.102.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06bc034c7b5e85fac85d2c6f181878266dd344790702d03e946c25cba78646a9"
+checksum = "88a710d5b95bff79a90708203cf9f74384e080d21fc6664aa4df463f2c66ac83"
 dependencies = [
  "bindgen",
  "bitflags 2.6.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -371,6 +371,15 @@ dependencies = [
 
 [[package]]
 name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "bincode"
 version = "2.0.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f11ea1a0346b94ef188834a65c068a03aec181c94896d481d7a0a40d85b0ce95"
@@ -386,6 +395,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e30759b3b99a1b802a7a3aa21c85c3ded5c28e1c83170d82d70f08bbf7f3e4c"
 dependencies = [
  "virtue",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.69.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
+dependencies = [
+ "bitflags 2.6.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.12.0",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.48",
+ "which 4.4.2",
 ]
 
 [[package]]
@@ -428,7 +460,7 @@ version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fc1244cc5f0cc267bd26b601e9ccd6851c6a4d395bba07e27c2de641dc84479"
 dependencies = [
- "convert_case 0.6.0",
+ "convert_case",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -864,7 +896,7 @@ dependencies = [
 name = "brioche-pack"
 version = "0.1.1"
 dependencies = [
- "bincode",
+ "bincode 2.0.0-rc.3",
  "bstr 1.8.0",
  "serde",
  "serde_with",
@@ -908,9 +940,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.5.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+checksum = "a12916984aab3fa6e39d655a33e09c0071eb36d6ab3aea5c2d78551f1df6d952"
 
 [[package]]
 name = "bzip2"
@@ -947,6 +979,15 @@ checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
 dependencies = [
  "jobserver",
  "libc",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -1011,6 +1052,17 @@ checksum = "defaa24ecc093c77630e6c15e17c51f5e187bf35ee514f4e2d67baaa96dae22b"
 dependencies = [
  "ciborium-io",
  "half",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -1121,18 +1173,18 @@ checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
 
 [[package]]
 name = "convert_case"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
-
-[[package]]
-name = "convert_case"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "cooked-waker"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147be55d677052dabc6b22252d5dd0fd4c29c8c27aa4f2fbef0f94aa003b406f"
 
 [[package]]
 name = "core-foundation"
@@ -1289,7 +1341,7 @@ dependencies = [
  "crossterm_winapi",
  "libc",
  "mio",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.3",
  "signal-hook 0.3.17",
  "signal-hook-mio",
  "winapi",
@@ -1449,29 +1501,41 @@ dependencies = [
 
 [[package]]
 name = "deno_core"
-version = "0.237.0"
+version = "0.300.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2ea708c221abdb5734e3c4b72075379c3046eb0ac54afa0ecb5e58509cce72c"
+checksum = "eb79d0494b8c15f97761645f4afca5d52a414d4dc8f8aef8ca3b3ca82240ab55"
 dependencies = [
  "anyhow",
+ "bincode 1.3.3",
+ "bit-set",
+ "bit-vec",
  "bytes",
+ "cooked-waker",
+ "deno_core_icudata",
  "deno_ops",
  "deno_unsync",
  "futures",
  "libc",
- "log",
- "parking_lot 0.12.1",
+ "memoffset 0.9.0",
+ "parking_lot 0.12.3",
+ "percent-encoding",
  "pin-project",
  "serde",
  "serde_json",
  "serde_v8",
  "smallvec",
- "sourcemap 7.1.1",
+ "sourcemap",
  "static_assertions",
  "tokio",
  "url",
  "v8",
 ]
+
+[[package]]
+name = "deno_core_icudata"
+version = "0.0.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13951ea98c0a4c372f162d669193b4c9d991512de9f2381dd161027f34b26b1"
 
 [[package]]
 name = "deno_media_type"
@@ -1486,9 +1550,9 @@ dependencies = [
 
 [[package]]
 name = "deno_ops"
-version = "0.113.0"
+version = "0.176.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5b9c0f6360795fb625774a8b5955c87c470c43159670cf5d2052df5ce9d84bc"
+checksum = "8ecb75c43c9441f413f0595f694746f90d8ffd292337287da309dbd93773928c"
 dependencies = [
  "proc-macro-rules",
  "proc-macro2",
@@ -1511,10 +1575,11 @@ dependencies = [
 
 [[package]]
 name = "deno_unsync"
-version = "0.3.7"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ba44060d41759ee53118341170e29f2e112bd1c616e5b2878e7aee566949c82"
+checksum = "03ee1607db298c8f12124b345a52d5f2f504a7504c9d535f1d8f07127b237010"
 dependencies = [
+ "parking_lot 0.12.3",
  "tokio",
 ]
 
@@ -1537,19 +1602,6 @@ checksum = "8eb30d70a07a3b04884d2677f06bec33509dc67ca60d92949e5535352d3191dc"
 dependencies = [
  "powerfmt",
  "serde",
-]
-
-[[package]]
-name = "derive_more"
-version = "0.99.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
-dependencies = [
- "convert_case 0.4.0",
- "proc-macro2",
- "quote",
- "rustc_version 0.4.0",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -1819,9 +1871,9 @@ dependencies = [
 
 [[package]]
 name = "fslock"
-version = "0.1.8"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57eafdd0c16f57161105ae1b98a1238f97645f2f588438b2949c99a2af9616bf"
+checksum = "04412b8935272e3a9bae6f48c7bfff74c2911f60525404edfdd28e49884c3bfb"
 dependencies = [
  "libc",
  "winapi",
@@ -1889,7 +1941,7 @@ checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
 dependencies = [
  "futures-core",
  "lock_api",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.3",
 ]
 
 [[package]]
@@ -1985,6 +2037,15 @@ dependencies = [
  "log",
  "regex-automata 0.4.3",
  "regex-syntax 0.8.2",
+]
+
+[[package]]
+name = "gzip-header"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95cc527b92e6029a62960ad99aa8a6660faa4555fe5f731aab13aa6a921795a2"
+dependencies = [
+ "crc32fast",
 ]
 
 [[package]]
@@ -2494,10 +2555,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "libc"
 version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+
+[[package]]
+name = "libloading"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
+dependencies = [
+ "cfg-if 1.0.0",
+ "windows-targets 0.52.0",
+]
 
 [[package]]
 name = "libm"
@@ -2681,9 +2758,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.1"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
 dependencies = [
  "adler",
 ]
@@ -3082,9 +3159,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.12.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
 dependencies = [
  "lock_api",
  "parking_lot_core 0.9.9",
@@ -3366,6 +3443,16 @@ checksum = "af7cee1a6c8a5b9208b3cb1061f10c0cb689087b3d8ce85fb9d2dd7a29b6ba66"
 dependencies = [
  "diff",
  "yansi",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d3928fb5db768cb86f891ff014f0144589297e3c6a1aba6ed7cecfdace270c7"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -3880,19 +3967,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc_version"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
-dependencies = [
- "semver 1.0.20",
-]
-
-[[package]]
 name = "rustix"
-version = "0.38.28"
+version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72e572a5e8ca657d7366229cdde4bd14c4eb5499a9573d4d366fe1b599daa316"
+checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
@@ -4115,12 +4193,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "semver"
-version = "1.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
-
-[[package]]
 name = "semver-parser"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4212,12 +4284,10 @@ dependencies = [
 
 [[package]]
 name = "serde_v8"
-version = "0.146.0"
+version = "0.209.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78309bd1ec4d14d165f271e203bdc45ad5bf45525da57bb70901f57942f6c0f7"
+checksum = "15d9095a8a725125fff1706f940af182e2a8ca01da8b0cd019aa47da93b28b94"
 dependencies = [
- "bytes",
- "derive_more",
  "num-bigint",
  "serde",
  "smallvec",
@@ -4306,6 +4376,12 @@ checksum = "da03fa3b94cc19e3ebfc88c4229c49d8f08cdbd1228870a45f0ffdf84988e14b"
 dependencies = [
  "dirs 5.0.1",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook"
@@ -4430,23 +4506,6 @@ dependencies = [
 
 [[package]]
 name = "sourcemap"
-version = "7.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7768edd06c02535e0d50653968f46e1e0d3aa54742190d35dd9466f59de9c71"
-dependencies = [
- "base64-simd",
- "data-encoding",
- "debugid",
- "if_chain",
- "rustc_version 0.2.3",
- "serde",
- "serde_json",
- "unicode-id-start",
- "url",
-]
-
-[[package]]
-name = "sourcemap"
 version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "208d40b9e8cad9f93613778ea295ed8f3c2b1824217c6cfc7219d3f6f45b96d4"
@@ -4457,7 +4516,7 @@ dependencies = [
  "debugid",
  "if_chain",
  "rustc-hash",
- "rustc_version 0.2.3",
+ "rustc_version",
  "serde",
  "serde_json",
  "unicode-id-start",
@@ -4859,7 +4918,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "siphasher",
- "sourcemap 8.0.1",
+ "sourcemap",
  "swc_atoms",
  "swc_eq_ignore_macros",
  "swc_visit",
@@ -4923,7 +4982,7 @@ dependencies = [
  "once_cell",
  "rustc-hash",
  "serde",
- "sourcemap 8.0.1",
+ "sourcemap",
  "swc_atoms",
  "swc_common",
  "swc_ecma_ast",
@@ -5467,7 +5526,7 @@ dependencies = [
  "libc",
  "mio",
  "num_cpus",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.3",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2 0.5.5",
@@ -5946,14 +6005,19 @@ dependencies = [
 
 [[package]]
 name = "v8"
-version = "0.82.0"
+version = "0.101.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f53dfb242f4c0c39ed3fc7064378a342e57b5c9bd774636ad34ffe405b808121"
+checksum = "06bc034c7b5e85fac85d2c6f181878266dd344790702d03e946c25cba78646a9"
 dependencies = [
- "bitflags 1.3.2",
+ "bindgen",
+ "bitflags 2.6.0",
  "fslock",
+ "gzip-header",
+ "home",
+ "miniz_oxide",
  "once_cell",
- "which",
+ "paste",
+ "which 6.0.2",
 ]
 
 [[package]]
@@ -6259,6 +6323,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d9c5ed668ee1f17edb3b627225343d210006a90bb1e3745ce1f30b1fb115075"
+dependencies = [
+ "either",
+ "home",
+ "rustix",
+ "winsafe",
+]
+
+[[package]]
 name = "whoami"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6454,6 +6530,12 @@ dependencies = [
  "cfg-if 1.0.0",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wyz"

--- a/crates/brioche-core/Cargo.toml
+++ b/crates/brioche-core/Cargo.toml
@@ -19,7 +19,7 @@ cfg-if = "1.0.0"
 console-subscriber = "0.3.0"
 debug-ignore = "1.0.5"
 deno_ast = { version = "0.40.0", features = ["transpiling"] }
-deno_core = "0.237.0"
+deno_core = "0.296.0"
 directories = "5.0.1"
 futures = "0.3.29"
 globset = "0.4.14"
@@ -42,7 +42,7 @@ reqwest-retry = "0.6.0"
 rust-embed = { version = "8.1.0", features = ["debug-embed", "interpolate-folder-path", "include-exclude"] }
 serde = { version = "1.0.193", features = ["derive"] }
 serde_json = "1.0.108"
-serde_v8 = "0.146.0"
+serde_v8 = "0.205.0"
 serde_with = { version = "3.4.0", features = ["hex"] }
 sha2 = "0.10.8"
 sqlx = { version = "0.7.3", features = ["runtime-tokio-rustls", "sqlite", "macros", "migrate", "json"] }

--- a/crates/brioche-core/Cargo.toml
+++ b/crates/brioche-core/Cargo.toml
@@ -19,7 +19,7 @@ cfg-if = "1.0.0"
 console-subscriber = "0.3.0"
 debug-ignore = "1.0.5"
 deno_ast = { version = "0.40.0", features = ["transpiling"] }
-deno_core = "0.296.0"
+deno_core = "0.300.0"
 directories = "5.0.1"
 futures = "0.3.29"
 globset = "0.4.14"
@@ -42,7 +42,7 @@ reqwest-retry = "0.6.0"
 rust-embed = { version = "8.1.0", features = ["debug-embed", "interpolate-folder-path", "include-exclude"] }
 serde = { version = "1.0.193", features = ["derive"] }
 serde_json = "1.0.108"
-serde_v8 = "0.205.0"
+serde_v8 = "0.209.0"
 serde_with = { version = "3.4.0", features = ["hex"] }
 sha2 = "0.10.8"
 sqlx = { version = "0.7.3", features = ["runtime-tokio-rustls", "sqlite", "macros", "migrate", "json"] }

--- a/crates/brioche-core/Cargo.toml
+++ b/crates/brioche-core/Cargo.toml
@@ -19,7 +19,7 @@ cfg-if = "1.0.0"
 console-subscriber = "0.3.0"
 debug-ignore = "1.0.5"
 deno_ast = { version = "0.40.0", features = ["transpiling"] }
-deno_core = "0.300.0"
+deno_core = "0.303.0"
 directories = "5.0.1"
 futures = "0.3.29"
 globset = "0.4.14"
@@ -42,7 +42,7 @@ reqwest-retry = "0.6.0"
 rust-embed = { version = "8.1.0", features = ["debug-embed", "interpolate-folder-path", "include-exclude"] }
 serde = { version = "1.0.193", features = ["derive"] }
 serde_json = "1.0.108"
-serde_v8 = "0.209.0"
+serde_v8 = "0.212.0"
 serde_with = { version = "3.4.0", features = ["hex"] }
 sha2 = "0.10.8"
 sqlx = { version = "0.7.3", features = ["runtime-tokio-rustls", "sqlite", "macros", "migrate", "json"] }

--- a/crates/brioche-core/src/script/bridge.rs
+++ b/crates/brioche-core/src/script/bridge.rs
@@ -1,0 +1,468 @@
+use std::{path::PathBuf, sync::Arc};
+
+use anyhow::Context as _;
+use futures::{StreamExt as _, TryStreamExt as _};
+use joinery::JoinableIterator as _;
+
+use crate::{
+    bake::BakeScope,
+    blob::BlobHash,
+    project::{
+        analyze::{StaticInclude, StaticQuery},
+        ProjectHash, Projects,
+    },
+    recipe::{Artifact, Recipe, WithMeta},
+    Brioche,
+};
+
+use super::specifier::{self, BriocheImportSpecifier, BriocheModuleSpecifier};
+
+/// A type used to call Brioche functions across Tokio runtimes. This is used
+/// to interact with Brioche from JavaScript code, due to restrictions that
+/// require the V8 runtime to run in its own Tokio runtime.
+///
+/// This type works by spawning a Tokio task that uses a channel for
+/// communicating across runtimes, which is explicitly supported by Tokio's
+/// channel types.
+#[derive(Clone)]
+pub struct RuntimeBridge {
+    tx: tokio::sync::mpsc::UnboundedSender<RuntimeBridgeMessage>,
+}
+
+impl RuntimeBridge {
+    pub fn new(brioche: Brioche, projects: Projects) -> Self {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+
+        tokio::spawn(async move {
+            while let Some(message) = rx.recv().await {
+                let brioche = brioche.clone();
+                let projects = projects.clone();
+
+                tokio::spawn(async move {
+                    match message {
+                        RuntimeBridgeMessage::LoadProjectFromModulePath { path, result_tx } => {
+                            let result =
+                                projects.load_from_module_path(&brioche, &path, false).await;
+                            let _ = result_tx.send(result);
+                        }
+                        RuntimeBridgeMessage::LoadSpecifierContents {
+                            specifier,
+                            contents_tx,
+                        } => {
+                            let contents =
+                                specifier::load_specifier_contents(&brioche.vfs, &specifier).await;
+                            let _ = contents_tx.send(contents);
+                        }
+                        RuntimeBridgeMessage::ResolveSpecifier {
+                            specifier,
+                            referrer,
+                            resolved_tx,
+                        } => {
+                            let resolved = specifier::resolve(&projects, &specifier, &referrer);
+                            let _ = resolved_tx.send(resolved);
+                        }
+                        RuntimeBridgeMessage::UpdateVfsContents {
+                            specifier,
+                            contents,
+                            result_tx,
+                        } => {
+                            let path = match specifier {
+                                BriocheModuleSpecifier::Runtime { .. } => {
+                                    let _ = result_tx.send(Ok(false));
+                                    return;
+                                }
+                                BriocheModuleSpecifier::File { path } => path,
+                            };
+
+                            let file_id = match brioche.vfs.load_cached(&path) {
+                                Ok(Some((file_id, _))) => file_id,
+                                Ok(None) => {
+                                    let _ = result_tx.send(Ok(false));
+                                    return;
+                                }
+                                Err(error) => {
+                                    let _ = result_tx.send(Err(error));
+                                    return;
+                                }
+                            };
+
+                            let result = brioche.vfs.update(file_id, contents).map(|_| true);
+                            let _ = result_tx.send(result);
+                        }
+                        RuntimeBridgeMessage::ReloadProjectFromSpecifier {
+                            specifier,
+                            result_tx,
+                        } => {
+                            let path = match specifier {
+                                BriocheModuleSpecifier::Runtime { .. } => {
+                                    let _ = result_tx.send(Ok(false));
+                                    return;
+                                }
+                                BriocheModuleSpecifier::File { path } => path,
+                            };
+
+                            let project = projects.find_containing_project(&path);
+                            let project = match project {
+                                Ok(project) => project,
+                                Err(error) => {
+                                    let _ = result_tx.send(Err(error).with_context(|| {
+                                        format!("no project found for path '{}'", path.display())
+                                    }));
+                                    return;
+                                }
+                            };
+
+                            if let Some(project) = project {
+                                let result = projects.clear(project).await;
+                                match result {
+                                    Ok(_) => {}
+                                    Err(error) => {
+                                        let _ = result_tx.send(Err(error));
+                                        return;
+                                    }
+                                }
+                            }
+
+                            let result = projects
+                                .load_from_module_path(&brioche, &path, false)
+                                .await
+                                .map(|_| true);
+                            let _ = result_tx.send(result);
+                        }
+                        RuntimeBridgeMessage::ReadSpecifierContents {
+                            specifier,
+                            contents_tx,
+                        } => {
+                            let contents =
+                                specifier::read_specifier_contents(&brioche.vfs, &specifier);
+                            let _ = contents_tx.send(contents);
+                        }
+                        RuntimeBridgeMessage::ProjectRootForModulePath {
+                            module_path,
+                            project_path_tx,
+                        } => {
+                            let project_hash = projects.find_containing_project(&module_path);
+                            let project_hash = match project_hash {
+                                Ok(Some(project_hash)) => project_hash,
+                                Ok(None) => {
+                                    let error = anyhow::anyhow!("containing project not found");
+                                    let _ = project_path_tx.send(Err(error));
+                                    return;
+                                }
+                                Err(error) => {
+                                    let _ = project_path_tx
+                                        .send(Err(error).context("failed to get project path"));
+                                    return;
+                                }
+                            };
+                            let project_path = projects.project_root(project_hash);
+                            let project_path = match project_path {
+                                Ok(project_path) => project_path,
+                                Err(error) => {
+                                    let _ = project_path_tx.send(Err(error));
+                                    return;
+                                }
+                            };
+                            let _ = project_path_tx.send(Ok(project_path));
+                        }
+                        RuntimeBridgeMessage::BakeAll {
+                            recipes,
+                            bake_scope,
+                            results_tx,
+                        } => {
+                            let results = futures::stream::iter(recipes)
+                                .then(|recipe| async {
+                                    let brioche = brioche.clone();
+                                    crate::bake::bake(&brioche, recipe, &bake_scope).await
+                                })
+                                .try_collect::<Vec<_>>()
+                                .await;
+
+                            let _ = results_tx.send(results);
+                        }
+                        RuntimeBridgeMessage::CreateProxy { recipe, result_tx } => {
+                            let result = crate::bake::create_proxy(&brioche, recipe).await;
+                            let _ = result_tx.send(result);
+                        }
+                        RuntimeBridgeMessage::ReadBlob {
+                            blob_hash,
+                            result_tx,
+                        } => {
+                            let permit = crate::blob::get_save_blob_permit().await;
+                            let permit = match permit {
+                                Ok(permit) => permit,
+                                Err(error) => {
+                                    let _ = result_tx.send(Err(error));
+                                    return;
+                                }
+                            };
+
+                            let path = crate::blob::blob_path(&brioche, permit, blob_hash).await;
+                            let path = match path {
+                                Ok(path) => path,
+                                Err(error) => {
+                                    let _ = result_tx.send(Err(error));
+                                    return;
+                                }
+                            };
+
+                            let result = tokio::fs::read(path)
+                                .await
+                                .with_context(|| format!("failed to read blob {blob_hash}"));
+
+                            let _ = result_tx.send(result);
+                        }
+                        RuntimeBridgeMessage::GetStatic {
+                            specifier,
+                            static_,
+                            result_tx,
+                        } => {
+                            let recipe_hash = projects.get_static(&specifier, &static_);
+                            let recipe_hash = match recipe_hash {
+                                Ok(Some(recipe_hash)) => recipe_hash,
+                                Ok(None) => {
+                                    let error = match static_ {
+                                        StaticQuery::Include(StaticInclude::File { path }) => {
+                                            anyhow::anyhow!("failed to resolve Brioche.includeFile({path:?}) from {specifier}, was the path passed in as a string literal?")
+                                        }
+                                        StaticQuery::Include(StaticInclude::Directory { path }) => {
+                                            anyhow::anyhow!("failed to resolve Brioche.includeDirectory({path:?}) from {specifier}, was the path passed in as a string literal?")
+                                        }
+                                        StaticQuery::Glob { patterns } => {
+                                            let patterns = patterns
+                                                .iter()
+                                                .map(|pattern| {
+                                                    lazy_format::lazy_format!("{pattern:?}")
+                                                })
+                                                .join_with(", ");
+                                            anyhow::anyhow!("failed to resolve Brioche.glob({patterns}) from {specifier}, were the patterns passed in as string literals?")
+                                        }
+                                        StaticQuery::Download { url } => {
+                                            anyhow::anyhow!("failed to resolve Brioche.download({url:?}) from {specifier}, was the URL passed in as a string literal?")
+                                        }
+                                    };
+                                    let _ = result_tx.send(Err(error));
+                                    return;
+                                }
+                                Err(error) => {
+                                    let _ = result_tx.send(Err(error));
+                                    return;
+                                }
+                            };
+
+                            let result = crate::recipe::get_recipe(&brioche, recipe_hash).await;
+                            let _ = result_tx.send(result);
+                        }
+                    }
+                });
+            }
+        });
+
+        Self { tx }
+    }
+
+    pub async fn load_project_from_module_path(
+        &self,
+        path: std::path::PathBuf,
+    ) -> anyhow::Result<ProjectHash> {
+        let (result_tx, result_rx) = tokio::sync::oneshot::channel();
+
+        self.tx
+            .send(RuntimeBridgeMessage::LoadProjectFromModulePath { path, result_tx })?;
+        let result = result_rx.await??;
+        Ok(result)
+    }
+
+    pub async fn load_specifier_contents(
+        &self,
+        specifier: BriocheModuleSpecifier,
+    ) -> anyhow::Result<Arc<Vec<u8>>> {
+        let (contents_tx, contents_rx) = tokio::sync::oneshot::channel();
+
+        self.tx.send(RuntimeBridgeMessage::LoadSpecifierContents {
+            specifier,
+            contents_tx,
+        })?;
+        let contents = contents_rx.await??;
+        Ok(contents)
+    }
+
+    pub fn resolve_specifier(
+        &self,
+        specifier: BriocheImportSpecifier,
+        referrer: BriocheModuleSpecifier,
+    ) -> anyhow::Result<BriocheModuleSpecifier> {
+        let (resolved_tx, resolved_rx) = std::sync::mpsc::channel();
+
+        self.tx.send(RuntimeBridgeMessage::ResolveSpecifier {
+            specifier,
+            referrer,
+            resolved_tx,
+        })?;
+        let resolved = resolved_rx.recv()??;
+        Ok(resolved)
+    }
+
+    pub async fn update_vfs_contents(
+        &self,
+        specifier: BriocheModuleSpecifier,
+        contents: Arc<Vec<u8>>,
+    ) -> anyhow::Result<bool> {
+        let (result_tx, result_rx) = tokio::sync::oneshot::channel();
+
+        self.tx.send(RuntimeBridgeMessage::UpdateVfsContents {
+            specifier,
+            contents,
+            result_tx,
+        })?;
+        let result = result_rx.await??;
+        Ok(result)
+    }
+
+    pub async fn reload_project_from_specifier(
+        &self,
+        specifier: BriocheModuleSpecifier,
+    ) -> anyhow::Result<bool> {
+        let (result_tx, result_rx) = tokio::sync::oneshot::channel();
+
+        self.tx
+            .send(RuntimeBridgeMessage::ReloadProjectFromSpecifier {
+                specifier,
+                result_tx,
+            })?;
+        let result = result_rx.await??;
+        Ok(result)
+    }
+
+    pub fn read_specifier_contents(
+        &self,
+        specifier: BriocheModuleSpecifier,
+    ) -> anyhow::Result<Arc<Vec<u8>>> {
+        let (contents_tx, contents_rx) = std::sync::mpsc::channel();
+
+        self.tx.send(RuntimeBridgeMessage::ReadSpecifierContents {
+            specifier,
+            contents_tx,
+        })?;
+        let contents = contents_rx.recv()??;
+        Ok(contents)
+    }
+
+    pub async fn project_root_for_module_path(
+        &self,
+        module_path: PathBuf,
+    ) -> anyhow::Result<PathBuf> {
+        let (project_path_tx, project_path_rx) = tokio::sync::oneshot::channel();
+
+        self.tx
+            .send(RuntimeBridgeMessage::ProjectRootForModulePath {
+                module_path,
+                project_path_tx,
+            })?;
+        let project_path = project_path_rx.await??;
+        Ok(project_path)
+    }
+
+    pub async fn bake_all(
+        &self,
+        recipes: Vec<WithMeta<Recipe>>,
+        bake_scope: BakeScope,
+    ) -> anyhow::Result<Vec<WithMeta<Artifact>>> {
+        let (results_tx, results_rx) = tokio::sync::oneshot::channel();
+
+        self.tx.send(RuntimeBridgeMessage::BakeAll {
+            recipes,
+            bake_scope,
+            results_tx,
+        })?;
+        let results = results_rx.await??;
+        Ok(results)
+    }
+
+    pub async fn create_proxy(&self, recipe: Recipe) -> anyhow::Result<Recipe> {
+        let (result_tx, result_rx) = tokio::sync::oneshot::channel();
+
+        self.tx
+            .send(RuntimeBridgeMessage::CreateProxy { recipe, result_tx })?;
+        let result = result_rx.await??;
+        Ok(result)
+    }
+
+    pub async fn read_blob(&self, blob_hash: BlobHash) -> anyhow::Result<Vec<u8>> {
+        let (result_tx, result_rx) = tokio::sync::oneshot::channel();
+
+        self.tx.send(RuntimeBridgeMessage::ReadBlob {
+            blob_hash,
+            result_tx,
+        })?;
+        let result = result_rx.await??;
+        Ok(result)
+    }
+
+    pub async fn get_static(
+        &self,
+        specifier: BriocheModuleSpecifier,
+        static_: StaticQuery,
+    ) -> anyhow::Result<Recipe> {
+        let (result_tx, result_rx) = tokio::sync::oneshot::channel();
+
+        self.tx.send(RuntimeBridgeMessage::GetStatic {
+            specifier,
+            static_,
+            result_tx,
+        })?;
+        let result = result_rx.await??;
+        Ok(result)
+    }
+}
+
+enum RuntimeBridgeMessage {
+    LoadProjectFromModulePath {
+        path: std::path::PathBuf,
+        result_tx: tokio::sync::oneshot::Sender<anyhow::Result<ProjectHash>>,
+    },
+    LoadSpecifierContents {
+        specifier: BriocheModuleSpecifier,
+        contents_tx: tokio::sync::oneshot::Sender<anyhow::Result<Arc<Vec<u8>>>>,
+    },
+    ResolveSpecifier {
+        specifier: BriocheImportSpecifier,
+        referrer: BriocheModuleSpecifier,
+        resolved_tx: std::sync::mpsc::Sender<anyhow::Result<BriocheModuleSpecifier>>,
+    },
+    UpdateVfsContents {
+        specifier: BriocheModuleSpecifier,
+        contents: Arc<Vec<u8>>,
+        result_tx: tokio::sync::oneshot::Sender<anyhow::Result<bool>>,
+    },
+    ReloadProjectFromSpecifier {
+        specifier: BriocheModuleSpecifier,
+        result_tx: tokio::sync::oneshot::Sender<anyhow::Result<bool>>,
+    },
+    ReadSpecifierContents {
+        specifier: BriocheModuleSpecifier,
+        contents_tx: std::sync::mpsc::Sender<anyhow::Result<Arc<Vec<u8>>>>,
+    },
+    ProjectRootForModulePath {
+        module_path: PathBuf,
+        project_path_tx: tokio::sync::oneshot::Sender<anyhow::Result<PathBuf>>,
+    },
+    BakeAll {
+        recipes: Vec<WithMeta<Recipe>>,
+        bake_scope: BakeScope,
+        results_tx: tokio::sync::oneshot::Sender<anyhow::Result<Vec<WithMeta<Artifact>>>>,
+    },
+    CreateProxy {
+        recipe: Recipe,
+        result_tx: tokio::sync::oneshot::Sender<anyhow::Result<Recipe>>,
+    },
+    ReadBlob {
+        blob_hash: BlobHash,
+        result_tx: tokio::sync::oneshot::Sender<anyhow::Result<Vec<u8>>>,
+    },
+    GetStatic {
+        specifier: BriocheModuleSpecifier,
+        static_: StaticQuery,
+        result_tx: tokio::sync::oneshot::Sender<anyhow::Result<Recipe>>,
+    },
+}

--- a/crates/brioche-core/src/script/evaluate.rs
+++ b/crates/brioche-core/src/script/evaluate.rs
@@ -9,7 +9,7 @@ use crate::{
     Brioche,
 };
 
-use super::BriocheModuleLoader;
+use super::{bridge::RuntimeBridge, BriocheModuleLoader};
 
 #[tracing::instrument(skip(brioche, projects, project_hash), fields(%project_hash), err)]
 pub async fn evaluate(
@@ -18,119 +18,173 @@ pub async fn evaluate(
     project_hash: ProjectHash,
     export: &str,
 ) -> anyhow::Result<WithMeta<Recipe>> {
-    let module_loader = BriocheModuleLoader::new(brioche, projects);
+    let bridge = RuntimeBridge::new(brioche.clone(), projects.clone());
+    let main_module = projects.project_root_module_specifier(project_hash)?;
+
+    let result = evaluate_with_deno(project_hash, export.to_string(), main_module, bridge).await?;
+    Ok(result)
+}
+
+async fn evaluate_with_deno(
+    project_hash: ProjectHash,
+    export: String,
+    main_module: super::specifier::BriocheModuleSpecifier,
+    bridge: RuntimeBridge,
+) -> anyhow::Result<WithMeta<Recipe>> {
+    // Create a channel to get the result from the other Tokio runtime
+    let (result_tx, result_rx) =
+        tokio::sync::oneshot::channel::<anyhow::Result<WithMeta<Recipe>>>();
+
     let bake_scope = BakeScope::Project {
         project_hash,
-        export: export.to_string(),
+        export: export.clone(),
     };
-    let mut js_runtime = deno_core::JsRuntime::new(deno_core::RuntimeOptions {
-        module_loader: Some(Rc::new(module_loader)),
-        extensions: vec![
-            super::brioche_rt::init_ops(brioche.clone(), projects.clone(), bake_scope),
-            super::js::brioche_js::init_ops(),
-        ],
-        ..Default::default()
+
+    // Spawn a new thread for the new Tokio runtime
+    std::thread::spawn(move || {
+        // Create a new Tokio runtime
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build();
+        let runtime = match runtime {
+            Ok(runtime) => runtime,
+            Err(error) => {
+                let _ = result_tx.send(Err(error.into()));
+                return;
+            }
+        };
+
+        // Spawn the main JS task on the new runtime. See this issue for
+        // more context on why this is required:
+        // https://github.com/brioche-dev/brioche/pull/105#issuecomment-2241289605
+        let result = runtime.block_on(async move {
+            // Create the runtime
+            let module_loader = BriocheModuleLoader::new(bridge.clone());
+            let mut js_runtime = deno_core::JsRuntime::new(deno_core::RuntimeOptions {
+                module_loader: Some(Rc::new(module_loader)),
+                extensions: vec![
+                    super::brioche_rt::init_ops(bridge, bake_scope),
+                    super::js::brioche_js::init_ops(),
+                ],
+                ..Default::default()
+            });
+
+            let main_module: deno_core::ModuleSpecifier = main_module.into();
+
+            tracing::debug!(%main_module, "evaluating module");
+
+            // Load and evaluate the main module
+            let module_id = js_runtime.load_main_es_module(&main_module).await?;
+            let result = js_runtime.mod_evaluate(module_id);
+            js_runtime
+                .run_event_loop(deno_core::PollEventLoopOptions::default())
+                .await?;
+            result.await?;
+
+            let module_namespace = js_runtime.get_module_namespace(module_id)?;
+
+            // Call the provided export from the module
+            let result = {
+                let mut js_scope = js_runtime.handle_scope();
+                let mut js_scope = deno_core::v8::TryCatch::new(&mut js_scope);
+
+                let module_namespace = deno_core::v8::Local::new(&mut js_scope, module_namespace);
+
+                let export_key = deno_core::v8::String::new(&mut js_scope, &export)
+                    .context("failed to create V8 string")?;
+                let export_value = module_namespace
+                    .get(&mut js_scope, export_key.into())
+                    .with_context(|| format!("expected module to have an export named {export}"))?;
+                let export_value: deno_core::v8::Local<deno_core::v8::Function> =
+                    export_value
+                        .try_into()
+                        .with_context(|| format!("expected export named {export} to be a function"))?;
+
+                tracing::debug!(%main_module, %export, "running exported function");
+
+                let result = export_value.call(&mut js_scope, module_namespace.into(), &[]);
+
+                let result = match result {
+                    Some(result) => result,
+                    None => {
+                        if let Some(exception) = js_scope.exception() {
+                            return Err(anyhow::anyhow!(
+                                deno_core::error::JsError::from_v8_exception(&mut js_scope, exception)
+                            ))
+                            .with_context(|| format!("error when calling {export}"));
+                        } else {
+                            anyhow::bail!("unknown error when calling {export}");
+                        }
+                    }
+                };
+                deno_core::v8::Global::new(&mut js_scope, result)
+            };
+
+            // Resolve the export if it's a promise
+            let resolved_result_fut = js_runtime.resolve(result);
+            let resolved_result = js_runtime.with_event_loop_promise(resolved_result_fut, Default::default()).await?;
+
+            // Call the `briocheSerialize` function on the result
+            let serialized_result = {
+                let mut js_scope = js_runtime.handle_scope();
+                let mut js_scope = deno_core::v8::TryCatch::new(&mut js_scope);
+
+                let resolved_result = deno_core::v8::Local::new(&mut js_scope, resolved_result);
+                let resolved_result: deno_core::v8::Local<deno_core::v8::Object> = resolved_result
+                    .try_into()
+                    .context("expected result to be an object")?;
+
+                let serialize_key = deno_core::v8::String::new(&mut js_scope, "briocheSerialize")
+                    .context("failed to create V8 string")?;
+                let result_serialize = resolved_result
+                    .get(&mut js_scope, serialize_key.into())
+                    .context("expected value to have a `briocheSerialize` function")?;
+                let result_serialize: deno_core::v8::Local<deno_core::v8::Function> = result_serialize
+                    .try_into()
+                    .context("expected `briocheSerialize` to be a function")?;
+
+                let serialized_result = result_serialize.call(&mut js_scope, resolved_result.into(), &[]);
+
+                let serialized_result = match serialized_result {
+                    Some(serialized_result) => serialized_result,
+                    None => {
+                        if let Some(exception) = js_scope.exception() {
+                            return Err(anyhow::anyhow!(
+                                deno_core::error::JsError::from_v8_exception(&mut js_scope, exception)
+                            ))
+                            .with_context(|| format!("error when serializing result from {export}"));
+                        } else {
+                            anyhow::bail!("unknown error when serializing result from {export}");
+                        }
+                    }
+                };
+
+                deno_core::v8::Global::new(&mut js_scope, serialized_result)
+            };
+
+            // Resolve the result of `briocheSerialize` if it's a promise
+            let serialized_resolved_result_fut = js_runtime.resolve(serialized_result);
+            let serialized_resolved_result = js_runtime.with_event_loop_promise(serialized_resolved_result_fut, Default::default()).await?;
+
+            let mut js_scope = js_runtime.handle_scope();
+
+            let serialized_resolved_result =
+                deno_core::v8::Local::new(&mut js_scope, serialized_resolved_result);
+
+            // Deserialize the result as a recipe
+            let recipe: WithMeta<Recipe> = serde_v8::from_v8(&mut js_scope, serialized_resolved_result)
+                .with_context(|| {
+                    format!("invalid recipe returned when serializing result from {export}")
+                })?;
+
+            tracing::debug!(%main_module, recipe_hash = %recipe.hash(), "finished evaluating module");
+
+            Ok(recipe)
+        });
+
+        let _ = result_tx.send(result);
     });
 
-    let main_module = projects.project_root_module_specifier(project_hash)?;
-    let main_module: deno_core::ModuleSpecifier = main_module.into();
-
-    tracing::debug!(%main_module, "evaluating module");
-
-    let module_id = js_runtime.load_main_es_module(&main_module).await?;
-    let result = js_runtime.mod_evaluate(module_id);
-    js_runtime
-        .run_event_loop(deno_core::PollEventLoopOptions::default())
-        .await?;
-    result.await?;
-
-    let module_namespace = js_runtime.get_module_namespace(module_id)?;
-
-    let result = {
-        let mut js_scope = js_runtime.handle_scope();
-        let mut js_scope = deno_core::v8::TryCatch::new(&mut js_scope);
-
-        let module_namespace = deno_core::v8::Local::new(&mut js_scope, module_namespace);
-
-        let export_key = deno_core::v8::String::new(&mut js_scope, export)
-            .context("failed to create V8 string")?;
-        let export_value = module_namespace
-            .get(&mut js_scope, export_key.into())
-            .with_context(|| format!("expected module to have an export named {export}"))?;
-        let export_value: deno_core::v8::Local<deno_core::v8::Function> =
-            export_value
-                .try_into()
-                .with_context(|| format!("expected export named {export} to be a function"))?;
-
-        tracing::debug!(%main_module, %export, "running exported function");
-
-        let result = export_value.call(&mut js_scope, module_namespace.into(), &[]);
-        let result = match result {
-            Some(result) => result,
-            None => {
-                if let Some(exception) = js_scope.exception() {
-                    return Err(anyhow::anyhow!(
-                        deno_core::error::JsError::from_v8_exception(&mut js_scope, exception)
-                    ))
-                    .with_context(|| format!("error when calling {export}"));
-                } else {
-                    anyhow::bail!("unknown error when calling {export}");
-                }
-            }
-        };
-        deno_core::v8::Global::new(&mut js_scope, result)
-    };
-
-    let resolved_result = js_runtime.resolve(result).await?;
-
-    let serialized_result = {
-        let mut js_scope = js_runtime.handle_scope();
-        let mut js_scope = deno_core::v8::TryCatch::new(&mut js_scope);
-
-        let resolved_result = deno_core::v8::Local::new(&mut js_scope, resolved_result);
-        let resolved_result: deno_core::v8::Local<deno_core::v8::Object> = resolved_result
-            .try_into()
-            .context("expected result to be an object")?;
-
-        let serialize_key = deno_core::v8::String::new(&mut js_scope, "briocheSerialize")
-            .context("failed to create V8 string")?;
-        let result_serialize = resolved_result
-            .get(&mut js_scope, serialize_key.into())
-            .context("expected value to have a `briocheSerialize` function")?;
-        let result_serialize: deno_core::v8::Local<deno_core::v8::Function> = result_serialize
-            .try_into()
-            .context("expected `briocheSerialize` to be a function")?;
-
-        let serialized_result = result_serialize.call(&mut js_scope, resolved_result.into(), &[]);
-        let serialized_result = match serialized_result {
-            Some(serialized_result) => serialized_result,
-            None => {
-                if let Some(exception) = js_scope.exception() {
-                    return Err(anyhow::anyhow!(
-                        deno_core::error::JsError::from_v8_exception(&mut js_scope, exception)
-                    ))
-                    .with_context(|| format!("error when serializing result from {export}"));
-                } else {
-                    anyhow::bail!("unknown error when serializing result from {export}");
-                }
-            }
-        };
-        deno_core::v8::Global::new(&mut js_scope, serialized_result)
-    };
-
-    let serialized_resolved_result = js_runtime.resolve(serialized_result).await?;
-
-    let mut js_scope = js_runtime.handle_scope();
-
-    let serialized_resolved_result =
-        deno_core::v8::Local::new(&mut js_scope, serialized_resolved_result);
-
-    let recipe: WithMeta<Recipe> = serde_v8::from_v8(&mut js_scope, serialized_resolved_result)
-        .with_context(|| {
-            format!("invalid recipe returned when serializing result from {export}")
-        })?;
-
-    tracing::debug!(%main_module, recipe_hash = %recipe.hash(), "finished evaluating module");
-
-    Ok(recipe)
+    let result = result_rx.await??;
+    Ok(result)
 }

--- a/crates/brioche-core/src/script/lsp.rs
+++ b/crates/brioche-core/src/script/lsp.rs
@@ -12,6 +12,7 @@ use crate::script::compiler_host::{brioche_compiler_host, BriocheCompilerHost};
 use crate::script::format::format_code;
 use crate::{Brioche, BriocheBuilder};
 
+use super::bridge::RuntimeBridge;
 use super::specifier::BriocheModuleSpecifier;
 
 /// The maximum time we spend resolving projects when regenerating a
@@ -19,22 +20,21 @@ use super::specifier::BriocheModuleSpecifier;
 const LOCKFILE_LOAD_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
 
 pub struct BriocheLspServer {
+    bridge: RuntimeBridge,
     compiler_host: BriocheCompilerHost,
     client: Client,
     js_lsp: JsLspTask,
 }
 
 impl BriocheLspServer {
-    pub async fn new(
-        local_pool: &tokio_util::task::LocalPoolHandle,
-        brioche: Brioche,
-        projects: Projects,
-        client: Client,
-    ) -> anyhow::Result<Self> {
-        let compiler_host = BriocheCompilerHost::new(brioche.clone(), projects.clone()).await;
-        let js_lsp = js_lsp_task(local_pool, compiler_host.clone());
+    pub async fn new(brioche: Brioche, projects: Projects, client: Client) -> anyhow::Result<Self> {
+        let bridge = RuntimeBridge::new(brioche.clone(), projects.clone());
+
+        let compiler_host = BriocheCompilerHost::new(bridge.clone()).await;
+        let js_lsp = js_lsp_task(compiler_host.clone(), bridge.clone());
 
         Ok(Self {
+            bridge,
             compiler_host,
             client,
             js_lsp,
@@ -103,7 +103,10 @@ impl LanguageServer for BriocheLspServer {
         let specifier = lsp_uri_to_module_specifier(&params.text_document.uri);
         match specifier {
             Ok(specifier) => {
-                let result = self.compiler_host.load_document(&specifier).await;
+                let result = self
+                    .compiler_host
+                    .load_documents(vec![specifier.clone()])
+                    .await;
                 match result {
                     Ok(()) => {}
                     Err(error) => {
@@ -146,14 +149,14 @@ impl LanguageServer for BriocheLspServer {
             let (lockfile_tx, lockfile_rx) = tokio::sync::oneshot::channel();
 
             std::thread::spawn({
-                let compiler_host = self.compiler_host.clone();
+                let bridge = self.bridge.clone();
                 let module_path = module_path.clone();
                 move || {
                     let local_set = tokio::task::LocalSet::new();
 
                     local_set.spawn_local(async move {
                         let result = try_update_lockfile_for_module(
-                            compiler_host.clone(),
+                            bridge,
                             module_path,
                             LOCKFILE_LOAD_TIMEOUT,
                         )
@@ -458,16 +461,11 @@ impl LanguageServer for BriocheLspServer {
 }
 
 async fn try_update_lockfile_for_module(
-    compiler_host: BriocheCompilerHost,
+    bridge: RuntimeBridge,
     module_path: PathBuf,
     load_timeout: std::time::Duration,
 ) -> anyhow::Result<bool> {
-    let project_hash = compiler_host
-        .projects
-        .find_containing_project(&module_path)
-        .context("failed to get project path")?
-        .context("containing project not found")?;
-    let project_path = compiler_host.projects.project_root(project_hash)?.clone();
+    let project_path = bridge.project_root_for_module_path(module_path).await?;
 
     // The instances of `Brioche` and `Projects` used for the LSP aren't
     // suitable for generating lockfiles (access to the registry is disabled,
@@ -538,121 +536,130 @@ impl JsLspTask {
     }
 }
 
-fn js_lsp_task(
-    local_pool: &tokio_util::task::LocalPoolHandle,
-    compiler_host: BriocheCompilerHost,
-) -> JsLspTask {
+fn js_lsp_task(compiler_host: BriocheCompilerHost, bridge: RuntimeBridge) -> JsLspTask {
     let (tx, mut rx) = tokio::sync::mpsc::channel::<(
         JsLspMessage,
         tokio::sync::oneshot::Sender<serde_json::Value>,
     )>(1);
 
-    let js_lsp_task = local_pool.spawn_pinned(|| async move {
-        let module_loader =
-            super::BriocheModuleLoader::new(&compiler_host.brioche, &compiler_host.projects);
+    std::thread::spawn(move || {
+        let module_loader = super::BriocheModuleLoader::new(bridge);
 
-        tracing::info!("building JS LSP");
-
-        let mut js_runtime = deno_core::JsRuntime::new(deno_core::RuntimeOptions {
-            module_loader: Some(Rc::new(module_loader)),
-            extensions: vec![
-                brioche_compiler_host::init_ops(compiler_host),
-                super::js::brioche_js::init_ops(),
-            ],
-            ..Default::default()
-        });
-
-        let main_module: deno_core::ModuleSpecifier = "briocheruntime:///dist/index.js".parse()?;
-
-        tracing::info!(%main_module, "evaluating module");
-
-        tracing::info!("loading module");
-
-        let module_id = js_runtime.load_main_es_module(&main_module).await?;
-        let result = js_runtime.mod_evaluate(module_id);
-        js_runtime
-            .run_event_loop(deno_core::PollEventLoopOptions::default())
-            .await?;
-        result.await?;
-
-        let module_namespace = js_runtime.get_module_namespace(module_id)?;
-
-        tracing::info!("calling JS");
-
-        let js_lsp = {
-            let mut js_scope = js_runtime.handle_scope();
-            let module_namespace = deno_core::v8::Local::new(&mut js_scope, module_namespace);
-
-            let export_key_name = "buildLsp";
-            let export_key = deno_core::v8::String::new(&mut js_scope, export_key_name)
-                .context("failed to create V8 string")?;
-            let export = module_namespace
-                .get(&mut js_scope, export_key.into())
-                .with_context(|| {
-                    format!("expected module to have an export named {export_key_name:?}")
-                })?;
-            let export: deno_core::v8::Local<deno_core::v8::Function> = export
-                .try_into()
-                .with_context(|| format!("expected export {export_key_name:?} to be a function"))?;
-
-            tracing::info!(%main_module, ?export_key_name, "running function");
-
-            let js_lsp = export
-                .call(&mut js_scope, module_namespace.into(), &[])
-                .context("failed to build LSP")?;
-            let js_lsp: deno_core::v8::Local<deno_core::v8::Object> =
-                js_lsp.try_into().context("expected LSP to be an object")?;
-            deno_core::v8::Global::new(&mut js_scope, js_lsp)
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build();
+        let runtime = match runtime {
+            Ok(runtime) => runtime,
+            Err(error) => {
+                tracing::error!("failed to create runtime: {error:#}");
+                return;
+            }
         };
 
-        tracing::info!("built JS LSP");
+        let result = runtime.block_on(async move {
+            tracing::info!("building JS LSP");
 
-        while let Some((message, response_tx)) = rx.recv().await {
-            tracing::info!(?message, "got message");
-            let response = match message {
-                JsLspMessage::Completion(params) => {
-                    call_method_1(&mut js_runtime, &js_lsp, "completion", &params)
-                }
-                JsLspMessage::Diagnostic(params) => {
-                    call_method_1(&mut js_runtime, &js_lsp, "diagnostic", &params)
-                }
-                JsLspMessage::GotoDefintion(params) => {
-                    call_method_1(&mut js_runtime, &js_lsp, "gotoDefinition", &params)
-                }
-                JsLspMessage::Hover(params) => {
-                    call_method_1(&mut js_runtime, &js_lsp, "hover", &params)
-                }
-                JsLspMessage::DocumentHighlight(params) => {
-                    call_method_1(&mut js_runtime, &js_lsp, "documentHighlight", &params)
-                }
-                JsLspMessage::References(params) => {
-                    call_method_1(&mut js_runtime, &js_lsp, "references", &params)
-                }
-                JsLspMessage::PrepareRename(params) => {
-                    call_method_1(&mut js_runtime, &js_lsp, "prepareRename", &params)
-                }
-                JsLspMessage::Rename(params) => {
-                    call_method_1(&mut js_runtime, &js_lsp, "rename", &params)
-                }
+            let mut js_runtime = deno_core::JsRuntime::new(deno_core::RuntimeOptions {
+                module_loader: Some(Rc::new(module_loader)),
+                extensions: vec![
+                    brioche_compiler_host::init_ops(compiler_host),
+                    super::js::brioche_js::init_ops(),
+                ],
+                ..Default::default()
+            });
+
+            let main_module: deno_core::ModuleSpecifier =
+                "briocheruntime:///dist/index.js".parse()?;
+
+            tracing::info!(%main_module, "evaluating module");
+
+            tracing::info!("loading module");
+
+            let module_id = js_runtime.load_main_es_module(&main_module).await?;
+            let result = js_runtime.mod_evaluate(module_id);
+            js_runtime
+                .run_event_loop(deno_core::PollEventLoopOptions::default())
+                .await?;
+            result.await?;
+
+            let module_namespace = js_runtime.get_module_namespace(module_id)?;
+
+            tracing::info!("calling JS");
+
+            let js_lsp = {
+                let mut js_scope = js_runtime.handle_scope();
+                let module_namespace = deno_core::v8::Local::new(&mut js_scope, module_namespace);
+
+                let export_key_name = "buildLsp";
+                let export_key = deno_core::v8::String::new(&mut js_scope, export_key_name)
+                    .context("failed to create V8 string")?;
+                let export = module_namespace
+                    .get(&mut js_scope, export_key.into())
+                    .with_context(|| {
+                        format!("expected module to have an export named {export_key_name:?}")
+                    })?;
+                let export: deno_core::v8::Local<deno_core::v8::Function> =
+                    export.try_into().with_context(|| {
+                        format!("expected export {export_key_name:?} to be a function")
+                    })?;
+
+                tracing::info!(%main_module, ?export_key_name, "running function");
+
+                let js_lsp = export
+                    .call(&mut js_scope, module_namespace.into(), &[])
+                    .context("failed to build LSP")?;
+                let js_lsp: deno_core::v8::Local<deno_core::v8::Object> =
+                    js_lsp.try_into().context("expected LSP to be an object")?;
+                deno_core::v8::Global::new(&mut js_scope, js_lsp)
             };
 
-            match response {
-                Ok(response) => {
-                    let _ = response_tx.send(response);
-                }
-                Err(error) => {
-                    tracing::error!("failed to call method: {error:#}");
-                    return Err(error);
-                }
-            };
-        }
+            tracing::info!("built JS LSP");
 
-        anyhow::Ok(())
-    });
+            while let Some((message, response_tx)) = rx.recv().await {
+                tracing::info!(?message, "got message");
+                let response = match message {
+                    JsLspMessage::Completion(params) => {
+                        call_method_1(&mut js_runtime, &js_lsp, "completion", &params)
+                    }
+                    JsLspMessage::Diagnostic(params) => {
+                        call_method_1(&mut js_runtime, &js_lsp, "diagnostic", &params)
+                    }
+                    JsLspMessage::GotoDefintion(params) => {
+                        call_method_1(&mut js_runtime, &js_lsp, "gotoDefinition", &params)
+                    }
+                    JsLspMessage::Hover(params) => {
+                        call_method_1(&mut js_runtime, &js_lsp, "hover", &params)
+                    }
+                    JsLspMessage::DocumentHighlight(params) => {
+                        call_method_1(&mut js_runtime, &js_lsp, "documentHighlight", &params)
+                    }
+                    JsLspMessage::References(params) => {
+                        call_method_1(&mut js_runtime, &js_lsp, "references", &params)
+                    }
+                    JsLspMessage::PrepareRename(params) => {
+                        call_method_1(&mut js_runtime, &js_lsp, "prepareRename", &params)
+                    }
+                    JsLspMessage::Rename(params) => {
+                        call_method_1(&mut js_runtime, &js_lsp, "rename", &params)
+                    }
+                };
 
-    tokio::task::spawn(async move {
-        if let Err(error) = js_lsp_task.await {
-            tracing::error!("error in JS LSP task: {error}");
+                match response {
+                    Ok(response) => {
+                        let _ = response_tx.send(response);
+                    }
+                    Err(error) => {
+                        tracing::error!("failed to call method: {error:#}");
+                        return Err(error);
+                    }
+                };
+            }
+
+            anyhow::Ok(())
+        });
+
+        if let Err(error) = result {
+            tracing::error!("failed to run runtime: {error:#}");
         }
     });
 

--- a/crates/brioche-core/src/script/lsp.rs
+++ b/crates/brioche-core/src/script/lsp.rs
@@ -554,8 +554,7 @@ fn js_lsp_task(
         tracing::info!("building JS LSP");
 
         let mut js_runtime = deno_core::JsRuntime::new(deno_core::RuntimeOptions {
-            module_loader: Some(Rc::new(module_loader.clone())),
-            source_map_getter: Some(Box::new(module_loader.clone())),
+            module_loader: Some(Rc::new(module_loader)),
             extensions: vec![
                 brioche_compiler_host::init_ops(compiler_host),
                 super::js::brioche_js::init_ops(),
@@ -569,9 +568,11 @@ fn js_lsp_task(
 
         tracing::info!("loading module");
 
-        let module_id = js_runtime.load_main_module(&main_module, None).await?;
+        let module_id = js_runtime.load_main_es_module(&main_module).await?;
         let result = js_runtime.mod_evaluate(module_id);
-        js_runtime.run_event_loop(false).await?;
+        js_runtime
+            .run_event_loop(deno_core::PollEventLoopOptions::default())
+            .await?;
         result.await?;
 
         let module_namespace = js_runtime.get_module_namespace(module_id)?;

--- a/crates/brioche/src/lsp.rs
+++ b/crates/brioche/src/lsp.rs
@@ -11,10 +11,7 @@ pub async fn lsp(_args: LspArgs) -> anyhow::Result<()> {
     let stdin = tokio::io::stdin();
     let stdout = tokio::io::stdout();
 
-    let local_pool = tokio_util::task::LocalPoolHandle::new(5);
-
     let (service, socket) = tower_lsp::LspService::new(move |client| {
-        let local_pool = &local_pool;
         futures::executor::block_on(async move {
             let (reporter, _guard) = brioche_core::reporter::start_lsp_reporter(client.clone());
             let brioche = brioche_core::BriocheBuilder::new(reporter)
@@ -23,10 +20,8 @@ pub async fn lsp(_args: LspArgs) -> anyhow::Result<()> {
                 .build()
                 .await?;
             let projects = brioche_core::project::Projects::default();
-            let lsp_server = brioche_core::script::lsp::BriocheLspServer::new(
-                local_pool, brioche, projects, client,
-            )
-            .await?;
+            let lsp_server =
+                brioche_core::script::lsp::BriocheLspServer::new(brioche, projects, client).await?;
             anyhow::Ok(lsp_server)
         })
         .expect("failed to build LSP")

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.77"
+channel = "1.79"
 profile = "default"
 targets = ["x86_64-unknown-linux-musl"]


### PR DESCRIPTION
Resolve #81 

This PR update `deno_core`and `serde_v8` to their latest version. I also made the switch to the usage of Rust 1.79, since deno_core requires it to make use of https://github.com/rust-lang/rust/pull/104087/.