### PR TITLE
Update `Process.dependencies` to allow more flexibility when setting envs

### DIFF
--- a/crates/brioche-core/src/bake/process.rs
+++ b/crates/brioche-core/src/bake/process.rs
@@ -822,6 +822,52 @@ async fn build_process_template(
     Ok(result)
 }
 
+enum DependencyEnvVarChange {
+    AppendPath {
+        artifact: WithMeta<Artifact>,
+        subpath: bstr::BString,
+    },
+    FallbackPath {
+        artifact: WithMeta<Artifact>,
+        subpath: bstr::BString,
+    },
+    FallbackValue {
+        value: bstr::BString,
+    },
+}
+
+impl DependencyEnvVarChange {
+    fn build_components(&self) -> Vec<CompleteProcessTemplateComponent> {
+        match self {
+            DependencyEnvVarChange::AppendPath { artifact, subpath }
+            | DependencyEnvVarChange::FallbackPath { artifact, subpath } => {
+                let mut subpath = subpath.clone();
+
+                // Build template components representing either `${artifact}` or
+                // `${artifact}/${subpath}`
+                if subpath.is_empty() {
+                    vec![CompleteProcessTemplateComponent::Input {
+                        artifact: artifact.clone(),
+                    }]
+                } else {
+                    subpath.insert(0, b'/');
+                    vec![
+                        CompleteProcessTemplateComponent::Input {
+                            artifact: artifact.clone(),
+                        },
+                        CompleteProcessTemplateComponent::Literal { value: subpath },
+                    ]
+                }
+            }
+            DependencyEnvVarChange::FallbackValue { value } => {
+                vec![CompleteProcessTemplateComponent::Literal {
+                    value: value.clone(),
+                }]
+            }
+        }
+    }
+}
+
 async fn append_dependency_envs(
     brioche: &Brioche,
     env: &mut BTreeMap<bstr::BString, CompleteProcessTemplate>,
@@ -830,7 +876,7 @@ async fn append_dependency_envs(
     // Tuples of env var values to add, where each artifact subpath will
     // be added to the env var separated by `:`
     // (env_var_name, artifact, artifact_subpath)
-    let mut env_var_appends: Vec<(bstr::BString, WithMeta<Artifact>, bstr::BString)> = vec![];
+    let mut env_var_changes: Vec<(bstr::BString, DependencyEnvVarChange)> = vec![];
 
     for dependency_artifact in dependencies {
         // Validate that the dependency is a directory
@@ -845,49 +891,93 @@ async fn append_dependency_envs(
             _ => None,
         });
         if let Some(env_dir) = env_dir {
-            // Each entry in the directory should be a directory whose
-            // name is treated as an env var
+            // Each entry in the directory will get treated as an env var,
+            // depending if it's a file, directory, or symlink
             let env_dir_entries = env_dir.entries(brioche).await?;
 
             for (env_var, env_dir_entry) in env_dir_entries {
-                // Validate the entry is a directory
-                let Artifact::Directory(env_dir_entry) = env_dir_entry else {
-                    anyhow::bail!("expected `brioche-env.d/env/{env_var}` to be a directory");
-                };
-                let env_value_entries = env_dir_entry.entries(brioche).await?;
+                match env_dir_entry {
+                    Artifact::Directory(env_dir_entry) => {
+                        let env_value_entries = env_dir_entry.entries(brioche).await?;
 
-                // Each entry within the env var directory should be a symlink
-                // pointing to a path to append to the env var
-                for (env_value_entry_name, env_value_entry) in env_value_entries {
-                    // Validate it's a symlink
-                    let Artifact::Symlink {
+                        // Each entry within the env var directory should be a symlink
+                        // pointing to a path to append to the env var
+                        for (env_value_entry_name, env_value_entry) in env_value_entries {
+                            // Validate it's a symlink
+                            let Artifact::Symlink {
+                                target: env_value_target,
+                            } = env_value_entry
+                            else {
+                                anyhow::bail!("expected `brioche-env.d/env/{env_var}/{env_value_entry_name}` to be a symlink");
+                            };
+
+                            // Get the path of the symlink relative to the
+                            // root of the dependency artifact
+                            let dependency_subpath = bstr::join(
+                                "/",
+                                [
+                                    "brioche-env.d".as_bytes(),
+                                    "env".as_bytes(),
+                                    &**env_var,
+                                    &*env_value_target,
+                                ]
+                                .into_iter(),
+                            );
+                            let dependency_subpath =
+                                crate::fs_utils::logical_path_bytes(&dependency_subpath)?;
+
+                            // Append the env var
+                            env_var_changes.push((
+                                env_var.clone(),
+                                DependencyEnvVarChange::AppendPath {
+                                    artifact: dependency_artifact.clone(),
+                                    subpath: dependency_subpath.into(),
+                                },
+                            ));
+                        }
+                    }
+                    Artifact::File(env_dir_file) => {
+                        // Read the file to get the env var value
+                        let permit = crate::blob::get_save_blob_permit().await?;
+                        let env_dir_blob_path =
+                            crate::blob::blob_path(brioche, permit, env_dir_file.content_blob)
+                                .await?;
+                        let env_value = tokio::fs::read(env_dir_blob_path).await?;
+
+                        // Add the env var
+                        env_var_changes.push((
+                            env_var.clone(),
+                            DependencyEnvVarChange::FallbackValue {
+                                value: env_value.into(),
+                            },
+                        ));
+                    }
+                    Artifact::Symlink {
                         target: env_value_target,
-                    } = env_value_entry
-                    else {
-                        anyhow::bail!("expected `brioche-env.d/env/{env_var}/{env_value_entry_name}` to be a symlink");
-                    };
+                    } => {
+                        // Get the path of the symlink relative to the
+                        // root of the dependency artifact
+                        let dependency_subpath = bstr::join(
+                            "/",
+                            [
+                                "brioche-env.d".as_bytes(),
+                                "env".as_bytes(),
+                                &*env_value_target,
+                            ]
+                            .into_iter(),
+                        );
+                        let dependency_subpath =
+                            crate::fs_utils::logical_path_bytes(&dependency_subpath)?;
 
-                    // Get the path of the symlink relative to the
-                    // root of the dependency artifact
-                    let dependency_subpath = bstr::join(
-                        "/",
-                        [
-                            "brioche-env.d".as_bytes(),
-                            "env".as_bytes(),
-                            &**env_var,
-                            &*env_value_target,
-                        ]
-                        .into_iter(),
-                    );
-                    let dependency_subpath =
-                        crate::fs_utils::logical_path_bytes(&dependency_subpath)?;
-
-                    // Append the env var
-                    env_var_appends.push((
-                        env_var.clone(),
-                        dependency_artifact.clone(),
-                        bstr::BString::new(dependency_subpath),
-                    ));
+                        // Add the env var
+                        env_var_changes.push((
+                            env_var.clone(),
+                            DependencyEnvVarChange::FallbackPath {
+                                artifact: dependency_artifact.clone(),
+                                subpath: dependency_subpath.into(),
+                            },
+                        ));
+                    }
                 }
             }
         }
@@ -896,39 +986,44 @@ async fn append_dependency_envs(
         // automatically
         let bin_artifact = dependency.get(brioche, b"bin").await?;
         if matches!(bin_artifact, Some(Artifact::Directory { .. })) {
-            env_var_appends.push(("PATH".into(), dependency_artifact.clone(), "bin".into()));
+            env_var_changes.push((
+                "PATH".into(),
+                DependencyEnvVarChange::AppendPath {
+                    artifact: dependency_artifact.clone(),
+                    subpath: "bin".into(),
+                },
+            ));
         }
     }
 
     // Append to the env vars
-    for (env_var, artifact, mut subpath) in env_var_appends {
-        // Build template components representing either `${artifact}` or
-        // `${artifact}/${subpath}`
-        let append_components = if subpath.is_empty() {
-            vec![CompleteProcessTemplateComponent::Input { artifact }]
-        } else {
-            subpath.insert(0, b'/');
-            vec![
-                CompleteProcessTemplateComponent::Input { artifact },
-                CompleteProcessTemplateComponent::Literal { value: subpath },
-            ]
-        };
-
+    for (env_var, change) in env_var_changes {
         // Get the current env var value
         let current_value = env
             .entry(env_var.clone())
             .or_insert_with(|| CompleteProcessTemplate { components: vec![] });
 
-        // If the current value is empty or unset, set it to the new value.
-        // Otherwise, add a `:` and append the new value
-        if current_value.is_empty() {
-            *current_value = CompleteProcessTemplate {
-                components: append_components,
-            };
-        } else {
-            current_value.append_literal(":");
-            current_value.components.extend(append_components);
-        };
+        let components = change.build_components();
+
+        match change {
+            DependencyEnvVarChange::AppendPath { .. } => {
+                // If the current value is empty or unset, set it to the new value.
+                // Otherwise, add a `:` and append the new value
+                if current_value.is_empty() {
+                    *current_value = CompleteProcessTemplate { components };
+                } else {
+                    current_value.append_literal(":");
+                    current_value.components.extend(components);
+                };
+            }
+            DependencyEnvVarChange::FallbackPath { .. }
+            | DependencyEnvVarChange::FallbackValue { .. } => {
+                // Only set the fallback value if the current value is unset
+                if current_value.is_empty() {
+                    *current_value = CompleteProcessTemplate { components };
+                }
+            }
+        }
     }
 
     Ok(())

--- a/crates/brioche-core/src/bake/process.rs
+++ b/crates/brioche-core/src/bake/process.rs
@@ -938,9 +938,9 @@ async fn append_dependency_envs(
                     }
                     Artifact::File(env_dir_file) => {
                         // Read the file to get the env var value
-                        let permit = crate::blob::get_save_blob_permit().await?;
+                        let mut permit = crate::blob::get_save_blob_permit().await?;
                         let env_dir_blob_path =
-                            crate::blob::blob_path(brioche, permit, env_dir_file.content_blob)
+                            crate::blob::blob_path(brioche, &mut permit, env_dir_file.content_blob)
                                 .await?;
                         let env_value = tokio::fs::read(env_dir_blob_path).await?;
 

--- a/crates/brioche-core/src/bake/unarchive.rs
+++ b/crates/brioche-core/src/bake/unarchive.rs
@@ -31,8 +31,8 @@ pub async fn bake_unarchive(
     let job_id = brioche.reporter.add_job(crate::reporter::NewJob::Unarchive);
 
     let archive_path = {
-        let permit = crate::blob::get_save_blob_permit().await?;
-        crate::blob::blob_path(brioche, permit, blob_hash).await?
+        let mut permit = crate::blob::get_save_blob_permit().await?;
+        crate::blob::blob_path(brioche, &mut permit, blob_hash).await?
     };
     let archive_file = tokio::fs::File::open(&archive_path).await?;
     let uncompressed_archive_size = archive_file.metadata().await?.len();

--- a/crates/brioche-core/src/blob.rs
+++ b/crates/brioche-core/src/blob.rs
@@ -452,7 +452,7 @@ pub async fn find_blob(brioche: &Brioche, hash: &Hash) -> anyhow::Result<Option<
 
 pub async fn blob_path(
     brioche: &Brioche,
-    _permit: SaveBlobPermit<'_>,
+    _permit: &mut SaveBlobPermit<'_>,
     blob_hash: BlobHash,
 ) -> anyhow::Result<PathBuf> {
     let local_path = local_blob_path(brioche, blob_hash);

--- a/crates/brioche-core/src/registry.rs
+++ b/crates/brioche-core/src/registry.rs
@@ -370,8 +370,9 @@ pub async fn fetch_bake_references(
         .try_for_each_concurrent(25, |blob| {
             let brioche = brioche.clone();
             async move {
-                let permit = crate::blob::get_save_blob_permit().await?;
-                super::blob::blob_path(&brioche, permit, blob).await?;
+                let mut permit = crate::blob::get_save_blob_permit().await?;
+                super::blob::blob_path(&brioche, &mut permit, blob).await?;
+                drop(permit);
 
                 brioche.reporter.update_job(
                     job_id,
@@ -564,8 +565,9 @@ pub async fn fetch_blobs(brioche: Brioche, blobs: &HashSet<BlobHash>) -> anyhow:
         .try_for_each_concurrent(25, |blob| {
             let brioche = brioche.clone();
             async move {
-                let permit = crate::blob::get_save_blob_permit().await?;
-                super::blob::blob_path(&brioche, permit, blob).await?;
+                let mut permit = crate::blob::get_save_blob_permit().await?;
+                super::blob::blob_path(&brioche, &mut permit, blob).await?;
+                drop(permit);
 
                 brioche.reporter.update_job(
                     job_id,

--- a/crates/brioche-core/src/script/bridge.rs
+++ b/crates/brioche-core/src/script/bridge.rs
@@ -189,7 +189,7 @@ impl RuntimeBridge {
                             result_tx,
                         } => {
                             let permit = crate::blob::get_save_blob_permit().await;
-                            let permit = match permit {
+                            let mut permit = match permit {
                                 Ok(permit) => permit,
                                 Err(error) => {
                                     let _ = result_tx.send(Err(error));
@@ -197,7 +197,8 @@ impl RuntimeBridge {
                                 }
                             };
 
-                            let path = crate::blob::blob_path(&brioche, permit, blob_hash).await;
+                            let path =
+                                crate::blob::blob_path(&brioche, &mut permit, blob_hash).await;
                             let path = match path {
                                 Ok(path) => path,
                                 Err(error) => {
@@ -205,6 +206,8 @@ impl RuntimeBridge {
                                     return;
                                 }
                             };
+
+                            drop(permit);
 
                             let result = tokio::fs::read(path)
                                 .await

--- a/crates/brioche-core/src/sync.rs
+++ b/crates/brioche-core/src/sync.rs
@@ -156,8 +156,8 @@ pub async fn sync_recipe_references(
             async move {
                 tokio::spawn(async move {
                     let blob_path = {
-                        let permit = crate::blob::get_save_blob_permit().await?;
-                        crate::blob::blob_path(&brioche, permit, blob_hash).await?
+                        let mut permit = crate::blob::get_save_blob_permit().await?;
+                        crate::blob::blob_path(&brioche, &mut permit, blob_hash).await?
                     };
 
                     // TODO: Figure out if we can stream the blob (this

--- a/crates/brioche-core/tests/bake_process.rs
+++ b/crates/brioche-core/tests/bake_process.rs
@@ -1282,6 +1282,30 @@ async fn test_bake_process_dependencies(
                                     )
                                     .await,
                                 ),
+                                ("DEP1_SYMLINK", brioche_test_support::symlink(b"../../a")),
+                                (
+                                    "DEP1_FILE",
+                                    brioche_test_support::file(
+                                        brioche_test_support::blob(brioche, b"dep1_file").await,
+                                        false,
+                                    ),
+                                ),
+                                (
+                                    "FALLBACK_1",
+                                    brioche_test_support::file(
+                                        brioche_test_support::blob(brioche, b"dep1_fallback1")
+                                            .await,
+                                        false,
+                                    ),
+                                ),
+                                (
+                                    "FALLBACK_2",
+                                    brioche_test_support::file(
+                                        brioche_test_support::blob(brioche, b"dep1_fallback2")
+                                            .await,
+                                        false,
+                                    ),
+                                ),
                             ],
                         )
                         .await,
@@ -1327,6 +1351,46 @@ async fn test_bake_process_dependencies(
                                     )
                                     .await,
                                 ),
+                                ("DEP2_SYMLINK", brioche_test_support::symlink(b"../../d")),
+                                (
+                                    "DEP2_FILE",
+                                    brioche_test_support::file(
+                                        brioche_test_support::blob(brioche, b"dep2_file").await,
+                                        false,
+                                    ),
+                                ),
+                                (
+                                    "FALLBACK_1",
+                                    brioche_test_support::file(
+                                        brioche_test_support::blob(brioche, b"dep2_fallback1")
+                                            .await,
+                                        false,
+                                    ),
+                                ),
+                                (
+                                    "FALLBACK_2",
+                                    brioche_test_support::file(
+                                        brioche_test_support::blob(brioche, b"dep2_fallback2")
+                                            .await,
+                                        false,
+                                    ),
+                                ),
+                                (
+                                    "FALLBACK_3",
+                                    brioche_test_support::file(
+                                        brioche_test_support::blob(brioche, b"dep2_fallback3")
+                                            .await,
+                                        false,
+                                    ),
+                                ),
+                                (
+                                    "FALLBACK_4",
+                                    brioche_test_support::file(
+                                        brioche_test_support::blob(brioche, b"dep2_fallback4")
+                                            .await,
+                                        false,
+                                    ),
+                                ),
                             ],
                         )
                         .await,
@@ -1349,6 +1413,14 @@ async fn test_bake_process_dependencies(
                 test "$PATH" = "$EXPECTED_PATH"
                 test "$DEP1" = "$EXPECTED_DEP1"
                 test "$DEP2" = "$EXPECTED_DEP2"
+                test "$DEP1_SYMLINK" = "$EXPECTED_DEP1_SYMLINK"
+                test "$DEP1_FILE" = "$EXPECTED_DEP1_FILE"
+                test "$DEP2_SYMLINK" = "$EXPECTED_DEP2_SYMLINK"
+                test "$DEP2_FILE" = "$EXPECTED_DEP2_FILE"
+                test "$FALLBACK_1" = "$EXPECTED_FALLBACK_1"
+                test "$FALLBACK_2" = "$EXPECTED_FALLBACK_2"
+                test "$FALLBACK_3" = "$EXPECTED_FALLBACK_3"
+                test "$FALLBACK_4" = "$EXPECTED_FALLBACK_4"
 
                 touch "$BRIOCHE_OUTPUT"
             "#),
@@ -1360,6 +1432,7 @@ async fn test_bake_process_dependencies(
                 tpl_join([template_input(utils()), tpl("/bin")]),
             ),
             ("DEP1".into(), tpl("hello")),
+            ("FALLBACK_4".into(), tpl("process_fallback4")),
             (
                 "EXPECTED_PATH".into(),
                 tpl_join([
@@ -1388,9 +1461,23 @@ async fn test_bake_process_dependencies(
                 ]),
             ),
             (
+                "EXPECTED_DEP1_SYMLINK".into(),
+                tpl_join([template_input(dep1.clone().into()), tpl("/a")]),
+            ),
+            ("EXPECTED_DEP1_FILE".into(), tpl("dep1_file")),
+            (
                 "EXPECTED_DEP2".into(),
                 tpl_join([template_input(dep2.clone().into()), tpl("/f")]),
             ),
+            (
+                "EXPECTED_DEP2_SYMLINK".into(),
+                tpl_join([template_input(dep2.clone().into()), tpl("/d")]),
+            ),
+            ("EXPECTED_DEP2_FILE".into(), tpl("dep2_file")),
+            ("EXPECTED_FALLBACK_1".into(), tpl("dep1_fallback1")),
+            ("EXPECTED_FALLBACK_2".into(), tpl("dep1_fallback2")),
+            ("EXPECTED_FALLBACK_3".into(), tpl("dep2_fallback3")),
+            ("EXPECTED_FALLBACK_4".into(), tpl("process_fallback4")),
         ]),
         dependencies: vec![
             WithMeta::without_meta(dep1.clone().into()),


### PR DESCRIPTION
This PR updates how the `dependencies` field is use when a `process` recipe is baked. Each dependency recipe can contain a `brioche-env.d/env` directory to set env vars on the process, but previously this was limited to appending `$PATH`-like env vars: each entry in `brioche-env.d/env` had to be a directory (whose name was an env var), where each entry within was a symlink, whose target would be appended to the env var (separated by `:`).

This PR lifts the restriction, and now each env var within `brioche-env.d/env` can either be a file, directory, or symlink:

- **Directory**: Same behavior as before. Each entry within the directory must be a symlink whose target is appended to the env var (the name of the symlink doesn't matter)
- **Symlink**: If the env var is empty, then it will be set to the target of the symlink. This is only used as a fallback, so this will be skipped if the env var is already set
- **File**: If the env var is empty, then it will be set to the file's contents. This is only used as a fallback, so this will be skipped if the env var is already set

So, this is now a valid structure for a dependency:

```
- bin/
  - cc
- brioche-env.d/
  - env/
    - PATH/
      - path1 -> ../../../bin
    - CC -> ../../bin/cc
    - DEBUG [file containing the string "1"]
```

When used as a dependency, it will append `bin` to `$PATH`, set `$CC` to the path to `bin/cc` (if unset), and set `$DEBUG` to `1` (if unset)