### PR TITLE
Clean up `WithMeta` handling

### DIFF
--- a/crates/brioche-core/benches/bake.rs
+++ b/crates/brioche-core/benches/bake.rs
@@ -183,14 +183,14 @@ async fn make_deep_dir(brioche: &Brioche, key: &str) -> Directory {
                                     "{key}a{a}/{key}b{b}/{key}c{c}/{key}d{d}/{key}e{e}/file.txt"
                                 )
                                 .as_bytes(),
-                                Some(WithMeta::without_meta(brioche_test_support::file(
+                                Some(brioche_test_support::file(
                                     brioche_test_support::blob(
                                         brioche,
                                         format!("a={a},b={b},c={c},d={d},e={e}"),
                                     )
                                     .await,
                                     false,
-                                ))),
+                                )),
                             )
                             .await
                             .unwrap();
@@ -211,10 +211,10 @@ async fn make_wide_dir(brioche: &Brioche, key: &str) -> Directory {
                 .insert(
                     brioche,
                     format!("{key}a{a}/{key}b{b}/file.txt").as_bytes(),
-                    Some(WithMeta::without_meta(brioche_test_support::file(
+                    Some(brioche_test_support::file(
                         brioche_test_support::blob(brioche, format!("a={a},b={b}")).await,
                         false,
-                    ))),
+                    )),
                 )
                 .await
                 .unwrap();

--- a/crates/brioche-core/benches/directory.rs
+++ b/crates/brioche-core/benches/directory.rs
@@ -1,4 +1,4 @@
-use brioche_core::recipe::{Directory, WithMeta};
+use brioche_core::recipe::Directory;
 
 fn main() {
     divan::main();
@@ -26,11 +26,7 @@ fn bench_directory_insert(bencher: divan::Bencher) {
                             for e in 0..3 {
                                 let path = format!("a{a}/b{b}/c{c}/d{d}/e{e}/file.txt");
                                 directory
-                                    .insert(
-                                        &brioche,
-                                        path.as_bytes(),
-                                        Some(WithMeta::without_meta(file_hello.clone())),
-                                    )
+                                    .insert(&brioche, path.as_bytes(), Some(file_hello.clone()))
                                     .await
                                     .unwrap();
                             }

--- a/crates/brioche-core/src/bake.rs
+++ b/crates/brioche-core/src/bake.rs
@@ -425,14 +425,14 @@ async fn run_bake(brioche: &Brioche, recipe: Recipe, meta: &Arc<Meta>) -> anyhow
             Ok(artifact.value)
         }
         Recipe::Peel { directory, depth } => {
-            let mut result = bake(brioche, *directory, &scope).await?;
+            let mut result = bake(brioche, *directory, &scope).await?.value;
 
             if depth == 0 {
                 anyhow::bail!("must peel at least 1 layer");
             }
 
             for _ in 0..depth {
-                let Artifact::Directory(dir) = result.value else {
+                let Artifact::Directory(dir) = result else {
                     anyhow::bail!("tried peeling non-directory artifact");
                 };
                 let entries = dir.entries(brioche).await?;
@@ -448,7 +448,7 @@ async fn run_bake(brioche: &Brioche, recipe: Recipe, meta: &Arc<Meta>) -> anyhow
                 result = peeled;
             }
 
-            Ok(result.value)
+            Ok(result)
         }
         Recipe::Get { directory, path } => {
             let artifact = bake(brioche, *directory, &scope).await?;
@@ -460,7 +460,7 @@ async fn run_bake(brioche: &Brioche, recipe: Recipe, meta: &Arc<Meta>) -> anyhow
                 anyhow::bail!("path not found in directory: {path:?}");
             };
 
-            Ok(result.value)
+            Ok(result)
         }
         Recipe::Insert {
             directory,
@@ -476,6 +476,7 @@ async fn run_bake(brioche: &Brioche, recipe: Recipe, meta: &Arc<Meta>) -> anyhow
                     }
                 }
             })?;
+            let artifact = artifact.map(|artifact| artifact.value);
 
             let Artifact::Directory(mut directory) = directory.value else {
                 anyhow::bail!("tried removing item from non-directory artifact");

--- a/crates/brioche-core/src/bake/collect_references.rs
+++ b/crates/brioche-core/src/bake/collect_references.rs
@@ -1,5 +1,5 @@
 use crate::{
-    recipe::{Artifact, Directory, WithMeta},
+    recipe::{Artifact, Directory},
     Brioche,
 };
 
@@ -18,7 +18,7 @@ pub async fn bake_collect_references(
             .insert(
                 brioche,
                 b"brioche-resources.d",
-                Some(WithMeta::without_meta(Artifact::Directory(resources_dir))),
+                Some(Artifact::Directory(resources_dir)),
             )
             .await?;
 
@@ -61,14 +61,9 @@ async fn collect_directory_references(
     let mut new_directory = Directory::default();
 
     for (name, artifact) in directory.entries(brioche).await? {
-        let new_artifact =
-            Box::pin(collect_references(brioche, artifact.value, resources_dir)).await?;
+        let new_artifact = Box::pin(collect_references(brioche, artifact, resources_dir)).await?;
         new_directory
-            .insert(
-                brioche,
-                &name,
-                Some(WithMeta::new(new_artifact, artifact.meta)),
-            )
+            .insert(brioche, &name, Some(new_artifact))
             .await?;
     }
 

--- a/crates/brioche-core/src/bake/process.rs
+++ b/crates/brioche-core/src/bake/process.rs
@@ -214,7 +214,7 @@ async fn resolve_command(
         // Get the artifact referred to by the subpath
         let subpath_artifact = dir.get(brioche, &subpath).await;
         let subpath_artifact = match &subpath_artifact {
-            Ok(Some(subpath_artifact)) => &subpath_artifact.value,
+            Ok(Some(subpath_artifact)) => subpath_artifact,
             Err(DirectoryError::EmptyPath { .. }) => {
                 // If the subpath was empty, use the directory itself
                 &artifact.value
@@ -232,7 +232,7 @@ async fn resolve_command(
         // Try to get the artifact referred to by the command
         let command_artifact = subpath_dir.get(brioche, &command_literal).await;
         let command_artifact = match &command_artifact {
-            Ok(Some(command_artifact)) => &command_artifact.value,
+            Ok(Some(command_artifact)) => command_artifact,
             _ => {
                 continue;
             }
@@ -840,7 +840,7 @@ async fn append_dependency_envs(
 
         // Get the directory `brioche-env.d/env` if it exists
         let env_dir = dependency.get(brioche, b"brioche-env.d/env").await?;
-        let env_dir = env_dir.and_then(|env_dir| match env_dir.value {
+        let env_dir = env_dir.and_then(|env_dir| match env_dir {
             Artifact::Directory(dir) => Some(dir),
             _ => None,
         });
@@ -851,7 +851,7 @@ async fn append_dependency_envs(
 
             for (env_var, env_dir_entry) in env_dir_entries {
                 // Validate the entry is a directory
-                let Artifact::Directory(env_dir_entry) = env_dir_entry.value else {
+                let Artifact::Directory(env_dir_entry) = env_dir_entry else {
                     anyhow::bail!("expected `brioche-env.d/env/{env_var}` to be a directory");
                 };
                 let env_value_entries = env_dir_entry.entries(brioche).await?;
@@ -862,7 +862,7 @@ async fn append_dependency_envs(
                     // Validate it's a symlink
                     let Artifact::Symlink {
                         target: env_value_target,
-                    } = env_value_entry.value
+                    } = env_value_entry
                     else {
                         anyhow::bail!("expected `brioche-env.d/env/{env_var}/{env_value_entry_name}` to be a symlink");
                     };
@@ -895,7 +895,6 @@ async fn append_dependency_envs(
         // If the artifact contains a `bin` directory, append that to `$PATH`
         // automatically
         let bin_artifact = dependency.get(brioche, b"bin").await?;
-        let bin_artifact = bin_artifact.as_ref().map(|artifact| &artifact.value);
         if matches!(bin_artifact, Some(Artifact::Directory { .. })) {
             env_var_appends.push(("PATH".into(), dependency_artifact.clone(), "bin".into()));
         }

--- a/crates/brioche-core/src/input.rs
+++ b/crates/brioche-core/src/input.rs
@@ -153,6 +153,7 @@ pub async fn create_input(
                     let resource_node_index = edge.target();
                     let resource_artifact = nodes_to_artifacts
                         .get(&resource_node_index)
+                        .map(|artifact| &artifact.value)
                         .ok_or_else(|| anyhow::anyhow!("resource node not found"))?;
 
                     resources
@@ -192,6 +193,7 @@ pub async fn create_input(
                     let entry_node_index = edge.target();
                     let entry_artifact = nodes_to_artifacts
                         .get(&entry_node_index)
+                        .map(|artifact| &artifact.value)
                         .ok_or_else(|| anyhow::anyhow!("directory entry node not found"))?;
 
                     directory

--- a/crates/brioche-core/src/output.rs
+++ b/crates/brioche-core/src/output.rs
@@ -253,7 +253,7 @@ async fn create_output_inner<'a: 'async_recursion>(
                     }
                 };
 
-                match (&entry.value, link_lock) {
+                match (&entry, link_lock) {
                     (Artifact::File(file), Some(link_lock)) => {
                         if !file.resources.is_empty() {
                             create_output_inner(
@@ -275,7 +275,7 @@ async fn create_output_inner<'a: 'async_recursion>(
                         // for the file, then hardlink to it
 
                         let local_output =
-                            create_local_output_inner(brioche, &entry.value, link_lock).await?;
+                            create_local_output_inner(brioche, &entry, link_lock).await?;
                         crate::fs_utils::try_remove(&entry_path).await?;
                         tokio::fs::hard_link(&local_output.path, &entry_path)
                             .await
@@ -284,7 +284,7 @@ async fn create_output_inner<'a: 'async_recursion>(
                     _ => {
                         create_output_inner(
                             brioche,
-                            &entry.value,
+                            &entry,
                             OutputOptions {
                                 output_path: &entry_path,
                                 resource_dir: Some(resource_dir),

--- a/crates/brioche-core/src/project.rs
+++ b/crates/brioche-core/src/project.rs
@@ -1325,7 +1325,7 @@ async fn resolve_static(
                         },
                     )
                     .await?;
-                    anyhow::Ok((relative_path, artifact))
+                    anyhow::Ok((relative_path, artifact.value))
                 })
                 .try_collect::<Vec<_>>()
                 .await?;

--- a/crates/brioche-core/src/recipe.rs
+++ b/crates/brioche-core/src/recipe.rs
@@ -430,20 +430,6 @@ impl std::ops::DerefMut for WithMeta<Artifact> {
     }
 }
 
-impl std::ops::Deref for WithMeta<RecipeHash> {
-    type Target = RecipeHash;
-
-    fn deref(&self) -> &Self::Target {
-        &self.value
-    }
-}
-
-impl std::ops::DerefMut for WithMeta<RecipeHash> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.value
-    }
-}
-
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct StackFrame {

--- a/crates/brioche-core/src/recipe.rs
+++ b/crates/brioche-core/src/recipe.rs
@@ -342,10 +342,13 @@ pub struct Meta {
     pub source: Option<Vec<StackFrame>>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct WithMeta<T> {
-    pub value: T,
+    #[serde(default, skip_serializing)]
     pub meta: Arc<Meta>,
+
+    #[serde(flatten)]
+    pub value: T,
 }
 
 impl<T> WithMeta<T> {
@@ -376,31 +379,6 @@ impl<T> WithMeta<T> {
 
     pub fn source_frame(&self) -> Option<&StackFrame> {
         self.meta.source.as_ref().and_then(|frames| frames.first())
-    }
-}
-
-impl<T> serde::Serialize for WithMeta<T>
-where
-    T: serde::Serialize,
-{
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        serde::Serialize::serialize(&self.value, serializer)
-    }
-}
-
-impl<'de, T> serde::Deserialize<'de> for WithMeta<T>
-where
-    T: serde::Deserialize<'de>,
-{
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let value: T = serde::Deserialize::deserialize(deserializer)?;
-        Ok(WithMeta::without_meta(value))
     }
 }
 

--- a/crates/brioche-core/src/references.rs
+++ b/crates/brioche-core/src/references.rs
@@ -142,11 +142,7 @@ pub fn referenced_recipes(recipe: &Recipe) -> Vec<RecipeHash> {
             content_blob: _,
             executable: _,
         } => referenced_recipes(resources),
-        Recipe::Directory(directory) => directory
-            .entry_hashes()
-            .values()
-            .map(|entry| entry.value)
-            .collect(),
+        Recipe::Directory(directory) => directory.entry_hashes().values().copied().collect(),
         Recipe::Symlink { .. } => vec![],
         Recipe::Download(_) => vec![],
         Recipe::Unarchive(unarchive) => referenced_recipes(&unarchive.file),
@@ -296,7 +292,7 @@ pub async fn descendent_artifact_blobs(
             Artifact::Symlink { .. } => {}
             Artifact::Directory(directory) => {
                 let entries = directory.entries(brioche).await?;
-                unvisited.extend(entries.into_values().map(|entry| entry.value));
+                unvisited.extend(entries.into_values());
             }
         }
     }

--- a/crates/brioche-core/tests/bake_process.rs
+++ b/crates/brioche-core/tests/bake_process.rs
@@ -42,16 +42,12 @@ async fn try_get(
     brioche: &brioche_core::Brioche,
     dir: &Directory,
     path: impl AsRef<[u8]>,
-) -> anyhow::Result<Option<WithMeta<Artifact>>> {
+) -> anyhow::Result<Option<Artifact>> {
     let artifact = dir.get(brioche, path.as_ref()).await?;
     Ok(artifact)
 }
 
-async fn get(
-    brioche: &brioche_core::Brioche,
-    dir: &Directory,
-    path: impl AsRef<[u8]>,
-) -> WithMeta<Artifact> {
+async fn get(brioche: &brioche_core::Brioche, dir: &Directory, path: impl AsRef<[u8]>) -> Artifact {
     let path = bstr::BStr::new(path.as_ref());
     try_get(brioche, dir, &path)
         .await
@@ -1041,7 +1037,7 @@ async fn test_bake_process_output_with_resources(
     };
 
     let program = get(brioche, &dir, "bin/program").await;
-    let Artifact::File(File { resources, .. }) = &program.value else {
+    let Artifact::File(File { resources, .. }) = &program else {
         panic!("expected file");
     };
 

--- a/crates/brioche-core/tests/directory.rs
+++ b/crates/brioche-core/tests/directory.rs
@@ -289,11 +289,7 @@ async fn test_directory_insert_new() -> anyhow::Result<()> {
         brioche_test_support::dir_value(&brioche, [("file1.txt", file1.clone())]).await;
 
     directory
-        .insert(
-            &brioche,
-            b"file2.txt",
-            Some(WithMeta::without_meta(file2.clone())),
-        )
+        .insert(&brioche, b"file2.txt", Some(file2.clone()))
         .await?;
 
     assert_eq!(
@@ -325,11 +321,7 @@ async fn test_directory_insert_replace() -> anyhow::Result<()> {
         brioche_test_support::dir_value(&brioche, [("file1.txt", file_old.clone())]).await;
 
     directory
-        .insert(
-            &brioche,
-            b"file1.txt",
-            Some(WithMeta::without_meta(file_new.clone())),
-        )
+        .insert(&brioche, b"file1.txt", Some(file_new.clone()))
         .await?;
 
     assert_eq!(
@@ -427,11 +419,7 @@ async fn test_directory_insert_new_nested() -> anyhow::Result<()> {
     .await;
 
     directory
-        .insert(
-            &brioche,
-            b"subdir/file2.txt",
-            Some(WithMeta::without_meta(file2.clone())),
-        )
+        .insert(&brioche, b"subdir/file2.txt", Some(file2.clone()))
         .await?;
 
     assert_eq!(
@@ -470,11 +458,7 @@ async fn test_directory_insert_new_dir() -> anyhow::Result<()> {
         brioche_test_support::dir_value(&brioche, [("file1.txt", file1.clone())]).await;
 
     directory
-        .insert(
-            &brioche,
-            b"subdir/file2.txt",
-            Some(WithMeta::without_meta(file2.clone())),
-        )
+        .insert(&brioche, b"subdir/file2.txt", Some(file2.clone()))
         .await?;
 
     assert_eq!(
@@ -526,11 +510,7 @@ async fn test_directory_insert_replace_nested() -> anyhow::Result<()> {
     .await;
 
     directory
-        .insert(
-            &brioche,
-            b"foo/bar",
-            Some(WithMeta::without_meta(file2.clone())),
-        )
+        .insert(&brioche, b"foo/bar", Some(file2.clone()))
         .await?;
 
     assert_eq!(

--- a/crates/brioche-test-support/src/lib.rs
+++ b/crates/brioche-test-support/src/lib.rs
@@ -196,7 +196,7 @@ pub async fn dir_value<K: AsRef<[u8]>>(
     let mut directory = Directory::default();
     for (k, v) in entries {
         directory
-            .insert(brioche, k.as_ref(), Some(WithMeta::without_meta(v)))
+            .insert(brioche, k.as_ref(), Some(v))
             .await
             .expect("failed to insert into dir");
     }


### PR DESCRIPTION
The `WithMeta` type is used to track the stack trace a recipe was created in TypeScript: since recipe evaluation is lazy, it can be really hard to track this down from just the recipes themselves. This metadata isn't used at all in Brioche today, but the eventual goal is to give better error messages (e.g. when a build fails, we could point to the line in TypeScript where the error occurred)

Turns out, this metadata wasn't properly being deserialized when going from TypeScript to Rust, so it always came back empty. This PR fixes that, and makes a few changes so the `WithMeta<_>` wrapper type is a bit simpler:

- Update `serde::Deserialize` impl on `WithMeta<_>` to try and deserialize the `meta` field (serialization still skips it). This also means the type that `WithMeta` wraps must now deserialize from an object
- Remove `WithMeta` for directory entries in the `Directory` type. Since these are string values (representing recipe hashes), this no longer worked with the deserialization changes to `WithMeta`