### PR TITLE
Tweak symlinks in `create_input`

### DIFF
--- a/crates/brioche-core/src/fs_utils.rs
+++ b/crates/brioche-core/src/fs_utils.rs
@@ -5,10 +5,14 @@ use bstr::ByteSlice as _;
 use relative_path::RelativePath;
 
 pub fn logical_path(path: &Path) -> PathBuf {
+    let mut root_components = vec![];
     let mut components = vec![];
     for component in path.components() {
         match component {
-            Component::Prefix(_) | Component::RootDir | Component::Normal(_) => {
+            Component::Prefix(_) | Component::RootDir => {
+                root_components.push(component);
+            }
+            Component::Normal(_) => {
                 components.push(component);
             }
             Component::CurDir => {}
@@ -18,7 +22,7 @@ pub fn logical_path(path: &Path) -> PathBuf {
         }
     }
 
-    PathBuf::from_iter(components)
+    PathBuf::from_iter(root_components.into_iter().chain(components))
 }
 
 pub fn logical_path_bytes(path: &[u8]) -> anyhow::Result<Vec<u8>> {

--- a/crates/brioche-core/src/input.rs
+++ b/crates/brioche-core/src/input.rs
@@ -525,14 +525,9 @@ fn add_input_plan_indirect_resources(plan: &mut CreateInputPlan) -> anyhow::Resu
         })
         .collect();
 
-    let mut visited_resources = HashSet::new();
     let mut indirect_resources = vec![];
 
     while let Some((node, resource_path, resource_node)) = resource_paths.pop() {
-        if !visited_resources.insert(resource_path.clone()) {
-            continue;
-        }
-
         for subresource_edge in plan.graph.edges(resource_node) {
             match subresource_edge.weight() {
                 CreateInputPlanEdge::DirectoryEntry { file_name } => {

--- a/crates/brioche-core/src/input.rs
+++ b/crates/brioche-core/src/input.rs
@@ -350,9 +350,13 @@ fn add_input_plan_nodes(
 
         node_index
     } else if metadata.is_symlink() {
-        let target =
+        let input_parent_path = options
+            .input_path
+            .parent()
+            .context("failed to get symlink parent directory")?;
+        let target_path =
             std::fs::read_link(options.input_path).context("failed to read symlink target")?;
-        let target = <Vec<u8>>::from_path_buf(target).map_err(|_| {
+        let target = <Vec<u8>>::from_path_buf(target_path.clone()).map_err(|_| {
             anyhow::anyhow!("invalid symlink target at {}", options.input_path.display())
         })?;
         let target = bstr::BString::from(target);
@@ -376,23 +380,72 @@ fn add_input_plan_nodes(
             .collect::<Result<Vec<_>, _>>()
             .context("failed to canonicalize resource dirs")?;
 
-        // Ensure the symlink target exists and is within a resource directory
-        let canonical_path = std::fs::canonicalize(options.input_path)
-            .inspect_err(|err| {
-                tracing::debug!(input_path = %options.input_path.display(), %target, error = %err, "ignoring broken symlink for input");
-            })
-            .ok()
-            .filter(|canonical_path| {
-                canonical_resource_dirs.iter().any(|canonical_resource_dir| {
-                    canonical_path.starts_with(canonical_resource_dir)
-                })
-            });
+        // Logically resolve the symlink target path
+        let resolved_path = input_parent_path.join(&target_path);
+        let resolved_path = crate::fs_utils::logical_path(&resolved_path);
 
-        // Add an edge to the symlink target if the symlink is valid
-        if let Some(canonical_path) = canonical_path {
+        // If the resolved path is within a resource directory, get the
+        // resource dir and the subpath
+        let resource_dir_with_subpath = resolved_path.ancestors().find_map(|ancestor| {
+            let subpath = resolved_path.strip_prefix(ancestor).ok()?;
+            let canonical_ancestor = std::fs::canonicalize(ancestor).ok()?;
+
+            let ancestor_is_resource_dir = canonical_resource_dirs
+                .iter()
+                .any(|canonical_resource_dir| canonical_ancestor == *canonical_resource_dir);
+
+            if ancestor_is_resource_dir {
+                Some((canonical_ancestor, subpath))
+            } else {
+                None
+            }
+        });
+
+        // If the resolved path is in a resource directory, get the
+        // metadata of the target
+        let target_info = resource_dir_with_subpath.and_then(|(resource_dir, subpath)| {
+            let target_metadata = std::fs::symlink_metadata(&resolved_path)
+                .inspect_err(|error| {
+                    tracing::debug!(
+                        input_path = %options.input_path.display(),
+                        resolved_path = %resolved_path.display(),
+                        %error,
+                        "symlink points into resource directory but the target could not be read, symlink may be broken"
+                    );
+                })
+                .ok()?;
+            Some((resource_dir, subpath, target_metadata))
+        });
+
+        // If the symlink's target could be resolved within a resource
+        // directory and if we could read the target's metadata, then we
+        // add a node for the target and add an edge to it. This should
+        // apply to most resource symlinks, but other symlinks may be broken
+        // or e.g. could intentionally point to an absolute path
+        if let Some((resource_dir, subpath, target_metadata)) = target_info {
+            // TODO: Handle nested symlinks
+            anyhow::ensure!(
+                !target_metadata.is_symlink(),
+                "target of symlink {} is another symlink, which is not supported",
+                options.input_path.display(),
+            );
+
+            for ancestor in subpath.ancestors().skip(1) {
+                let ancestor_path = resource_dir.join(ancestor);
+                let ancestor_metadata = std::fs::symlink_metadata(&ancestor_path)
+                    .context("failed to get ancestor metadata")?;
+
+                // TODO: Handle traversing through directory symlinks
+                anyhow::ensure!(
+                    !ancestor_metadata.is_symlink(),
+                    "symlink {} traverses through a symlink path, which is not supported",
+                    options.input_path.display(),
+                );
+            }
+
             let target_node = add_input_plan_nodes(
                 InputOptions {
-                    input_path: &canonical_path,
+                    input_path: &resolved_path,
                     remove_input: false,
                     resource_dir: options.resource_dir,
                     input_resource_dirs: options.input_resource_dirs,
@@ -516,8 +569,12 @@ fn add_input_plan_indirect_resources(plan: &mut CreateInputPlan) -> anyhow::Resu
                     indirect_resources.push((
                         node,
                         target_node,
-                        CreateInputPlanEdge::IndirectResource { path: target_path },
+                        CreateInputPlanEdge::IndirectResource {
+                            path: target_path.clone(),
+                        },
                     ));
+
+                    resource_paths.push((node, target_path, target_node));
                 }
             }
         }


### PR DESCRIPTION
This PR fixes some issues around symlink handling in the `create_input` function. I found this after finding a bug introduced by #115, but also found some other issues too.

First, when calling `create_input` on a directory, if two files refer to the same resource path and that path is a symlink, then that resource would only get added to one of the files. This was due to some unsound memoization, which has now been removed.

Second, the way that symlink resources were canonicalized meant that, in some situations, `create_input` could end up creating a directory structure that didn't match the input. I worked out two such cases:

1. When a symlink's target points to another symlink (`link1 -> link2`, `link2 -> target`)
2. When a symlink's target has another symlink as a path component (`link1 -> link2/file`, `link2 -> dir`)

For now, I made the call to just return an error if either of these two situations occur. I don't believe either case was used in practice (although, if it was, hopefully `brioche-packages` will make that pretty clear). I believe a proper implementation to support both cases would be very complicated and error-prone, so just throwing an error now will make it possible to revisit in the future