### PR TITLE
Revert "Fix `--sync` missing some recipes"

### DIFF
--- a/crates/brioche-core/src/registry.rs
+++ b/crates/brioche-core/src/registry.rs
@@ -12,7 +12,6 @@ use crate::{
     blob::BlobHash,
     project::{Project, ProjectHash},
     recipe::{Artifact, Recipe, RecipeHash},
-    references::ReferencedRecipe,
     Brioche,
 };
 
@@ -503,14 +502,7 @@ pub async fn fetch_recipes_deep(
 
         for recipe in &new_recipes {
             let referenced_recipes = crate::references::referenced_recipes(recipe);
-            let referenced_recipe_hashes =
-                referenced_recipes
-                    .into_iter()
-                    .filter_map(|reference| match reference {
-                        ReferencedRecipe::RecipeHash(hash) => Some(hash),
-                        ReferencedRecipe::Recipe(_) => None,
-                    });
-            pending_recipes.extend(referenced_recipe_hashes);
+            pending_recipes.extend(referenced_recipes);
         }
 
         checked_recipes.extend(new_recipes.iter().map(|recipe| recipe.hash()));

--- a/crates/brioche-core/src/sync.rs
+++ b/crates/brioche-core/src/sync.rs
@@ -4,7 +4,7 @@ use human_repr::HumanDuration;
 
 use crate::{
     project::ProjectHash,
-    references::{ProjectReferences, RecipeReferences, ReferencedRecipe},
+    references::{ProjectReferences, RecipeReferences},
     Brioche,
 };
 
@@ -55,12 +55,9 @@ pub async fn sync_bakes(
 
     let mut sync_references = RecipeReferences::default();
 
-    let recipe_hashes = bakes.iter().flat_map(|(input, output)| {
-        [
-            ReferencedRecipe::Recipe(input.clone()),
-            ReferencedRecipe::Recipe(output.clone().into()),
-        ]
-    });
+    let recipe_hashes = bakes
+        .iter()
+        .flat_map(|(input, output)| [input.hash(), output.hash()]);
     crate::references::recipe_references(brioche, &mut sync_references, recipe_hashes).await?;
 
     let num_recipe_refs = sync_references.recipes.len();

--- a/crates/brioche-core/tests/recipe.rs
+++ b/crates/brioche-core/tests/recipe.rs
@@ -114,13 +114,9 @@ async fn test_recipe_save_multiple() -> anyhow::Result<()> {
         brioche_core::recipe::save_recipes(&brioche, [file_2.clone(), file_3.clone()]).await?;
     assert_eq!(new_artifacts, 1);
 
-    let mut results = HashMap::new();
-    brioche_core::recipe::get_recipes(
-        &brioche,
-        [file_1.hash(), file_2.hash(), file_3.hash()],
-        &mut results,
-    )
-    .await?;
+    let results =
+        brioche_core::recipe::get_recipes(&brioche, [file_1.hash(), file_2.hash(), file_3.hash()])
+            .await?;
 
     assert_eq!(
         results,

--- a/crates/brioche-core/tests/sync_to_registry.rs
+++ b/crates/brioche-core/tests/sync_to_registry.rs
@@ -22,11 +22,8 @@ async fn test_sync_to_registry_process_and_complete_process() -> anyhow::Result<
         Recipe::CompleteProcess(complete_process_recipe.clone()).hash();
 
     // Create a mocked output for the complete_process recipe
-    let output_resource_dir = brioche_test_support::empty_dir_value();
-    let output_resource_dir_hash = Recipe::Directory(output_resource_dir.clone()).hash();
     let dummy_blob = brioche_test_support::blob(&brioche, "dummy value").await;
-    let mocked_output =
-        brioche_test_support::file_with_resources(dummy_blob, false, output_resource_dir);
+    let mocked_output = brioche_test_support::file(dummy_blob, false);
     brioche_test_support::mock_bake(
         &brioche,
         &Recipe::CompleteProcess(complete_process_recipe.clone()),
@@ -87,7 +84,6 @@ async fn test_sync_to_registry_process_and_complete_process() -> anyhow::Result<
                 process_recipe_hash,
                 complete_process_recipe_hash,
                 mocked_output.hash(),
-                output_resource_dir_hash,
             ])?)
             .create(),
     );


### PR DESCRIPTION
Reverts brioche-dev/brioche#122

Okay, it finally hit me what was happening...

So the way it was previously implemented `--sync` would find all top-level recipes for a build, then would sync them plus any recipes that they referenced _by hash_. #122 changed it so it would find _all_ internal recipes, either by hash or nested directly. The PR changed it so these internal recipes would be synced too

I think it would be a valid decision to sync these internal recipes, but for the purposes of `--sync`, I think it's the wrong choice. Namely, it just pollutes the registry with some recipes that should never get directly downloaded (clients only download the recipes referenced by hash, they would never have a need to download a recipe embedded directly)

As for the issue with `eza`, I finally realized that it was just because some of the bakes I had locally were non canonical (meaning that what was stored in my local DB was different than the registry), which meant that later recipes diverged enough that I got a cache miss.

Basically, all that is to say is that everything was already working as expected prior to #112, although the end result was unintuitive. Upon reflection, I felt that the earlier behavior was more in line with how syncing should work