### PR TITLE
Implement new `glob` recipe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -892,6 +892,7 @@ dependencies = [
  "url",
  "urlencoding",
  "walkdir",
+ "wax",
  "zstd",
 ]
 
@@ -1162,6 +1163,26 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const_format"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a214c7af3d04997541b18d432afaff4c455e79e2029079647e72fc2bd27673"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f6ff08fd20f4f299298a28e2dfa8a8ba1036e6cd2460ac1de7b425d76f2500"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
 
 [[package]]
 name = "constant_time_eq"
@@ -2449,6 +2470,15 @@ dependencies = [
 
 [[package]]
 name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25db6b064527c5d482d0423354fcd07a89a2dfe07b67892e62411946db7f07b0"
@@ -3368,6 +3398,15 @@ name = "pkg-config"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
+
+[[package]]
+name = "pori"
+version = "0.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a63d338dec139f56dacc692ca63ad35a6be6a797442479b55acd611d79e906"
+dependencies = [
+ "nom 7.1.3",
+]
 
 [[package]]
 name = "powerfmt"
@@ -5871,6 +5910,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "229730647fbc343e3a80e463c1db7f78f3855d3f3739bee0dda773c9a037c90a"
+
+[[package]]
 name = "unicode_categories"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6098,6 +6143,20 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "wax"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d12a78aa0bab22d2f26ed1a96df7ab58e8a93506a3e20adb47c51a93b4e1357"
+dependencies = [
+ "const_format",
+ "itertools 0.11.0",
+ "nom 7.1.3",
+ "pori",
+ "regex",
+ "thiserror",
 ]
 
 [[package]]

--- a/crates/brioche-core/Cargo.toml
+++ b/crates/brioche-core/Cargo.toml
@@ -64,6 +64,7 @@ url = { version = "2.5.0", features = ["serde"] }
 urlencoding = "2.1.3"
 walkdir = "2.5.0"
 petgraph = "0.6.5"
+wax = { version = "0.6.0", default-features = false }
 
 [dev-dependencies]
 assert_matches = "1.5.0"

--- a/crates/brioche-core/src/references.rs
+++ b/crates/brioche-core/src/references.rs
@@ -127,6 +127,7 @@ pub fn referenced_blobs(recipe: &Recipe) -> Vec<BlobHash> {
         | Recipe::Peel { .. }
         | Recipe::Get { .. }
         | Recipe::Insert { .. }
+        | Recipe::Glob { .. }
         | Recipe::SetPermissions { .. }
         | Recipe::Proxy(_)
         | Recipe::CollectReferences { .. }
@@ -255,6 +256,10 @@ pub fn referenced_recipes(recipe: &Recipe) -> Vec<RecipeHash> {
             .into_iter()
             .chain(recipe.iter().flat_map(|recipe| referenced_recipes(recipe)))
             .collect(),
+        Recipe::Glob {
+            directory,
+            patterns: _,
+        } => referenced_recipes(directory),
         Recipe::SetPermissions {
             file,
             executable: _,

--- a/crates/brioche-core/tests/bake_glob.rs
+++ b/crates/brioche-core/tests/bake_glob.rs
@@ -1,0 +1,248 @@
+use core::panic;
+
+use brioche_core::{
+    recipe::{Directory, Recipe, WithMeta},
+    Brioche,
+};
+
+pub async fn bake_to_recipe(brioche: &Brioche, recipe: &Recipe) -> Recipe {
+    let artifact = brioche_test_support::bake_without_meta(brioche, recipe.clone()).await;
+    Recipe::from(artifact.expect("failed to bake"))
+}
+
+pub async fn bake_glob(brioche: &Brioche, recipe: &Recipe, patterns: &[&str]) -> Directory {
+    let glob_recipe = Recipe::Glob {
+        directory: Box::new(WithMeta::without_meta(recipe.clone())),
+        patterns: patterns.iter().map(|&pattern| pattern.into()).collect(),
+    };
+
+    let Recipe::Directory(result) = bake_to_recipe(brioche, &glob_recipe).await else {
+        panic!("expected baked glob to return a directory");
+    };
+
+    result
+}
+
+#[tokio::test]
+async fn test_bake_glob_basic() -> anyhow::Result<()> {
+    let (brioche, _context) = brioche_test_support::brioche_test().await;
+
+    let blob = brioche_test_support::blob(&brioche, b"hello").await;
+
+    let directory = brioche_test_support::lazy_dir([(
+        "foo",
+        brioche_test_support::lazy_dir([
+            (
+                "bar",
+                brioche_test_support::lazy_dir([
+                    (
+                        "baz",
+                        brioche_test_support::lazy_dir([(
+                            "hello.include",
+                            brioche_test_support::lazy_file(blob, false),
+                        )]),
+                    ),
+                    ("hi.include", brioche_test_support::lazy_file(blob, false)),
+                    ("other.txt", brioche_test_support::lazy_file(blob, false)),
+                ]),
+            ),
+            (
+                "included",
+                brioche_test_support::lazy_dir([(
+                    "other.txt",
+                    brioche_test_support::lazy_file(blob, false),
+                )]),
+            ),
+            (
+                "something.txt",
+                brioche_test_support::lazy_file(blob, false),
+            ),
+        ]),
+    )]);
+
+    let globbed = bake_glob(
+        &brioche,
+        &directory,
+        &["**/*.include", "foo/included", "foo/something.txt"],
+    )
+    .await;
+
+    assert_eq!(
+        globbed,
+        brioche_test_support::dir_value(
+            &brioche,
+            [(
+                "foo",
+                brioche_test_support::dir(
+                    &brioche,
+                    [
+                        (
+                            "bar",
+                            brioche_test_support::dir(
+                                &brioche,
+                                [
+                                    (
+                                        "baz",
+                                        brioche_test_support::dir(
+                                            &brioche,
+                                            [(
+                                                "hello.include",
+                                                brioche_test_support::file(blob, false)
+                                            ),]
+                                        )
+                                        .await
+                                    ),
+                                    ("hi.include", brioche_test_support::file(blob, false)),
+                                ]
+                            )
+                            .await
+                        ),
+                        (
+                            "included",
+                            brioche_test_support::dir(
+                                &brioche,
+                                [("other.txt", brioche_test_support::file(blob, false)),]
+                            )
+                            .await
+                        ),
+                        ("something.txt", brioche_test_support::file(blob, false)),
+                    ]
+                )
+                .await
+            ),]
+        )
+        .await
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_bake_glob_non_utf8() -> anyhow::Result<()> {
+    let (brioche, _context) = brioche_test_support::brioche_test().await;
+
+    let blob = brioche_test_support::blob(&brioche, b"hello").await;
+
+    let directory = brioche_test_support::lazy_dir([
+        (b"foo\x80.txt", brioche_test_support::lazy_file(blob, false)),
+        (b"bar\x81.txt", brioche_test_support::lazy_file(blob, false)),
+        (b"bar\x82.txt", brioche_test_support::lazy_file(blob, false)),
+        (b"baz\x83.txt", brioche_test_support::lazy_file(blob, false)),
+    ]);
+
+    let globbed = bake_glob(
+        &brioche,
+        &directory,
+        &[
+            // Wildcards should match invalid UTF-8 sequences
+            "foo*.txt",
+            // The Unicode replacement character should match any byte
+            // in an invalid UTF-8 sequences
+            "bar�.txt",
+        ],
+    )
+    .await;
+
+    assert_eq!(
+        globbed,
+        brioche_test_support::dir_value(
+            &brioche,
+            [
+                (b"foo\x80.txt", brioche_test_support::file(blob, false)),
+                (b"bar\x81.txt", brioche_test_support::file(blob, false)),
+                (b"bar\x82.txt", brioche_test_support::file(blob, false)),
+            ]
+        )
+        .await
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_bake_glob_no_matches() -> anyhow::Result<()> {
+    let (brioche, _context) = brioche_test_support::brioche_test().await;
+
+    let blob = brioche_test_support::blob(&brioche, b"hello").await;
+
+    let directory = brioche_test_support::lazy_dir([(
+        "foo",
+        brioche_test_support::lazy_dir([
+            (
+                "bar",
+                brioche_test_support::lazy_dir([
+                    (
+                        "baz",
+                        brioche_test_support::lazy_dir([(
+                            "hello.include",
+                            brioche_test_support::lazy_file(blob, false),
+                        )]),
+                    ),
+                    ("hi.include", brioche_test_support::lazy_file(blob, false)),
+                    ("other.txt", brioche_test_support::lazy_file(blob, false)),
+                ]),
+            ),
+            (
+                "included",
+                brioche_test_support::lazy_dir([(
+                    "other.txt",
+                    brioche_test_support::lazy_file(blob, false),
+                )]),
+            ),
+            (
+                "something.txt",
+                brioche_test_support::lazy_file(blob, false),
+            ),
+        ]),
+    )]);
+
+    let globbed = bake_glob(&brioche, &directory, &["**/*.nothing"]).await;
+
+    assert_eq!(globbed, brioche_test_support::empty_dir_value());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_bake_glob_no_patterns() -> anyhow::Result<()> {
+    let (brioche, _context) = brioche_test_support::brioche_test().await;
+
+    let blob = brioche_test_support::blob(&brioche, b"hello").await;
+
+    let directory = brioche_test_support::lazy_dir([(
+        "foo",
+        brioche_test_support::lazy_dir([
+            (
+                "bar",
+                brioche_test_support::lazy_dir([
+                    (
+                        "baz",
+                        brioche_test_support::lazy_dir([(
+                            "hello.include",
+                            brioche_test_support::lazy_file(blob, false),
+                        )]),
+                    ),
+                    ("hi.include", brioche_test_support::lazy_file(blob, false)),
+                    ("other.txt", brioche_test_support::lazy_file(blob, false)),
+                ]),
+            ),
+            (
+                "included",
+                brioche_test_support::lazy_dir([(
+                    "other.txt",
+                    brioche_test_support::lazy_file(blob, false),
+                )]),
+            ),
+            (
+                "something.txt",
+                brioche_test_support::lazy_file(blob, false),
+            ),
+        ]),
+    )]);
+
+    let globbed = bake_glob(&brioche, &directory, &[]).await;
+
+    assert_eq!(globbed, brioche_test_support::empty_dir_value());
+
+    Ok(())
+}


### PR DESCRIPTION
Closes #79

This PR implements the new `glob` recipe type, which takes a directory recipe and a list of patterns, and bakes to a new directory filtered down based on the list of patterns.

Even though Brioche already uses `globset` for glob matching, I ended up using [Wax](https://crates.io/crates/wax) to match glob patterns for the `glob` recipe. This is because `globset` (and most other glob matching libraries) use `std::path::Path` somewhere in the pipeline, which might lead to different behavior depending on the host platform. On the other hand, Wax is meant to be portable across platforms, so it's a good fit for this use case

One limitation around Wax is that the paths to match against must be `&str`s, which mean they must be valid UTF-8. Brioche currently doesn't enforce that filenames are UTF-8, so paths in artifacts are converted using [`String::from_utf8_lossy`](https://doc.rust-lang.org/stable/std/string/struct.String.html#method.from_utf8_lossy), which means that wildcards will even work with invalid UTF-8 sequences in paths (this also means a glob pattern can use the Unicode replacement character (�) to match an invalid UTF-8 byte)

I also disallowed any glob patterns from containing `!`. As far as I can tell, Wax doesn't handle "negative patterns" natively, so I wanted to reserve `!` in case we wanted to support gitignore-style syntax for excluding specific files in the future