### PR TITLE
Add `--locked` flag for several subcommands

### DIFF
--- a/crates/brioche-core/src/script/bridge.rs
+++ b/crates/brioche-core/src/script/bridge.rs
@@ -9,7 +9,7 @@ use crate::{
     blob::BlobHash,
     project::{
         analyze::{GitRefOptions, StaticInclude, StaticOutput, StaticOutputKind, StaticQuery},
-        ProjectHash, Projects,
+        ProjectHash, ProjectValidation, Projects,
     },
     recipe::{Artifact, DownloadRecipe, Recipe, WithMeta},
     Brioche,
@@ -41,8 +41,9 @@ impl RuntimeBridge {
                 tokio::spawn(async move {
                     match message {
                         RuntimeBridgeMessage::LoadProjectFromModulePath { path, result_tx } => {
-                            let result =
-                                projects.load_from_module_path(&brioche, &path, false).await;
+                            let result = projects
+                                .load_from_module_path(&brioche, &path, ProjectValidation::Minimal)
+                                .await;
                             let _ = result_tx.send(result);
                         }
                         RuntimeBridgeMessage::LoadSpecifierContents {
@@ -124,7 +125,7 @@ impl RuntimeBridge {
                             }
 
                             let result = projects
-                                .load_from_module_path(&brioche, &path, false)
+                                .load_from_module_path(&brioche, &path, ProjectValidation::Minimal)
                                 .await
                                 .map(|_| true);
                             let _ = result_tx.send(result);

--- a/crates/brioche-core/src/script/bridge.rs
+++ b/crates/brioche-core/src/script/bridge.rs
@@ -9,7 +9,7 @@ use crate::{
     blob::BlobHash,
     project::{
         analyze::{GitRefOptions, StaticInclude, StaticOutput, StaticOutputKind, StaticQuery},
-        ProjectHash, ProjectValidation, Projects,
+        ProjectHash, ProjectLocking, ProjectValidation, Projects,
     },
     recipe::{Artifact, DownloadRecipe, Recipe, WithMeta},
     Brioche,
@@ -42,7 +42,12 @@ impl RuntimeBridge {
                     match message {
                         RuntimeBridgeMessage::LoadProjectFromModulePath { path, result_tx } => {
                             let result = projects
-                                .load_from_module_path(&brioche, &path, ProjectValidation::Minimal)
+                                .load_from_module_path(
+                                    &brioche,
+                                    &path,
+                                    ProjectValidation::Minimal,
+                                    ProjectLocking::Unlocked,
+                                )
                                 .await;
                             let _ = result_tx.send(result);
                         }
@@ -125,7 +130,12 @@ impl RuntimeBridge {
                             }
 
                             let result = projects
-                                .load_from_module_path(&brioche, &path, ProjectValidation::Minimal)
+                                .load_from_module_path(
+                                    &brioche,
+                                    &path,
+                                    ProjectValidation::Minimal,
+                                    ProjectLocking::Unlocked,
+                                )
                                 .await
                                 .map(|_| true);
                             let _ = result_tx.send(result);

--- a/crates/brioche-core/src/script/lsp.rs
+++ b/crates/brioche-core/src/script/lsp.rs
@@ -7,7 +7,7 @@ use tower_lsp::lsp_types::request::GotoTypeDefinitionResponse;
 use tower_lsp::lsp_types::*;
 use tower_lsp::{Client, LanguageServer};
 
-use crate::project::{ProjectValidation, Projects};
+use crate::project::{ProjectLocking, ProjectValidation, Projects};
 use crate::script::compiler_host::{brioche_compiler_host, BriocheCompilerHost};
 use crate::script::format::format_code;
 use crate::{Brioche, BriocheBuilder};
@@ -503,7 +503,12 @@ async fn try_update_lockfile_for_module(
 
     tokio::time::timeout(
         load_timeout,
-        projects.load(&brioche, &project_path, ProjectValidation::Minimal),
+        projects.load(
+            &brioche,
+            &project_path,
+            ProjectValidation::Minimal,
+            ProjectLocking::Unlocked,
+        ),
     )
     .await
     .context("timed out trying to load project")?

--- a/crates/brioche-core/src/script/lsp.rs
+++ b/crates/brioche-core/src/script/lsp.rs
@@ -7,7 +7,7 @@ use tower_lsp::lsp_types::request::GotoTypeDefinitionResponse;
 use tower_lsp::lsp_types::*;
 use tower_lsp::{Client, LanguageServer};
 
-use crate::project::Projects;
+use crate::project::{ProjectValidation, Projects};
 use crate::script::compiler_host::{brioche_compiler_host, BriocheCompilerHost};
 use crate::script::format::format_code;
 use crate::{Brioche, BriocheBuilder};
@@ -501,10 +501,13 @@ async fn try_update_lockfile_for_module(
         .context("failed to build `Brioche` instance")?;
     let projects = Projects::default();
 
-    tokio::time::timeout(load_timeout, projects.load(&brioche, &project_path, false))
-        .await
-        .context("timed out trying to load project")?
-        .context("failed to load project")?;
+    tokio::time::timeout(
+        load_timeout,
+        projects.load(&brioche, &project_path, ProjectValidation::Minimal),
+    )
+    .await
+    .context("timed out trying to load project")?
+    .context("failed to load project")?;
 
     let updated = projects
         .commit_dirty_lockfile_for_project_path(&project_path)

--- a/crates/brioche-core/tests/project_load.rs
+++ b/crates/brioche-core/tests/project_load.rs
@@ -1,5 +1,5 @@
 use assert_matches::assert_matches;
-use brioche_core::project::ProjectValidation;
+use brioche_core::project::{ProjectLocking, ProjectValidation};
 
 #[tokio::test]
 async fn test_project_load_simple() -> anyhow::Result<()> {
@@ -793,11 +793,21 @@ async fn test_project_load_with_remote_workspace_registry_dep() -> anyhow::Resul
 
     let projects = brioche_core::project::Projects::default();
     let bar_hash = projects
-        .load(&brioche, &bar_dir, ProjectValidation::Standard)
+        .load(
+            &brioche,
+            &bar_dir,
+            ProjectValidation::Standard,
+            ProjectLocking::Unlocked,
+        )
         .await
         .expect("failed to load bar project");
     let foo_hash = projects
-        .load(&brioche, &foo_dir, ProjectValidation::Standard)
+        .load(
+            &brioche,
+            &foo_dir,
+            ProjectValidation::Standard,
+            ProjectLocking::Unlocked,
+        )
         .await
         .expect("failed to load foo project");
 

--- a/crates/brioche-core/tests/project_load.rs
+++ b/crates/brioche-core/tests/project_load.rs
@@ -1,4 +1,5 @@
 use assert_matches::assert_matches;
+use brioche_core::project::ProjectValidation;
 
 #[tokio::test]
 async fn test_project_load_simple() -> anyhow::Result<()> {
@@ -792,11 +793,11 @@ async fn test_project_load_with_remote_workspace_registry_dep() -> anyhow::Resul
 
     let projects = brioche_core::project::Projects::default();
     let bar_hash = projects
-        .load(&brioche, &bar_dir, true)
+        .load(&brioche, &bar_dir, ProjectValidation::Standard)
         .await
         .expect("failed to load bar project");
     let foo_hash = projects
-        .load(&brioche, &foo_dir, true)
+        .load(&brioche, &foo_dir, ProjectValidation::Standard)
         .await
         .expect("failed to load foo project");
 

--- a/crates/brioche-test-support/src/lib.rs
+++ b/crates/brioche-test-support/src/lib.rs
@@ -8,7 +8,7 @@ use std::{
 
 use brioche_core::{
     blob::{BlobHash, SaveBlobOptions},
-    project::{self, ProjectHash, Projects},
+    project::{self, ProjectHash, ProjectValidation, Projects},
     recipe::{
         CreateDirectory, Directory, File, ProcessRecipe, ProcessTemplate, ProcessTemplateComponent,
         Recipe, WithMeta,
@@ -60,7 +60,9 @@ pub async fn load_project(
     path: &Path,
 ) -> anyhow::Result<(Projects, ProjectHash)> {
     let projects = Projects::default();
-    let project_hash = projects.load(brioche, path, true).await?;
+    let project_hash = projects
+        .load(brioche, path, ProjectValidation::Standard)
+        .await?;
 
     Ok((projects, project_hash))
 }
@@ -70,7 +72,9 @@ pub async fn load_project_no_validate(
     path: &Path,
 ) -> anyhow::Result<(Projects, ProjectHash)> {
     let projects = Projects::default();
-    let project_hash = projects.load(brioche, path, false).await?;
+    let project_hash = projects
+        .load(brioche, path, ProjectValidation::Minimal)
+        .await?;
 
     Ok((projects, project_hash))
 }
@@ -402,7 +406,11 @@ impl TestContext {
 
         let projects = Projects::default();
         let project_hash = projects
-            .load(&self.brioche, &temp_project_path, true)
+            .load(
+                &self.brioche,
+                &temp_project_path,
+                ProjectValidation::Standard,
+            )
             .await
             .expect("failed to load temp project");
         projects.commit_dirty_lockfiles().await.unwrap();

--- a/crates/brioche-test-support/src/lib.rs
+++ b/crates/brioche-test-support/src/lib.rs
@@ -8,7 +8,7 @@ use std::{
 
 use brioche_core::{
     blob::{BlobHash, SaveBlobOptions},
-    project::{self, ProjectHash, ProjectValidation, Projects},
+    project::{self, ProjectHash, ProjectLocking, ProjectValidation, Projects},
     recipe::{
         CreateDirectory, Directory, File, ProcessRecipe, ProcessTemplate, ProcessTemplateComponent,
         Recipe, WithMeta,
@@ -61,7 +61,12 @@ pub async fn load_project(
 ) -> anyhow::Result<(Projects, ProjectHash)> {
     let projects = Projects::default();
     let project_hash = projects
-        .load(brioche, path, ProjectValidation::Standard)
+        .load(
+            brioche,
+            path,
+            ProjectValidation::Standard,
+            ProjectLocking::Unlocked,
+        )
         .await?;
 
     Ok((projects, project_hash))
@@ -73,7 +78,12 @@ pub async fn load_project_no_validate(
 ) -> anyhow::Result<(Projects, ProjectHash)> {
     let projects = Projects::default();
     let project_hash = projects
-        .load(brioche, path, ProjectValidation::Minimal)
+        .load(
+            brioche,
+            path,
+            ProjectValidation::Minimal,
+            ProjectLocking::Unlocked,
+        )
         .await?;
 
     Ok((projects, project_hash))
@@ -410,6 +420,7 @@ impl TestContext {
                 &self.brioche,
                 &temp_project_path,
                 ProjectValidation::Standard,
+                ProjectLocking::Unlocked,
             )
             .await
             .expect("failed to load temp project");

--- a/crates/brioche/src/build.rs
+++ b/crates/brioche/src/build.rs
@@ -56,6 +56,7 @@ pub async fn build(args: BuildArgs) -> anyhow::Result<ExitCode> {
         .build()
         .await?;
     let projects = brioche_core::project::Projects::default();
+
     let locking = if args.locked {
         ProjectLocking::Locked
     } else {

--- a/crates/brioche/src/check.rs
+++ b/crates/brioche/src/check.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 use std::process::ExitCode;
 
 use brioche_core::project::ProjectHash;
+use brioche_core::project::ProjectLocking;
 use brioche_core::project::ProjectValidation;
 use brioche_core::project::Projects;
 use brioche_core::reporter::ConsoleReporterKind;
@@ -44,13 +45,23 @@ pub async fn check(args: CheckArgs) -> anyhow::Result<ExitCode> {
     let check_options = CheckOptions {
         locked: args.locked,
     };
+    let locking = if args.locked {
+        ProjectLocking::Locked
+    } else {
+        ProjectLocking::Unlocked
+    };
 
     // Loop over the projects
     for project_path in projects_path {
         let project_name = format!("project '{name}'", name = project_path.display());
 
         match projects
-            .load(&brioche, &project_path, ProjectValidation::Standard)
+            .load(
+                &brioche,
+                &project_path,
+                ProjectValidation::Standard,
+                locking,
+            )
             .await
         {
             Ok(project_hash) => {

--- a/crates/brioche/src/check.rs
+++ b/crates/brioche/src/check.rs
@@ -13,6 +13,10 @@ use crate::consolidate_result;
 
 #[derive(Debug, Parser)]
 pub struct CheckArgs {
+    /// Validate that the lockfile is up-to-date
+    #[arg(long)]
+    locked: bool,
+
     #[command(flatten)]
     project: super::MultipleProjectArgs,
 }
@@ -36,14 +40,25 @@ pub async fn check(args: CheckArgs) -> anyhow::Result<ExitCode> {
             args.project.project
         };
 
+    let check_options = CheckOptions {
+        locked: args.locked,
+    };
+
     // Loop over the projects
     for project_path in projects_path {
         let project_name = format!("project '{name}'", name = project_path.display());
 
         match projects.load(&brioche, &project_path, true).await {
             Ok(project_hash) => {
-                let result =
-                    run_check(&reporter, &brioche, &projects, project_hash, &project_name).await;
+                let result = run_check(
+                    &reporter,
+                    &brioche,
+                    &projects,
+                    project_hash,
+                    &project_name,
+                    &check_options,
+                )
+                .await;
                 consolidate_result(&reporter, &project_name, result, &mut error_result);
             }
             Err(e) => {
@@ -65,8 +80,15 @@ pub async fn check(args: CheckArgs) -> anyhow::Result<ExitCode> {
             .await
         {
             Ok(project_hash) => {
-                let result =
-                    run_check(&reporter, &brioche, &projects, project_hash, &project_name).await;
+                let result = run_check(
+                    &reporter,
+                    &brioche,
+                    &projects,
+                    project_hash,
+                    &project_name,
+                    &check_options,
+                )
+                .await;
                 consolidate_result(&reporter, &project_name, result, &mut error_result);
             }
             Err(e) => {
@@ -86,17 +108,28 @@ pub async fn check(args: CheckArgs) -> anyhow::Result<ExitCode> {
     Ok(exit_code)
 }
 
+struct CheckOptions {
+    locked: bool,
+}
+
 async fn run_check(
     reporter: &Reporter,
     brioche: &Brioche,
     projects: &Projects,
     project_hash: ProjectHash,
     project_name: &String,
+    options: &CheckOptions,
 ) -> Result<bool, anyhow::Error> {
     let result = async {
-        let num_lockfiles_updated = projects.commit_dirty_lockfiles().await?;
-        if num_lockfiles_updated > 0 {
-            tracing::info!(num_lockfiles_updated, "updated lockfiles");
+        // If the `--locked` flag is used, validate that all lockfiles are
+        // up-to-date. Otherwise, write any out-of-date lockfiles
+        if options.locked {
+            projects.validate_no_dirty_lockfiles()?;
+        } else {
+            let num_lockfiles_updated = projects.commit_dirty_lockfiles().await?;
+            if num_lockfiles_updated > 0 {
+                tracing::info!(num_lockfiles_updated, "updated lockfiles");
+            }
         }
 
         brioche_core::script::check::check(brioche, projects, project_hash).await

--- a/crates/brioche/src/check.rs
+++ b/crates/brioche/src/check.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 use std::process::ExitCode;
 
 use brioche_core::project::ProjectHash;
+use brioche_core::project::ProjectValidation;
 use brioche_core::project::Projects;
 use brioche_core::reporter::ConsoleReporterKind;
 use brioche_core::reporter::Reporter;
@@ -48,7 +49,10 @@ pub async fn check(args: CheckArgs) -> anyhow::Result<ExitCode> {
     for project_path in projects_path {
         let project_name = format!("project '{name}'", name = project_path.display());
 
-        match projects.load(&brioche, &project_path, true).await {
+        match projects
+            .load(&brioche, &project_path, ProjectValidation::Standard)
+            .await
+        {
             Ok(project_hash) => {
                 let result = run_check(
                     &reporter,

--- a/crates/brioche/src/check.rs
+++ b/crates/brioche/src/check.rs
@@ -32,6 +32,14 @@ pub async fn check(args: CheckArgs) -> anyhow::Result<ExitCode> {
         .await?;
     let projects = brioche_core::project::Projects::default();
 
+    let check_options = CheckOptions {
+        locked: args.locked,
+    };
+    let locking = if args.locked {
+        ProjectLocking::Locked
+    } else {
+        ProjectLocking::Unlocked
+    };
     let mut error_result = Option::None;
 
     // Handle the case where no projects and no registries are specified
@@ -41,15 +49,6 @@ pub async fn check(args: CheckArgs) -> anyhow::Result<ExitCode> {
         } else {
             args.project.project
         };
-
-    let check_options = CheckOptions {
-        locked: args.locked,
-    };
-    let locking = if args.locked {
-        ProjectLocking::Locked
-    } else {
-        ProjectLocking::Unlocked
-    };
 
     // Loop over the projects
     for project_path in projects_path {

--- a/crates/brioche/src/format.rs
+++ b/crates/brioche/src/format.rs
@@ -1,7 +1,7 @@
 use std::{path::PathBuf, process::ExitCode};
 
 use brioche_core::{
-    project::{ProjectHash, ProjectValidation, Projects},
+    project::{ProjectHash, ProjectLocking, ProjectValidation, Projects},
     reporter::{ConsoleReporterKind, Reporter},
 };
 use clap::Parser;
@@ -36,7 +36,12 @@ pub async fn format(args: FormatArgs) -> anyhow::Result<ExitCode> {
         let project_name = format!("project '{name}'", name = project_path.display());
 
         match projects
-            .load(&brioche, &project_path, ProjectValidation::Standard)
+            .load(
+                &brioche,
+                &project_path,
+                ProjectValidation::Standard,
+                ProjectLocking::Unlocked,
+            )
             .await
         {
             Ok(project_hash) => {

--- a/crates/brioche/src/format.rs
+++ b/crates/brioche/src/format.rs
@@ -1,7 +1,7 @@
 use std::{path::PathBuf, process::ExitCode};
 
 use brioche_core::{
-    project::{ProjectHash, Projects},
+    project::{ProjectHash, ProjectValidation, Projects},
     reporter::{ConsoleReporterKind, Reporter},
 };
 use clap::Parser;
@@ -35,7 +35,10 @@ pub async fn format(args: FormatArgs) -> anyhow::Result<ExitCode> {
     for project_path in args.project {
         let project_name = format!("project '{name}'", name = project_path.display());
 
-        match projects.load(&brioche, &project_path, true).await {
+        match projects
+            .load(&brioche, &project_path, ProjectValidation::Standard)
+            .await
+        {
             Ok(project_hash) => {
                 let result = run_format(
                     &reporter,

--- a/crates/brioche/src/install.rs
+++ b/crates/brioche/src/install.rs
@@ -3,6 +3,7 @@ use std::process::ExitCode;
 
 use anyhow::Context as _;
 use brioche_core::project::ProjectHash;
+use brioche_core::project::ProjectLocking;
 use brioche_core::project::ProjectValidation;
 use brioche_core::project::Projects;
 use brioche_core::reporter::ConsoleReporterKind;
@@ -52,7 +53,12 @@ pub async fn install(args: InstallArgs) -> anyhow::Result<ExitCode> {
         let project_name = format!("project '{name}'", name = project_path.display());
 
         match projects
-            .load(&brioche, &project_path, ProjectValidation::Standard)
+            .load(
+                &brioche,
+                &project_path,
+                ProjectValidation::Standard,
+                ProjectLocking::Unlocked,
+            )
             .await
         {
             Ok(project_hash) => {

--- a/crates/brioche/src/install.rs
+++ b/crates/brioche/src/install.rs
@@ -3,6 +3,7 @@ use std::process::ExitCode;
 
 use anyhow::Context as _;
 use brioche_core::project::ProjectHash;
+use brioche_core::project::ProjectValidation;
 use brioche_core::project::Projects;
 use brioche_core::reporter::ConsoleReporterKind;
 use brioche_core::reporter::Reporter;
@@ -50,7 +51,10 @@ pub async fn install(args: InstallArgs) -> anyhow::Result<ExitCode> {
     for project_path in projects_path {
         let project_name = format!("project '{name}'", name = project_path.display());
 
-        match projects.load(&brioche, &project_path, true).await {
+        match projects
+            .load(&brioche, &project_path, ProjectValidation::Standard)
+            .await
+        {
             Ok(project_hash) => {
                 let result = run_install(
                     &reporter,

--- a/crates/brioche/src/publish.rs
+++ b/crates/brioche/src/publish.rs
@@ -1,7 +1,7 @@
 use std::{path::PathBuf, process::ExitCode};
 
 use brioche_core::{
-    project::{ProjectHash, Projects},
+    project::{ProjectHash, ProjectValidation, Projects},
     reporter::{ConsoleReporterKind, Reporter},
     Brioche,
 };
@@ -31,7 +31,10 @@ pub async fn publish(args: PublishArgs) -> anyhow::Result<ExitCode> {
     for project_path in args.project {
         let project_name = format!("project '{name}'", name = project_path.display());
 
-        match projects.load(&brioche, &project_path, true).await {
+        match projects
+            .load(&brioche, &project_path, ProjectValidation::Standard)
+            .await
+        {
             Ok(project_hash) => {
                 let result =
                     run_publish(&reporter, &brioche, &projects, project_hash, &project_name).await;

--- a/crates/brioche/src/publish.rs
+++ b/crates/brioche/src/publish.rs
@@ -1,7 +1,7 @@
 use std::{path::PathBuf, process::ExitCode};
 
 use brioche_core::{
-    project::{ProjectHash, ProjectValidation, Projects},
+    project::{ProjectHash, ProjectLocking, ProjectValidation, Projects},
     reporter::{ConsoleReporterKind, Reporter},
     Brioche,
 };
@@ -32,7 +32,12 @@ pub async fn publish(args: PublishArgs) -> anyhow::Result<ExitCode> {
         let project_name = format!("project '{name}'", name = project_path.display());
 
         match projects
-            .load(&brioche, &project_path, ProjectValidation::Standard)
+            .load(
+                &brioche,
+                &project_path,
+                ProjectValidation::Standard,
+                ProjectLocking::Locked,
+            )
             .await
         {
             Ok(project_hash) => {

--- a/crates/brioche/src/run.rs
+++ b/crates/brioche/src/run.rs
@@ -1,7 +1,7 @@
 use std::process::ExitCode;
 
 use anyhow::Context as _;
-use brioche_core::reporter::ConsoleReporterKind;
+use brioche_core::{project::ProjectLocking, reporter::ConsoleReporterKind};
 use clap::Parser;
 use human_repr::HumanDuration;
 use tracing::Instrument;
@@ -51,7 +51,9 @@ pub async fn run(args: RunArgs) -> anyhow::Result<ExitCode> {
     let projects = brioche_core::project::Projects::default();
 
     let build_future = async {
-        let project_hash = super::load_project(&brioche, &projects, &args.project).await?;
+        let project_hash =
+            super::load_project(&brioche, &projects, &args.project, ProjectLocking::Unlocked)
+                .await?;
 
         let num_lockfiles_updated = projects.commit_dirty_lockfiles().await?;
         if num_lockfiles_updated > 0 {

--- a/crates/brioche/src/run.rs
+++ b/crates/brioche/src/run.rs
@@ -27,6 +27,10 @@ pub struct RunArgs {
     #[arg(long)]
     check: bool,
 
+    /// Validate that the lockfile is up-to-date
+    #[arg(long)]
+    locked: bool,
+
     /// Keep temporary build files. Useful for debugging build failures
     #[arg(long)]
     keep_temps: bool,
@@ -50,14 +54,24 @@ pub async fn run(args: RunArgs) -> anyhow::Result<ExitCode> {
         .await?;
     let projects = brioche_core::project::Projects::default();
 
-    let build_future = async {
-        let project_hash =
-            super::load_project(&brioche, &projects, &args.project, ProjectLocking::Unlocked)
-                .await?;
+    let locking = if args.locked {
+        ProjectLocking::Locked
+    } else {
+        ProjectLocking::Unlocked
+    };
 
-        let num_lockfiles_updated = projects.commit_dirty_lockfiles().await?;
-        if num_lockfiles_updated > 0 {
-            tracing::info!(num_lockfiles_updated, "updated lockfiles");
+    let build_future = async {
+        let project_hash = super::load_project(&brioche, &projects, &args.project, locking).await?;
+
+        // If the `--locked` flag is used, validate that all lockfiles are
+        // up-to-date. Otherwise, write any out-of-date lockfiles
+        if args.locked {
+            projects.validate_no_dirty_lockfiles()?;
+        } else {
+            let num_lockfiles_updated = projects.commit_dirty_lockfiles().await?;
+            if num_lockfiles_updated > 0 {
+                tracing::info!(num_lockfiles_updated, "updated lockfiles");
+            }
         }
 
         if args.check {


### PR DESCRIPTION
This PR updates several subcommands with a new `--locked` flag, namely `build`, `check`, `run`, and `install`. When used, the command will fail unless the lockfiles are up-to-date.

The main motivation for this change is for use in CI, such as in the `brioche-packages` repo (see brioche-dev/brioche-packages#111 for an example of a PR that got through with an out-of-date lockfile)

Currently, the error messages leave a lot to be desired... here's an example error:

```
Error occurred with project './packages/hello_world': project load errors: [FailedToLoadDependency { name: "std", cause: "hash for download 'https://example.com/' not found in lockfile" }]
```