### PR TITLE
Fix OpenTelemetry runtime and shutdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4250,6 +4250,8 @@ dependencies = [
  "rand 0.8.5",
  "serde_json",
  "thiserror 1.0.69",
+ "tokio",
+ "tokio-stream",
  "tracing",
 ]
 

--- a/crates/brioche-core/Cargo.toml
+++ b/crates/brioche-core/Cargo.toml
@@ -30,8 +30,8 @@ json-canon = "0.1.3"
 lazy_format = "2.0.3"
 nix = { version = "0.29.0", features = ["user"] }
 opentelemetry = "0.27.0"
-opentelemetry_sdk = "0.27.0"
-opentelemetry-otlp = {version = "0.27.0", default-features = false, features = ["http-proto", "reqwest-rustls"] }
+opentelemetry_sdk = { version = "0.27.0", features = ["rt-tokio"] }
+opentelemetry-otlp = { version = "0.27.0", default-features = false, features = ["http-proto", "reqwest-rustls"] }
 opentelemetry-semantic-conventions = "0.27.0"
 pathdiff = "0.2.2"
 regex = "1.11.1"

--- a/crates/brioche-core/src/reporter/console.rs
+++ b/crates/brioche-core/src/reporter/console.rs
@@ -52,11 +52,6 @@ pub fn start_console_reporter(
         num_jobs: Arc::new(AtomicUsize::new(0)),
         tx: tx.clone(),
     };
-    let guard = ReporterGuard {
-        tx,
-        shutdown_rx: Some(shutdown_rx),
-        shutdown_opentelemetry: brioche_otel_enabled,
-    };
 
     std::thread::spawn({
         let queued_lines = queued_lines.clone();
@@ -131,16 +126,16 @@ pub fn start_console_reporter(
         }
     });
 
-    let opentelemetry_layer = if brioche_otel_enabled {
-        opentelemetry::global::set_text_map_propagator(
-            opentelemetry_sdk::propagation::TraceContextPropagator::new(),
-        );
+    let guard;
+    let opentelemetry_layer;
+
+    if brioche_otel_enabled {
         let exporter = opentelemetry_otlp::SpanExporter::builder()
             .with_http()
             .with_http_client(reqwest::Client::new())
             .build()?;
         let provider = opentelemetry_sdk::trace::TracerProvider::builder()
-            .with_simple_exporter(exporter)
+            .with_batch_exporter(exporter, opentelemetry_sdk::runtime::Tokio)
             .with_config(opentelemetry_sdk::trace::Config::default().with_resource(
                 opentelemetry_sdk::Resource::default().merge(&opentelemetry_sdk::Resource::new(
                     vec![
@@ -157,13 +152,23 @@ pub fn start_console_reporter(
             ))
             .build();
 
-        Some(
+        opentelemetry_layer = Some(
             tracing_opentelemetry::layer()
-                .with_tracer(provider.tracer("tracing-opentelemetry"))
+                .with_tracer(provider.tracer("brioche"))
                 .with_filter(tracing_debug_filter()),
-        )
+        );
+        guard = ReporterGuard {
+            tx,
+            shutdown_rx: Some(shutdown_rx),
+            opentelemetry_tracer_provider: Some(provider),
+        };
     } else {
-        None
+        opentelemetry_layer = None;
+        guard = ReporterGuard {
+            tx,
+            shutdown_rx: Some(shutdown_rx),
+            opentelemetry_tracer_provider: None,
+        };
     };
 
     let log_file_layer = match std::env::var_os("BRIOCHE_LOG_OUTPUT") {


### PR DESCRIPTION
This PR fixes some issues around OpenTelemetry following #140: namely, trying to use `BRIOCHE_ENABLE_OTEL=1` would cause a deadlock, and even after fixing that, events wouldn't be flushed properly. There were two fixes involved:

1. Enable Tokio batched OpenTelemetry exporter. This fixes a panic that was silently being ignored, caused by some HTTP code trying to access the Tokio runtime on a non-Tokio thread
2. Update OpenTelemetry shutdown code. `opentelemetry::global::shutdown_tracer_provider()`  no longer seems to do it. Now, we explicitly shut down the tracer provider directly.