### PR TITLE
Add frame to process events after writing description

### DIFF
--- a/crates/brioche-core/src/bake/process.rs
+++ b/crates/brioche-core/src/bake/process.rs
@@ -1310,7 +1310,7 @@ impl BakeDir {
         // all files
         crate::fs_utils::set_directory_rwx_recursive(&path)
             .await
-            .context("failed to set permissions for temprorary bake directory")?;
+            .context("failed to set permissions for temporary bake directory")?;
 
         tokio::fs::remove_dir_all(&path)
             .await

--- a/crates/brioche-core/src/process_events/writer.rs
+++ b/crates/brioche-core/src/process_events/writer.rs
@@ -161,6 +161,10 @@ where
         Ok(bytes.len())
     }
 
+    pub fn inner_mut(&mut self) -> &mut W {
+        &mut self.writer
+    }
+
     pub fn into_inner(self) -> W {
         self.writer
     }


### PR DESCRIPTION
This is a small PR that updates the process events writer (see #138) so the process description is split into a new frame and flushed immediately, even before the process runs.

The main motivation here is, if you see an `events.bin.zst` file on disk, you should be able to inspect it to see which process it's for right away without waiting for it to hit a frame size of 1MB.