### PR TITLE
Speed up tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -921,6 +921,8 @@ dependencies = [
  "anyhow",
  "brioche-core",
  "mockito",
+ "reqwest",
+ "reqwest-middleware",
  "serde",
  "serde_json",
  "tempdir",
@@ -1869,6 +1871,21 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -3200,6 +3217,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3923,6 +3956,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4165,10 +4215,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "openssl"
+version = "0.10.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6174bc48f102d208783c2c84bf931bb75927a617866870de8a4ea85597f871f5"
+dependencies = [
+ "bitflags 2.6.0",
+ "cfg-if 1.0.0",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "opentelemetry"
@@ -5019,11 +5107,13 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "hyper-util",
  "ipnet",
  "js-sys",
  "log",
  "mime",
+ "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -5038,6 +5128,7 @@ dependencies = [
  "sync_wrapper 1.0.1",
  "system-configuration",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "tower-service",
@@ -6814,6 +6905,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.87",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/brioche-core/src/bake.rs
+++ b/crates/brioche-core/src/bake.rs
@@ -18,6 +18,8 @@ use super::{
     Brioche,
 };
 
+pub use process::{process_rootfs_recipes, ProcessRootfsRecipes};
+
 mod collect_references;
 mod download;
 mod process;

--- a/crates/brioche-core/src/registry.rs
+++ b/crates/brioche-core/src/registry.rs
@@ -51,6 +51,14 @@ impl RegistryClient {
             .with(retry_middleware)
             .build();
 
+        Self::new_with_client(client, url, auth)
+    }
+
+    pub fn new_with_client(
+        client: reqwest_middleware::ClientWithMiddleware,
+        url: url::Url,
+        auth: RegistryAuthentication,
+    ) -> Self {
         Self::Enabled { client, url, auth }
     }
 

--- a/crates/brioche-core/tests/bake_process.rs
+++ b/crates/brioche-core/tests/bake_process.rs
@@ -70,6 +70,8 @@ async fn brioche_test() -> (
 
     let (brioche, context) = brioche_test_support::brioche_test().await;
 
+    brioche_test_support::load_rootfs_recipes(&brioche, current_platform()).await;
+
     (brioche, context, lock)
 }
 

--- a/crates/brioche-test-support/Cargo.toml
+++ b/crates/brioche-test-support/Cargo.toml
@@ -7,6 +7,8 @@ edition = "2021"
 anyhow = { version = "1.0.93", features = ["backtrace"] }
 brioche-core = { path = "../brioche-core" }
 mockito = "1.6.1"
+reqwest = "0.12.9"
+reqwest-middleware = "0.4.0"
 serde = { version = "1.0.215", features = ["derive"] }
 serde_json = "1.0.133"
 tempdir = "0.3.7"

--- a/crates/brioche-test-support/src/lib.rs
+++ b/crates/brioche-test-support/src/lib.rs
@@ -37,7 +37,8 @@ pub async fn brioche_test_with(
     let (reporter, reporter_guard) = brioche_core::reporter::start_test_reporter();
     let builder = BriocheBuilder::new(reporter)
         .home(brioche_home)
-        .registry_client(brioche_core::registry::RegistryClient::new(
+        .registry_client(brioche_core::registry::RegistryClient::new_with_client(
+            reqwest_middleware::ClientBuilder::new(reqwest::Client::new()).build(),
             registry_server.url().parse().unwrap(),
             brioche_core::registry::RegistryAuthentication::Admin {
                 password: "admin".to_string(),

--- a/crates/brioche-test-support/src/lib.rs
+++ b/crates/brioche-test-support/src/lib.rs
@@ -1,20 +1,22 @@
 #![allow(unused)]
 
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::{BTreeMap, HashMap, VecDeque},
     path::{Path, PathBuf},
     process::Output,
+    sync::OnceLock,
 };
 
 use brioche_core::{
     blob::{BlobHash, SaveBlobOptions},
     project::{self, ProjectHash, ProjectLocking, ProjectValidation, Projects},
     recipe::{
-        CreateDirectory, Directory, File, ProcessRecipe, ProcessTemplate, ProcessTemplateComponent,
-        Recipe, WithMeta,
+        CreateDirectory, Directory, DownloadRecipe, File, ProcessRecipe, ProcessTemplate,
+        ProcessTemplateComponent, Recipe, WithMeta,
     },
     Brioche, BriocheBuilder,
 };
+use tokio::{io::AsyncSeekExt as _, sync::Mutex};
 
 pub async fn brioche_test() -> (Brioche, TestContext) {
     brioche_test_with(|builder| builder).await
@@ -54,6 +56,193 @@ pub async fn brioche_test_with(
         _reporter_guard: reporter_guard,
     };
     (brioche, context)
+}
+
+/// Pre-load rootfs used when baking processes into `brioche`. Each file
+/// will be downloaded to a temporary path and re-used within the same
+/// test run.
+pub async fn load_rootfs_recipes(brioche: &Brioche, platform: brioche_core::platform::Platform) {
+    static FILES: OnceLock<Mutex<HashMap<DownloadRecipe, Mutex<tokio::fs::File>>>> =
+        OnceLock::new();
+
+    let brioche_core::bake::ProcessRootfsRecipes { sh, env } =
+        brioche_core::bake::process_rootfs_recipes(platform);
+
+    brioche_core::recipe::save_recipes(brioche, vec![sh.clone(), env.clone()])
+        .await
+        .unwrap();
+
+    // Get all inner download recipes from the returned rootfs recipes
+    let mut recipes = VecDeque::from_iter([sh, env]);
+    let mut download_recipes = vec![];
+    while let Some(recipe) = recipes.pop_front() {
+        match recipe {
+            Recipe::Download(download) => {
+                download_recipes.push(download);
+            }
+            Recipe::Unarchive(unarchive) => {
+                recipes.push_back(unarchive.file.value);
+            }
+            Recipe::Process(_) => unimplemented!(),
+            Recipe::CompleteProcess(_) => unimplemented!(),
+            Recipe::CreateFile {
+                content: _,
+                executable: _,
+                resources,
+            } => {
+                recipes.push_back(resources.value);
+            }
+            Recipe::CreateDirectory(directory) => {
+                recipes.extend(directory.entries.into_values().map(|recipe| recipe.value));
+            }
+            Recipe::Cast { recipe, to: _ } => {
+                recipes.push_back(recipe.value);
+            }
+            Recipe::Merge { directories } => {
+                recipes.extend(directories.into_iter().map(|recipe| recipe.value))
+            }
+            Recipe::Peel {
+                directory,
+                depth: _,
+            } => recipes.push_back(directory.value),
+            Recipe::Get { directory, path: _ } => {
+                recipes.push_back(directory.value);
+            }
+            Recipe::Insert {
+                directory,
+                path: _,
+                recipe,
+            } => {
+                recipes.push_back(directory.value);
+                if let Some(recipe) = recipe {
+                    recipes.push_back(recipe.value);
+                }
+            }
+            Recipe::Glob {
+                directory,
+                patterns: _,
+            } => {
+                recipes.push_back(directory.value);
+            }
+            Recipe::SetPermissions {
+                file,
+                executable: _,
+            } => {
+                recipes.push_back(file.value);
+            }
+            Recipe::CollectReferences { recipe } => {
+                recipes.push_back(recipe.value);
+            }
+            Recipe::Proxy(_) => unimplemented!(),
+            Recipe::Sync { recipe } => {
+                recipes.push_back(recipe.value);
+            }
+            Recipe::File {
+                content_blob: _,
+                executable: _,
+                resources: _,
+            } => unimplemented!(),
+            Recipe::Directory(_) => unimplemented!(),
+            Recipe::Symlink { target: _ } => {}
+        }
+    }
+
+    for download in download_recipes {
+        let mut files = FILES.get_or_init(Default::default).lock().await;
+        match files.entry(download.clone()) {
+            std::collections::hash_map::Entry::Occupied(entry) => {
+                // File already exists, get it and rewind to the start
+                let mut file = entry.get().lock().await;
+                file.rewind().await.unwrap();
+
+                // Save the file as a blob
+                let mut permit = brioche_core::blob::get_save_blob_permit().await.unwrap();
+                let blob_hash = brioche_core::blob::save_blob_from_reader(
+                    brioche,
+                    &mut permit,
+                    &mut *file,
+                    brioche_core::blob::SaveBlobOptions::default()
+                        .expected_hash(Some(download.hash.clone())),
+                    &mut vec![],
+                )
+                .await
+                .unwrap();
+
+                // Save a bake result, so the download maps to a file with
+                // the saved blob
+                let input_recipe = brioche_core::recipe::Recipe::Download(download.clone());
+                let output_recipe = brioche_core::recipe::Recipe::File {
+                    content_blob: blob_hash,
+                    executable: false,
+                    resources: Box::new(WithMeta::without_meta(
+                        brioche_core::recipe::Recipe::Directory(Default::default()),
+                    )),
+                };
+                let input_hash = input_recipe.hash();
+                let input_json = serde_json::to_string(&input_recipe).unwrap();
+                let output_hash = output_recipe.hash();
+                let output_json = serde_json::to_string(&output_recipe).unwrap();
+                brioche_core::bake::save_bake_result(
+                    brioche,
+                    input_hash,
+                    &input_json,
+                    output_hash,
+                    &output_json,
+                )
+                .await
+                .unwrap();
+            }
+            std::collections::hash_map::Entry::Vacant(entry) => {
+                // Download the recipe and open the blob file
+                let blob_hash = brioche_core::download::download(
+                    brioche,
+                    &download.url,
+                    Some(download.hash.clone()),
+                )
+                .await;
+                let blob_hash = match blob_hash {
+                    Ok(blob_hash) => blob_hash,
+                    Err(error) => {
+                        panic!("failed to download rootfs blob {}: {error:#}", download.url);
+                    }
+                };
+                let blob_path = brioche_core::blob::local_blob_path(brioche, blob_hash);
+                let mut blob_file = tokio::fs::File::open(&blob_path).await.unwrap();
+
+                // Create a temporary file
+                let temp_dir = std::env::temp_dir();
+                let temp_path = temp_dir.join(format!(
+                    "brioche-download-{}-{}",
+                    download.hash,
+                    ulid::Ulid::new()
+                ));
+                let mut temp_file = tokio::fs::File::create_new(&temp_path).await.unwrap();
+
+                // Unlink the temporary file. This will automatically remove
+                // the file when it's closed
+                match tokio::fs::remove_file(&temp_path).await {
+                    Ok(_) => {}
+                    Err(error) => {
+                        panic!(
+                            "failed to unlink temporary path {}: {error:#}",
+                            temp_path.display()
+                        );
+                    }
+                }
+
+                // Copy the downloaded file into the temp file
+                match tokio::io::copy(&mut blob_file, &mut temp_file).await {
+                    Ok(_) => {}
+                    Err(error) => {
+                        panic!("failed to copy blob file for {}: {error:#}", download.url);
+                    }
+                }
+
+                // Keep the temp file open for next time
+                entry.insert(Mutex::new(temp_file));
+            }
+        };
+    }
 }
 
 pub async fn load_project(


### PR DESCRIPTION
This PR speeds up `cargo test` tests, namely those under `bake_process`.

The main discovery I made was that every registry hit was getting a 501 response, which is what Mockito returns when a URL isn't stubbed. This in turn triggered the `reqwest-retry` middleware, causing it to try the same request again after a delay, until it reached the maximum number of retries. So, there was an unnecessary ~5s pause per (expensive) baked recipe in the tests...

This PR fixes that by disabling the retry middleware for tests. Additionally, it splits the `bake_process` tests up into separate tests again, along with some extra caching around the rootfs files needed when baking processes.