### PR TITLE
Fix some LSP errors from converting between line / column numbers and positions

### DIFF
--- a/crates/brioche-core/src/script/lsp.rs
+++ b/crates/brioche-core/src/script/lsp.rs
@@ -561,7 +561,12 @@ impl JsLspTask {
             .await
             .map_err(|_| anyhow::anyhow!("timeout waiting for response from JS LSP"))??;
 
-        let response = serde_json::from_value(response)?;
+        let response = serde_json::from_value(response.clone()).inspect_err(|_| {
+            tracing::warn!(
+                "failed to deserialize response: {:?}",
+                serde_json::to_string(&response)
+            )
+        })?;
 
         Ok(response)
     }


### PR DESCRIPTION
This PR makes some minor tweaks to the LSP that should resolve a few errors and exceptions:

- Log warning message when deserializing response from LSP fails (this should help debug future failures)
- Prevent `Lsp.diagnostic()` from returning out-of-bounds line / column numbers causing deserialization error
- Catch exceptions from `ts.getPositionOfLineAndCharacter()`