### PR TITLE
Fix `--sync` missing some recipes

### DIFF
--- a/crates/brioche-core/src/references.rs
+++ b/crates/brioche-core/src/references.rs
@@ -37,7 +37,8 @@ pub async fn recipe_references(
             break;
         }
 
-        let recipes = crate::recipe::get_recipes(brioche, unvisited.drain(..)).await?;
+        let mut recipes = HashMap::new();
+        crate::recipe::get_recipes(brioche, unvisited.drain(..), &mut recipes).await?;
 
         for recipe in recipes.values() {
             unvisited.extend(referenced_recipes(recipe));

--- a/crates/brioche-core/src/registry.rs
+++ b/crates/brioche-core/src/registry.rs
@@ -12,6 +12,7 @@ use crate::{
     blob::BlobHash,
     project::{Project, ProjectHash},
     recipe::{Artifact, Recipe, RecipeHash},
+    references::ReferencedRecipe,
     Brioche,
 };
 
@@ -502,7 +503,14 @@ pub async fn fetch_recipes_deep(
 
         for recipe in &new_recipes {
             let referenced_recipes = crate::references::referenced_recipes(recipe);
-            pending_recipes.extend(referenced_recipes);
+            let referenced_recipe_hashes =
+                referenced_recipes
+                    .into_iter()
+                    .filter_map(|reference| match reference {
+                        ReferencedRecipe::RecipeHash(hash) => Some(hash),
+                        ReferencedRecipe::Recipe(_) => None,
+                    });
+            pending_recipes.extend(referenced_recipe_hashes);
         }
 
         checked_recipes.extend(new_recipes.iter().map(|recipe| recipe.hash()));

--- a/crates/brioche-core/src/sync.rs
+++ b/crates/brioche-core/src/sync.rs
@@ -4,7 +4,7 @@ use human_repr::HumanDuration;
 
 use crate::{
     project::ProjectHash,
-    references::{ProjectReferences, RecipeReferences},
+    references::{ProjectReferences, RecipeReferences, ReferencedRecipe},
     Brioche,
 };
 
@@ -55,9 +55,12 @@ pub async fn sync_bakes(
 
     let mut sync_references = RecipeReferences::default();
 
-    let recipe_hashes = bakes
-        .iter()
-        .flat_map(|(input, output)| [input.hash(), output.hash()]);
+    let recipe_hashes = bakes.iter().flat_map(|(input, output)| {
+        [
+            ReferencedRecipe::Recipe(input.clone()),
+            ReferencedRecipe::Recipe(output.clone().into()),
+        ]
+    });
     crate::references::recipe_references(brioche, &mut sync_references, recipe_hashes).await?;
 
     let num_recipe_refs = sync_references.recipes.len();

--- a/crates/brioche-core/tests/recipe.rs
+++ b/crates/brioche-core/tests/recipe.rs
@@ -114,9 +114,13 @@ async fn test_recipe_save_multiple() -> anyhow::Result<()> {
         brioche_core::recipe::save_recipes(&brioche, [file_2.clone(), file_3.clone()]).await?;
     assert_eq!(new_artifacts, 1);
 
-    let results =
-        brioche_core::recipe::get_recipes(&brioche, [file_1.hash(), file_2.hash(), file_3.hash()])
-            .await?;
+    let mut results = HashMap::new();
+    brioche_core::recipe::get_recipes(
+        &brioche,
+        [file_1.hash(), file_2.hash(), file_3.hash()],
+        &mut results,
+    )
+    .await?;
 
     assert_eq!(
         results,

--- a/crates/brioche-core/tests/sync_to_registry.rs
+++ b/crates/brioche-core/tests/sync_to_registry.rs
@@ -22,8 +22,11 @@ async fn test_sync_to_registry_process_and_complete_process() -> anyhow::Result<
         Recipe::CompleteProcess(complete_process_recipe.clone()).hash();
 
     // Create a mocked output for the complete_process recipe
+    let output_resource_dir = brioche_test_support::empty_dir_value();
+    let output_resource_dir_hash = Recipe::Directory(output_resource_dir.clone()).hash();
     let dummy_blob = brioche_test_support::blob(&brioche, "dummy value").await;
-    let mocked_output = brioche_test_support::file(dummy_blob, false);
+    let mocked_output =
+        brioche_test_support::file_with_resources(dummy_blob, false, output_resource_dir);
     brioche_test_support::mock_bake(
         &brioche,
         &Recipe::CompleteProcess(complete_process_recipe.clone()),
@@ -84,6 +87,7 @@ async fn test_sync_to_registry_process_and_complete_process() -> anyhow::Result<
                 process_recipe_hash,
                 complete_process_recipe_hash,
                 mocked_output.hash(),
+                output_resource_dir_hash,
             ])?)
             .create(),
     );


### PR DESCRIPTION
This PR fixes an issue where calling `brioche build --sync` would end up missing some recipes while syncing. The result was that running e.g. `brioche install -r eza` would end up needing to build the Rust crate, even though the latest version had been built and synced from [`brioche-packages`](https://github.com/brioche-dev/brioche-packages)

This was caused by the function `brioche_core::references::recipe_references` missing recipes in some cases. ~~Basically, this function wouldn't return child recipes directly, but would skip straight to returning the grandchild recipe dependencies-- effectively skipping a layer of dependencies. If this skipped layer included "expensive" recipes, then that would lead to cases like those seen with `eza` where the user would end up baking the expensive recipes manually~~ **Update**: I spent quite a bit of time trying to write a unit test for this issue, but I wasn't able to reproduce it. So, I'm not exactly sure what exact conditions are needed to cause the issue (but I was able to reliably trigger it with the current version of [the `eza` package](https://github.com/brioche-dev/brioche-packages/tree/77e0da6af50ace3dea6ea9eab494ffadd1344aad/packages/eza))

This new change makes recipe syncing slightly slower (~1.5s to ~3s for `eza` when testing locally), but this new implementation should be more correct

Internally, this change makes it so recipes can either be referenced by hash or referenced directly, which helps when trying to fetch referenced recipes from the database (i.e. no need to fetch a recipe if it's just nested within another recipe)