### PR TITLE
Add reduced plaintext output format

### DIFF
--- a/crates/brioche/src/build.rs
+++ b/crates/brioche/src/build.rs
@@ -1,10 +1,7 @@
 use std::{path::PathBuf, process::ExitCode};
 
 use anyhow::Context as _;
-use brioche_core::{
-    fs_utils, project::ProjectLocking, reporter::console::ConsoleReporterKind,
-    utils::DisplayDuration,
-};
+use brioche_core::{fs_utils, project::ProjectLocking, utils::DisplayDuration};
 use clap::Parser;
 use tracing::Instrument;
 
@@ -45,11 +42,16 @@ pub struct BuildArgs {
     /// Sync / cache baked recipes to the registry during the build
     #[arg(long)]
     sync: bool,
+
+    /// The output display format.
+    #[arg(long, value_enum, default_value_t)]
+    display: super::DisplayMode,
 }
 
 pub async fn build(args: BuildArgs) -> anyhow::Result<ExitCode> {
-    let (reporter, mut guard) =
-        brioche_core::reporter::console::start_console_reporter(ConsoleReporterKind::Auto)?;
+    let (reporter, mut guard) = brioche_core::reporter::console::start_console_reporter(
+        args.display.to_console_reporter_kind(),
+    )?;
 
     let brioche = brioche_core::BriocheBuilder::new(reporter.clone())
         .keep_temps(args.keep_temps)

--- a/crates/brioche/src/check.rs
+++ b/crates/brioche/src/check.rs
@@ -5,7 +5,6 @@ use brioche_core::project::ProjectHash;
 use brioche_core::project::ProjectLocking;
 use brioche_core::project::ProjectValidation;
 use brioche_core::project::Projects;
-use brioche_core::reporter::console::ConsoleReporterKind;
 use brioche_core::reporter::Reporter;
 use brioche_core::Brioche;
 use clap::Parser;
@@ -21,11 +20,16 @@ pub struct CheckArgs {
 
     #[command(flatten)]
     project: super::MultipleProjectArgs,
+
+    /// The output display format.
+    #[arg(long, value_enum, default_value_t)]
+    display: super::DisplayMode,
 }
 
 pub async fn check(args: CheckArgs) -> anyhow::Result<ExitCode> {
-    let (reporter, mut guard) =
-        brioche_core::reporter::console::start_console_reporter(ConsoleReporterKind::Auto)?;
+    let (reporter, mut guard) = brioche_core::reporter::console::start_console_reporter(
+        args.display.to_console_reporter_kind(),
+    )?;
 
     let brioche = brioche_core::BriocheBuilder::new(reporter.clone())
         .build()

--- a/crates/brioche/src/format.rs
+++ b/crates/brioche/src/format.rs
@@ -2,7 +2,7 @@ use std::{path::PathBuf, process::ExitCode};
 
 use brioche_core::{
     project::{ProjectHash, ProjectLocking, ProjectValidation, Projects},
-    reporter::{console::ConsoleReporterKind, Reporter},
+    reporter::Reporter,
 };
 use clap::Parser;
 use tracing::Instrument;
@@ -18,11 +18,16 @@ pub struct FormatArgs {
     /// Check formatting without writing changes
     #[arg(long)]
     check: bool,
+
+    /// The output display format.
+    #[arg(long, value_enum, default_value_t)]
+    display: super::DisplayMode,
 }
 
 pub async fn format(args: FormatArgs) -> anyhow::Result<ExitCode> {
-    let (reporter, mut guard) =
-        brioche_core::reporter::console::start_console_reporter(ConsoleReporterKind::Auto)?;
+    let (reporter, mut guard) = brioche_core::reporter::console::start_console_reporter(
+        args.display.to_console_reporter_kind(),
+    )?;
 
     let brioche = brioche_core::BriocheBuilder::new(reporter.clone())
         .build()

--- a/crates/brioche/src/install.rs
+++ b/crates/brioche/src/install.rs
@@ -6,7 +6,6 @@ use brioche_core::project::ProjectHash;
 use brioche_core::project::ProjectLocking;
 use brioche_core::project::ProjectValidation;
 use brioche_core::project::Projects;
-use brioche_core::reporter::console::ConsoleReporterKind;
 use brioche_core::reporter::Reporter;
 use brioche_core::utils::DisplayDuration;
 use brioche_core::Brioche;
@@ -31,11 +30,16 @@ pub struct InstallArgs {
     /// Validate that the lockfile is up-to-date
     #[arg(long)]
     locked: bool,
+
+    /// The output display format.
+    #[arg(long, value_enum, default_value_t)]
+    display: super::DisplayMode,
 }
 
 pub async fn install(args: InstallArgs) -> anyhow::Result<ExitCode> {
-    let (reporter, mut guard) =
-        brioche_core::reporter::console::start_console_reporter(ConsoleReporterKind::Auto)?;
+    let (reporter, mut guard) = brioche_core::reporter::console::start_console_reporter(
+        args.display.to_console_reporter_kind(),
+    )?;
 
     let brioche = brioche_core::BriocheBuilder::new(reporter.clone())
         .build()

--- a/crates/brioche/src/main.rs
+++ b/crates/brioche/src/main.rs
@@ -331,6 +331,9 @@ enum DisplayMode {
 
     /// Plaintext output.
     Plain,
+
+    /// Plaintext output with less stuff, e.g. by hiding process outputs.
+    PlainReduced,
 }
 
 impl DisplayMode {
@@ -341,6 +344,9 @@ impl DisplayMode {
                 brioche_core::reporter::console::ConsoleReporterKind::SuperConsole
             }
             DisplayMode::Plain => brioche_core::reporter::console::ConsoleReporterKind::Plain,
+            DisplayMode::PlainReduced => {
+                brioche_core::reporter::console::ConsoleReporterKind::PlainReduced
+            }
         }
     }
 }

--- a/crates/brioche/src/main.rs
+++ b/crates/brioche/src/main.rs
@@ -319,6 +319,32 @@ fn consolidate_result(
     }
 }
 
+#[derive(Debug, Default, Clone, Copy, clap::ValueEnum)]
+enum DisplayMode {
+    /// Display with console output if stdout is a tty, otherwise use
+    /// plain output.
+    #[default]
+    Auto,
+
+    /// Pretty console-based output.
+    Console,
+
+    /// Plaintext output.
+    Plain,
+}
+
+impl DisplayMode {
+    fn to_console_reporter_kind(self) -> brioche_core::reporter::console::ConsoleReporterKind {
+        match self {
+            DisplayMode::Auto => brioche_core::reporter::console::ConsoleReporterKind::Auto,
+            DisplayMode::Console => {
+                brioche_core::reporter::console::ConsoleReporterKind::SuperConsole
+            }
+            DisplayMode::Plain => brioche_core::reporter::console::ConsoleReporterKind::Plain,
+        }
+    }
+}
+
 /// Start a task that handles Ctrl-C. When Ctrl-C is received, all critical
 /// tasks will be cancelled, and the program will exit once they have all
 /// exited.

--- a/crates/brioche/src/publish.rs
+++ b/crates/brioche/src/publish.rs
@@ -2,7 +2,7 @@ use std::{path::PathBuf, process::ExitCode};
 
 use brioche_core::{
     project::{ProjectHash, ProjectLocking, ProjectValidation, Projects},
-    reporter::{console::ConsoleReporterKind, Reporter},
+    reporter::Reporter,
     Brioche,
 };
 use clap::Parser;
@@ -14,11 +14,16 @@ pub struct PublishArgs {
     /// The path to the project directory to publish
     #[arg(short, long)]
     project: Vec<PathBuf>,
+
+    /// The output display format.
+    #[arg(long, value_enum, default_value_t)]
+    display: super::DisplayMode,
 }
 
 pub async fn publish(args: PublishArgs) -> anyhow::Result<ExitCode> {
-    let (reporter, mut guard) =
-        brioche_core::reporter::console::start_console_reporter(ConsoleReporterKind::Auto)?;
+    let (reporter, mut guard) = brioche_core::reporter::console::start_console_reporter(
+        args.display.to_console_reporter_kind(),
+    )?;
 
     let brioche = brioche_core::BriocheBuilder::new(reporter.clone())
         .build()

--- a/crates/brioche/src/run.rs
+++ b/crates/brioche/src/run.rs
@@ -1,9 +1,7 @@
 use std::process::ExitCode;
 
 use anyhow::Context as _;
-use brioche_core::{
-    project::ProjectLocking, reporter::console::ConsoleReporterKind, utils::DisplayDuration,
-};
+use brioche_core::{project::ProjectLocking, utils::DisplayDuration};
 use clap::Parser;
 use tracing::Instrument;
 
@@ -36,6 +34,10 @@ pub struct RunArgs {
     #[arg(long)]
     keep_temps: bool,
 
+    /// The output display format.
+    #[arg(long, value_enum, default_value_t)]
+    display: super::DisplayMode,
+
     /// Arguments to pass to the command
     #[arg(last = true)]
     args: Vec<std::ffi::OsString>,
@@ -45,7 +47,9 @@ pub async fn run(args: RunArgs) -> anyhow::Result<ExitCode> {
     let (reporter, mut guard) = if args.quiet {
         brioche_core::reporter::start_null_reporter()
     } else {
-        brioche_core::reporter::console::start_console_reporter(ConsoleReporterKind::Auto)?
+        brioche_core::reporter::console::start_console_reporter(
+            args.display.to_console_reporter_kind(),
+        )?
     };
 
     let brioche = brioche_core::BriocheBuilder::new(reporter.clone())


### PR DESCRIPTION
This PR adds a new `--display` flag to most CLI commands (specifically, those that create a console output reporter). This flag takes 4 different options:

- `--display console` - Enable pretty (SuperConsole-based) console output
- `--display plain` - Enable plaintext-only output
- `--display auto` Use `console` or `plain` based on if stderr is a tty or not (default, matches current behavior)
- `--display plain-reduced` - New format: plaintext-only output, but don't show process outputs

The main motivation for the new `plain-reduced` format is for GitHub Actions runs, where log outputs are so long that it actually makes it difficult to view a failed build in the browser. Instead of trying to log the build outputs during the build, we can instead just show a bit of the output from the events file on failure, or attach the events file as an artifact.