### PR TITLE
Fix race condition when trying to fetch the same project from the registry more than once

### DIFF
--- a/crates/brioche-core/src/project.rs
+++ b/crates/brioche-core/src/project.rs
@@ -1665,6 +1665,18 @@ impl std::str::FromStr for ProjectHash {
     }
 }
 
+impl std::cmp::Ord for ProjectHash {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.0.as_bytes().cmp(other.0.as_bytes())
+    }
+}
+
+impl std::cmp::PartialOrd for ProjectHash {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct Workspace {
     pub definition: WorkspaceDefinition,


### PR DESCRIPTION
Closes #128 

This PR updates the `fetch_project_from_registry` function to use a mutex to ensure that the same project doesn't get cloned more than once at a time. This works by using a `BTreeMap` (wrapped in a `Mutex`), where each key-value pair is a project hash and another mutex

As far as implementation, there are a few other places in the code where we have a similar problem of wanting to ensure that a piece of code only runs once for a particular key: baking recipes, and creating outputs. For baking, we use a map that contains channels, which allows parallel calls to get the result immediately without doing more work. For creating outputs, we use a lazier option of using a single mutex to guard the whole section-- it's not (currently) fine-grained. This new implementation is kind of like a mix between these two other implementations, where we do have fine-grained locking, but each invocation ends up doing a bit of work to read the filesystem to figure out where the output goes

One downside with this implementation is that the mutex map uses `Arc`s, and it never gets keys removed. We could switch to using `Weak` values then add a "remove" phase, but I thought it'd be unlikely that enough keys could ever be added to the map to become an issue