### PR TITLE
Update unarchive to use `tar` crate instead of `tokio_tar`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -883,11 +883,11 @@ dependencies = [
  "sqlx",
  "strum 0.26.3",
  "superconsole",
+ "tar",
  "termwiz 0.22.0",
  "thiserror",
  "tick-encoding",
  "tokio",
- "tokio-tar",
  "tokio-util",
  "toml",
  "tower-lsp",
@@ -4656,15 +4656,6 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_syscall"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
@@ -6286,6 +6277,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "tar"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ff6c40d3aedb5e06b57c6f669ad17ab063dd1e63d977c6a88e7f4dfa4f04020"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "tempdir"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6591,21 +6593,6 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
-]
-
-[[package]]
-name = "tokio-tar"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d5714c010ca3e5c27114c1cdeb9d14641ace49874aa5626d7149e47aedace75"
-dependencies = [
- "filetime",
- "futures-core",
- "libc",
- "redox_syscall 0.3.5",
- "tokio",
- "tokio-stream",
- "xattr",
 ]
 
 [[package]]
@@ -7599,9 +7586,9 @@ dependencies = [
 
 [[package]]
 name = "xattr"
-version = "1.1.3"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7dae5072fe1f8db8f8d29059189ac175196e410e40ba42d5d4684ae2f750995"
+checksum = "8da84f1a25939b27f6820d92aed108f83ff920fdf11a7b19366c27c4cda81d4f"
 dependencies = [
  "libc",
  "linux-raw-sys",

--- a/crates/brioche-core/Cargo.toml
+++ b/crates/brioche-core/Cargo.toml
@@ -52,7 +52,6 @@ termwiz = "0.22.0"
 thiserror = "1.0.51"
 tick-encoding = "0.1.2"
 tokio = { version = "1.35.0", features = ["full", "tracing"] }
-tokio-tar = "0.3.1"
 tokio-util = { version = "0.7.10", features = ["compat", "full"] }
 toml = "0.8.8"
 tower-lsp = "0.20.0"
@@ -66,6 +65,7 @@ walkdir = "2.5.0"
 petgraph = "0.6.5"
 wax = { version = "0.6.0", default-features = false }
 gix = { version = "0.66.0", features = ["blocking-network-client", "blocking-http-transport-reqwest"] }
+tar = "0.4.42"
 
 [dev-dependencies]
 assert_matches = "1.5.0"


### PR DESCRIPTION
Closes #103

This PR updates the `unarchive` recipe to use the [`tar`](https://crates.io/crates/tar) crate (actively maintained, but sync-only) instead of the [`tokio-tar`](https://crates.io/crates/tokio-tar) crate (async, but apparently unmaintained). This was specifically done to address the bug seen in #103, where tarfiles with long names weren't getting handled properly

I referenced #117 as inspiration, but ended up with a few different decisions in the implementation. Namely, the sync work happens in a `spawn_blocking` Tokio task, and uses a channel for the async parts (actually building the artifacts, which boil down to database writes). I also used [`tokio_util::io::SyncIoBridge`](https://docs.rs/tokio-util/0.7.12/tokio_util/io/struct.SyncIoBridge.html) so that we could keep doing async decompression (which I believe is sound and won't block the executor). This also has the advantage of not needing to buffer the tarfile into memory

One disadvantage with this implementation is that the blob creation is all synchronous (there's a new `save_blob_from_reader_sync` function for this purpose). And, since there's no way to block to acquire a semaphore, we have to acquire a semaphore on the permit outside the `spawn_blocking` section, meaning we have to keep a semaphore permit for the entire duration that the archive is unpacked. I couldn't figure out a good way around this without either buffering stuff in memory or having a separate lock specifically for synchronous code