### PR TITLE
Add new `attach_resources` recipe

### DIFF
--- a/crates/brioche-core/src/bake.rs
+++ b/crates/brioche-core/src/bake.rs
@@ -20,6 +20,7 @@ use super::{
 
 pub use process::{process_rootfs_recipes, ProcessRootfsRecipes};
 
+mod attach_resources;
 mod collect_references;
 mod download;
 mod process;
@@ -248,7 +249,7 @@ async fn bake_inner(
                     let baked = run_bake(&brioche, recipe.value, &meta).await?;
 
                     // Send expensive recipes to optionally be synced to
-                    // the registry right afer we baked it
+                    // the registry right after we baked it
                     if let Some(input_recipe) = input_recipe {
                         brioche
                             .sync_tx
@@ -537,6 +538,22 @@ async fn run_bake(brioche: &Brioche, recipe: Recipe, meta: &Arc<Meta>) -> anyhow
             };
 
             let directory = collect_references::bake_collect_references(brioche, directory).await?;
+
+            Ok(Artifact::Directory(directory))
+        }
+        Recipe::AttachResources { recipe } => {
+            let artifact = bake(brioche, *recipe, &scope).await?;
+            let Artifact::Directory(mut directory) = artifact.value else {
+                anyhow::bail!("tried attaching resources for non-directory artifact");
+            };
+
+            attach_resources::attach_resources(
+                brioche,
+                &mut directory,
+                &[],
+                std::borrow::Cow::Borrowed(&[]),
+            )
+            .await?;
 
             Ok(Artifact::Directory(directory))
         }

--- a/crates/brioche-core/src/bake.rs
+++ b/crates/brioche-core/src/bake.rs
@@ -547,13 +547,7 @@ async fn run_bake(brioche: &Brioche, recipe: Recipe, meta: &Arc<Meta>) -> anyhow
                 anyhow::bail!("tried attaching resources for non-directory artifact");
             };
 
-            attach_resources::attach_resources(
-                brioche,
-                &mut directory,
-                &[],
-                std::borrow::Cow::Borrowed(&[]),
-            )
-            .await?;
+            attach_resources::attach_resources(brioche, &mut directory).await?;
 
             Ok(Artifact::Directory(directory))
         }

--- a/crates/brioche-core/src/bake/attach_resources.rs
+++ b/crates/brioche-core/src/bake/attach_resources.rs
@@ -1,0 +1,236 @@
+use std::{
+    borrow::Cow,
+    collections::{BTreeMap, HashSet, VecDeque},
+};
+
+use anyhow::Context as _;
+use joinery::JoinableIterator as _;
+
+use crate::{
+    recipe::{Artifact, Directory, WithMeta},
+    Brioche,
+};
+
+/// Recursively walk a directory, attaching resources to directory entries
+/// from discovered `brioche-resources.d` directories. Returns `true` if
+/// the directory was changed.
+pub async fn attach_resources(
+    brioche: &Brioche,
+    directory: &mut Directory,
+    subpath: &[&bstr::BStr],
+    mut resource_dirs: Cow<'_, [Directory]>,
+) -> anyhow::Result<bool> {
+    let mut changed = false;
+
+    let mut entries = directory.entries(brioche).await?;
+
+    // If there's a `brioche-resources.d` directory, remove it from the list
+    // of entries to walk, and add it to the list of resource directories
+    // to search.
+    match entries.entry("brioche-resources.d".into()) {
+        std::collections::btree_map::Entry::Occupied(resource_dir_entry) => {
+            if matches!(resource_dir_entry.get(), Artifact::Directory(_)) {
+                let Artifact::Directory(resource_dir) = resource_dir_entry.remove() else {
+                    unreachable!();
+                };
+
+                resource_dirs.to_mut().push(resource_dir);
+            }
+        }
+        std::collections::btree_map::Entry::Vacant(_) => {}
+    }
+
+    for (name, entry) in entries {
+        let mut entry_subpath = subpath.to_vec();
+        entry_subpath.push(bstr::BStr::new(&name));
+
+        match entry {
+            Artifact::File(mut file) => {
+                // Try to find resources referenced by the file
+                let file_resources =
+                    file_resources_to_attach(brioche, &file, &entry_subpath, &resource_dirs)
+                        .await?;
+
+                // If the resources have changed, update the file's resources
+                // then replace the old directory entry
+                if file_resources != file.resources {
+                    file.resources = file_resources;
+                    directory
+                        .insert(brioche, &name, Some(Artifact::File(file)))
+                        .await?;
+                    changed = true;
+                }
+            }
+            Artifact::Symlink { .. } => {
+                // Nothing to do for symlinks
+            }
+            Artifact::Directory(mut subdir) => {
+                // Recursively attach resources within the subdirectory
+                let subdir_changed = attach_resources(
+                    brioche,
+                    &mut subdir,
+                    &entry_subpath,
+                    Cow::Borrowed(&resource_dirs),
+                );
+                let subdir_changed = Box::pin(subdir_changed).await?;
+
+                // If the subdirectory was updated, replace it in the directory
+                if subdir_changed {
+                    directory
+                        .insert(brioche, &name, Some(Artifact::Directory(subdir)))
+                        .await?;
+                    changed = true;
+                }
+            }
+        }
+    }
+
+    Ok(changed)
+}
+
+async fn file_resources_to_attach(
+    brioche: &Brioche,
+    file: &crate::recipe::File,
+    entry_subpath: &[&bstr::BStr],
+    resource_dirs: &[Directory],
+) -> anyhow::Result<Directory> {
+    let entry_subpath = entry_subpath.iter().join_with("/");
+    let blob_path = crate::blob::blob_path(
+        brioche,
+        &mut crate::blob::get_save_blob_permit().await?,
+        file.content_blob,
+    )
+    .await?;
+
+    // Get any referenced resource paths from the pack, if any
+    let extracted = tokio::task::spawn_blocking(move || {
+        let file = std::fs::File::open(blob_path)?;
+        let extracted = brioche_pack::extract_pack(file).ok();
+
+        anyhow::Ok(extracted)
+    })
+    .await??;
+    let pack = extracted.map(|extracted| extracted.pack);
+
+    let mut visited_resource_paths = HashSet::new();
+    let mut pending_resource_paths: VecDeque<_> = pack
+        .into_iter()
+        .flat_map(|pack| pack.paths())
+        .map(|path| (path, false))
+        .collect();
+
+    // Collect all referenced resources
+    let mut file_resources = BTreeMap::new();
+    while let Some((path, is_symlink_target)) = pending_resource_paths.pop_front() {
+        // Skip resource paths we've already visited
+        if !visited_resource_paths.insert(path.clone()) {
+            continue;
+        }
+
+        // Get the file's existing resource if it has one
+        let existing_resource = file.resources.get(brioche, &path).await?;
+
+        // Get the resource from the resource directories to search
+        let mut new_resource = None;
+        for resource_dir in resource_dirs {
+            if new_resource.is_some() {
+                break;
+            }
+
+            new_resource = resource_dir.get(brioche, &path).await?;
+        }
+
+        // Ensure we found the resource
+        let resource = match (existing_resource, new_resource) {
+            (Some(resource), None) | (None, Some(resource)) => {
+                // If we only found the existing resource or the new resource,
+                // then we have the resource to add
+                resource
+            }
+            (Some(existing), Some(new)) => {
+                // If we found both the existing resource and the new resource,
+                // ensure they match. If they don't, this means that the
+                // new resource path is trying to shadow an existing resource
+                anyhow::ensure!(
+                    existing == new,
+                    "conflicting resource in `{entry_subpath}`: resource `{path}` differs"
+                );
+                existing
+            }
+            (None, None) => {
+                if !is_symlink_target {
+                    // We didn't find the resource anywhere, so return an error.
+                    // NOTE: This is currently more strict than how resources
+                    // are added from a process recipe, so it might make sense
+                    // to loosen this.
+                    anyhow::bail!("resource `{path}` required by `{entry_subpath}` not found");
+                } else {
+                    // Skip broken symlink targets
+                    tracing::debug!(
+                        %entry_subpath,
+                        resource_path = %path,
+                        "symlink points into resource directory but the target could not be found, symlink may be broken"
+                    );
+                    continue;
+                }
+            }
+        };
+
+        match resource {
+            Artifact::File(file) => {
+                // Add the file to the file's resources
+                file_resources.insert(path, WithMeta::without_meta(Artifact::File(file)));
+            }
+            Artifact::Symlink { target } => {
+                // Disallow nested symlinks for now so we match
+                // how resources are handled in process recipes.
+                // TODO: Handle nested symlinks
+                if is_symlink_target {
+                    anyhow::bail!("resource `{path}` in `{entry_subpath}` is another symlink, which is not supported");
+                }
+
+                // Resolve the symlink path relative to the resource dir
+                let mut target_path = path.clone();
+                target_path.extend_from_slice(b"/../");
+                target_path.extend_from_slice(&target);
+
+                let target_path = crate::fs_utils::logical_path_bytes(&target_path).with_context(|| format!("failed to normalize symlink target `{target}` for resource `{path}` in `{entry_subpath}`"))?;
+
+                // Add the symlink itself as a resource
+                file_resources.insert(
+                    path,
+                    WithMeta::without_meta(Artifact::Symlink {
+                        target: target.clone(),
+                    }),
+                );
+
+                // Add the symlink target as a resource path
+                pending_resource_paths.push_back((bstr::BString::from(target_path), true));
+            }
+            Artifact::Directory(directory) => {
+                let entries = directory.entry_hashes();
+
+                // Add an empty directory if there are no sub-entries to add
+                if entries.is_empty() {
+                    file_resources.insert(
+                        path.clone(),
+                        WithMeta::without_meta(Artifact::Directory(Directory::default())),
+                    );
+                }
+
+                // Add each directory entry as a resource
+                for name in entries.keys() {
+                    let mut entry_path = path.clone();
+                    entry_path.extend_from_slice(b"/");
+                    entry_path.extend_from_slice(name);
+
+                    pending_resource_paths.push_back((entry_path, is_symlink_target));
+                }
+            }
+        }
+    }
+
+    // Build a directory from all the resources we found
+    let file_resources = Directory::create(brioche, &file_resources).await?;
+    Ok(file_resources)
+}

--- a/crates/brioche-core/src/bake/attach_resources.rs
+++ b/crates/brioche-core/src/bake/attach_resources.rs
@@ -17,7 +17,10 @@ pub async fn attach_resources(brioche: &Brioche, directory: &mut Directory) -> a
     // of paths to update, so that each path is processed after all of its
     // dependencies are processed.
     let planned_nodes = petgraph::algo::toposort(petgraph::visit::Reversed(&plan.graph), None)
-        .map_err(|_| anyhow::anyhow!("cycle detected in input"))?;
+        .map_err(|error| {
+            let cycle_node = &plan.graph[error.node_id()];
+            anyhow::anyhow!("resource cycle detected in path: {}", cycle_node.path)
+        })?;
 
     for node_index in planned_nodes {
         let node = &plan.graph[node_index];

--- a/crates/brioche-core/src/input.rs
+++ b/crates/brioche-core/src/input.rs
@@ -524,10 +524,17 @@ fn add_input_plan_indirect_resources(plan: &mut CreateInputPlan) -> anyhow::Resu
             Some((node, resource_path.clone(), resource_node))
         })
         .collect();
+    let mut visited_resource_paths = HashSet::new();
 
     let mut indirect_resources = vec![];
 
-    while let Some((node, resource_path, resource_node)) = resource_paths.pop() {
+    while let Some(visit) = resource_paths.pop() {
+        if !visited_resource_paths.insert(visit.clone()) {
+            continue;
+        }
+
+        let (node, resource_path, resource_node) = visit;
+
         for subresource_edge in plan.graph.edges(resource_node) {
             match subresource_edge.weight() {
                 CreateInputPlanEdge::DirectoryEntry { file_name } => {

--- a/crates/brioche-core/src/recipe.rs
+++ b/crates/brioche-core/src/recipe.rs
@@ -96,7 +96,12 @@ pub enum Recipe {
         file: Box<WithMeta<Recipe>>,
         executable: Option<bool>,
     },
+    #[serde(rename_all = "camelCase")]
     CollectReferences {
+        recipe: Box<WithMeta<Recipe>>,
+    },
+    #[serde(rename_all = "camelCase")]
+    AttachResources {
         recipe: Box<WithMeta<Recipe>>,
     },
     #[serde(rename_all = "camelCase")]
@@ -159,6 +164,7 @@ impl Recipe {
             | Recipe::Glob { .. }
             | Recipe::SetPermissions { .. }
             | Recipe::CollectReferences { .. }
+            | Recipe::AttachResources { .. }
             | Recipe::Proxy(_) => false,
         }
     }
@@ -187,7 +193,7 @@ pub async fn get_recipes(
     // Release the lock
     drop(cached_recipes);
 
-    // Return early if we have no uncached recipess to fetch
+    // Return early if we have no uncached recipes to fetch
     if uncached_recipes.is_empty() {
         return Ok(recipes);
     }
@@ -1044,6 +1050,7 @@ impl TryFrom<Recipe> for Artifact {
             | Recipe::Glob { .. }
             | Recipe::SetPermissions { .. }
             | Recipe::CollectReferences { .. }
+            | Recipe::AttachResources { .. }
             | Recipe::Proxy { .. } => Err(RecipeIncomplete),
         }
     }

--- a/crates/brioche-core/src/references.rs
+++ b/crates/brioche-core/src/references.rs
@@ -133,6 +133,7 @@ pub fn referenced_blobs(recipe: &Recipe) -> Vec<BlobHash> {
         | Recipe::SetPermissions { .. }
         | Recipe::Proxy(_)
         | Recipe::CollectReferences { .. }
+        | Recipe::AttachResources { .. }
         | Recipe::Sync { .. } => vec![],
     }
 }
@@ -264,6 +265,7 @@ pub fn referenced_recipes(recipe: &Recipe) -> Vec<RecipeHash> {
         } => referenced_recipes(file),
         Recipe::Proxy(proxy) => vec![proxy.recipe],
         Recipe::CollectReferences { recipe } => referenced_recipes(recipe),
+        Recipe::AttachResources { recipe } => referenced_recipes(recipe),
         Recipe::Sync { recipe } => referenced_recipes(recipe),
     }
 }

--- a/crates/brioche-core/tests/bake_attach_resources.rs
+++ b/crates/brioche-core/tests/bake_attach_resources.rs
@@ -1,0 +1,354 @@
+use pretty_assertions::assert_eq;
+
+use brioche_core::{blob::BlobHash, recipe::Recipe};
+use brioche_test_support::{bake_without_meta, brioche_test, without_meta};
+
+async fn blob_with_resource_paths(
+    brioche: &brioche_core::Brioche,
+    content: impl AsRef<[u8]>,
+    resource_paths: impl IntoIterator<Item = impl AsRef<[u8]>>,
+) -> BlobHash {
+    let mut content = content.as_ref().to_vec();
+    let resource_paths = resource_paths
+        .into_iter()
+        .map(|path| path.as_ref().to_vec())
+        .collect();
+    brioche_pack::inject_pack(
+        &mut content,
+        &brioche_pack::Pack::Metadata {
+            resource_paths,
+            format: "test".into(),
+            metadata: vec![],
+        },
+    )
+    .expect("failed to inject pack");
+
+    brioche_test_support::blob(brioche, content).await
+}
+
+#[tokio::test]
+async fn test_bake_attach_resources_without_resources() -> anyhow::Result<()> {
+    let (brioche, _context) = brioche_test().await;
+
+    let foo_blob = brioche_test_support::blob(&brioche, b"foo").await;
+    let bar_blob = brioche_test_support::blob(&brioche, b"bar").await;
+    let baz_blob = brioche_test_support::blob(&brioche, b"baz").await;
+
+    let dir = brioche_test_support::dir(
+        &brioche,
+        [
+            ("foo.txt", brioche_test_support::file(foo_blob, false)),
+            ("bar.txt", brioche_test_support::file(bar_blob, true)),
+            (
+                "brioche-resources.d",
+                brioche_test_support::symlink("../brioche-resources.d"),
+            ),
+            (
+                "dir",
+                brioche_test_support::dir(
+                    &brioche,
+                    [("baz.txt", brioche_test_support::file(baz_blob, false))],
+                )
+                .await,
+            ),
+        ],
+    )
+    .await;
+    let recipe = Recipe::AttachResources {
+        recipe: Box::new(without_meta(dir.clone().into())),
+    };
+
+    let output = bake_without_meta(&brioche, recipe).await?;
+    assert_eq!(output, dir);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_bake_attach_resources_add_all_resources() -> anyhow::Result<()> {
+    let (brioche, _context) = brioche_test().await;
+
+    let foo_blob = blob_with_resource_paths(&brioche, b"foo", ["fizz/a"]).await;
+    let bar_blob = blob_with_resource_paths(&brioche, b"bar", ["fizz/b", "fizz/c", "d.txt"]).await;
+    let baz_blob = blob_with_resource_paths(&brioche, b"baz", ["fizz/c", "buzz", "e.lnk"]).await;
+
+    let a_blob = brioche_test_support::blob(&brioche, b"a").await;
+    let b_blob = brioche_test_support::blob(&brioche, b"b").await;
+    let c_blob = brioche_test_support::blob(&brioche, b"c").await;
+    let d_blob = brioche_test_support::blob(&brioche, b"d").await;
+    let e_blob = brioche_test_support::blob(&brioche, b"e").await;
+
+    let dir = brioche_test_support::dir(
+        &brioche,
+        [
+            ("foo.txt", brioche_test_support::file(foo_blob, false)),
+            ("bar.txt", brioche_test_support::file(bar_blob, true)),
+            ("dir/baz.txt", brioche_test_support::file(baz_blob, false)),
+            (
+                "brioche-resources.d",
+                brioche_test_support::dir(
+                    &brioche,
+                    [
+                        ("fizz/a", brioche_test_support::file(a_blob, false)),
+                        ("fizz/b", brioche_test_support::file(b_blob, true)),
+                        ("fizz/c", brioche_test_support::file(c_blob, false)),
+                        ("buzz/a.txt", brioche_test_support::symlink("../fizz/a")),
+                        (
+                            "buzz/b.txt",
+                            brioche_test_support::symlink("../fizz/broken.txt"),
+                        ),
+                        ("buzz/d.txt", brioche_test_support::symlink("../d.txt")),
+                        ("d.txt", brioche_test_support::file(d_blob, false)),
+                        ("d.lnk", brioche_test_support::symlink("d.txt")),
+                        ("e.txt", brioche_test_support::file(e_blob, false)),
+                        ("e.lnk", brioche_test_support::symlink("e.txt")),
+                    ],
+                )
+                .await,
+            ),
+        ],
+    )
+    .await;
+    let recipe = Recipe::AttachResources {
+        recipe: Box::new(without_meta(dir.clone().into())),
+    };
+
+    let expected_output = brioche_test_support::dir(
+        &brioche,
+        [
+            (
+                "foo.txt",
+                brioche_test_support::file_with_resources(
+                    foo_blob,
+                    false,
+                    brioche_test_support::dir_value(
+                        &brioche,
+                        [("fizz/a", brioche_test_support::file(a_blob, false))],
+                    )
+                    .await,
+                ),
+            ),
+            (
+                "bar.txt",
+                brioche_test_support::file_with_resources(
+                    bar_blob,
+                    true,
+                    brioche_test_support::dir_value(
+                        &brioche,
+                        [
+                            ("fizz/b", brioche_test_support::file(b_blob, true)),
+                            ("fizz/c", brioche_test_support::file(c_blob, false)),
+                            ("d.txt", brioche_test_support::file(d_blob, false)),
+                        ],
+                    )
+                    .await,
+                ),
+            ),
+            (
+                "dir",
+                brioche_test_support::dir(
+                    &brioche,
+                    [(
+                        "baz.txt",
+                        brioche_test_support::file_with_resources(
+                            baz_blob,
+                            false,
+                            brioche_test_support::dir_value(
+                                &brioche,
+                                [
+                                    ("fizz/a", brioche_test_support::file(a_blob, false)),
+                                    ("fizz/c", brioche_test_support::file(c_blob, false)),
+                                    ("buzz/a.txt", brioche_test_support::symlink("../fizz/a")),
+                                    (
+                                        "buzz/b.txt",
+                                        brioche_test_support::symlink("../fizz/broken.txt"),
+                                    ),
+                                    ("buzz/d.txt", brioche_test_support::symlink("../d.txt")),
+                                    ("d.txt", brioche_test_support::file(d_blob, false)),
+                                    ("e.txt", brioche_test_support::file(e_blob, false)),
+                                    ("e.lnk", brioche_test_support::symlink("e.txt")),
+                                ],
+                            )
+                            .await,
+                        ),
+                    )],
+                )
+                .await,
+            ),
+            (
+                "brioche-resources.d",
+                brioche_test_support::dir(
+                    &brioche,
+                    [
+                        ("fizz/a", brioche_test_support::file(a_blob, false)),
+                        ("fizz/b", brioche_test_support::file(b_blob, true)),
+                        ("fizz/c", brioche_test_support::file(c_blob, false)),
+                        ("buzz/a.txt", brioche_test_support::symlink("../fizz/a")),
+                        (
+                            "buzz/b.txt",
+                            brioche_test_support::symlink("../fizz/broken.txt"),
+                        ),
+                        ("buzz/d.txt", brioche_test_support::symlink("../d.txt")),
+                        ("d.txt", brioche_test_support::file(d_blob, false)),
+                        ("d.lnk", brioche_test_support::symlink("d.txt")),
+                        ("e.txt", brioche_test_support::file(e_blob, false)),
+                        ("e.lnk", brioche_test_support::symlink("e.txt")),
+                    ],
+                )
+                .await,
+            ),
+        ],
+    )
+    .await;
+
+    let output = bake_without_meta(&brioche, recipe).await?;
+
+    assert_eq!(output, expected_output);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_bake_attach_resources_remove_unused_resources() -> anyhow::Result<()> {
+    let (brioche, _context) = brioche_test().await;
+
+    let foo_blob = brioche_test_support::blob(&brioche, b"foo").await;
+    let bar_blob = brioche_test_support::blob(&brioche, b"bar").await;
+    let baz_blob = brioche_test_support::blob(&brioche, b"baz").await;
+
+    let a_blob = brioche_test_support::blob(&brioche, b"a").await;
+    let b_blob = brioche_test_support::blob(&brioche, b"b").await;
+    let c_blob = brioche_test_support::blob(&brioche, b"c").await;
+    let d_blob = brioche_test_support::blob(&brioche, b"d").await;
+    let e_blob = brioche_test_support::blob(&brioche, b"e").await;
+
+    let dir = brioche_test_support::dir(
+        &brioche,
+        [
+            (
+                "foo.txt",
+                brioche_test_support::file_with_resources(
+                    foo_blob,
+                    false,
+                    brioche_test_support::dir_value(
+                        &brioche,
+                        [("fizz/a", brioche_test_support::file(a_blob, false))],
+                    )
+                    .await,
+                ),
+            ),
+            (
+                "bar.txt",
+                brioche_test_support::file_with_resources(
+                    bar_blob,
+                    true,
+                    brioche_test_support::dir_value(
+                        &brioche,
+                        [
+                            ("fizz/b", brioche_test_support::file(b_blob, true)),
+                            ("fizz/c", brioche_test_support::file(c_blob, false)),
+                            ("d.txt", brioche_test_support::file(d_blob, false)),
+                        ],
+                    )
+                    .await,
+                ),
+            ),
+            (
+                "dir",
+                brioche_test_support::dir(
+                    &brioche,
+                    [(
+                        "baz.txt",
+                        brioche_test_support::file_with_resources(
+                            baz_blob,
+                            false,
+                            brioche_test_support::dir_value(
+                                &brioche,
+                                [
+                                    ("fizz/a", brioche_test_support::file(a_blob, false)),
+                                    ("fizz/c", brioche_test_support::file(c_blob, false)),
+                                    ("buzz/a.txt", brioche_test_support::symlink("../fizz/a")),
+                                    (
+                                        "buzz/b.txt",
+                                        brioche_test_support::symlink("../fizz/broken.txt"),
+                                    ),
+                                    ("buzz/d.txt", brioche_test_support::symlink("../d.txt")),
+                                    ("d.txt", brioche_test_support::file(d_blob, false)),
+                                    ("e.txt", brioche_test_support::file(e_blob, false)),
+                                    ("e.lnk", brioche_test_support::symlink("e.txt")),
+                                ],
+                            )
+                            .await,
+                        ),
+                    )],
+                )
+                .await,
+            ),
+            (
+                "brioche-resources.d",
+                brioche_test_support::dir(
+                    &brioche,
+                    [
+                        ("fizz/a", brioche_test_support::file(a_blob, false)),
+                        ("fizz/b", brioche_test_support::file(b_blob, true)),
+                        ("fizz/c", brioche_test_support::file(c_blob, false)),
+                        ("buzz/a.txt", brioche_test_support::symlink("../fizz/a")),
+                        (
+                            "buzz/b.txt",
+                            brioche_test_support::symlink("../fizz/broken.txt"),
+                        ),
+                        ("buzz/d.txt", brioche_test_support::symlink("../d.txt")),
+                        ("d.txt", brioche_test_support::file(d_blob, false)),
+                        ("d.lnk", brioche_test_support::symlink("d.txt")),
+                        ("e.txt", brioche_test_support::file(e_blob, false)),
+                        ("e.lnk", brioche_test_support::symlink("e.txt")),
+                    ],
+                )
+                .await,
+            ),
+        ],
+    )
+    .await;
+
+    let recipe = Recipe::AttachResources {
+        recipe: Box::new(without_meta(dir.clone().into())),
+    };
+
+    let expected_output = brioche_test_support::dir(
+        &brioche,
+        [
+            ("foo.txt", brioche_test_support::file(foo_blob, false)),
+            ("bar.txt", brioche_test_support::file(bar_blob, true)),
+            ("dir/baz.txt", brioche_test_support::file(baz_blob, false)),
+            (
+                "brioche-resources.d",
+                brioche_test_support::dir(
+                    &brioche,
+                    [
+                        ("fizz/a", brioche_test_support::file(a_blob, false)),
+                        ("fizz/b", brioche_test_support::file(b_blob, true)),
+                        ("fizz/c", brioche_test_support::file(c_blob, false)),
+                        ("buzz/a.txt", brioche_test_support::symlink("../fizz/a")),
+                        (
+                            "buzz/b.txt",
+                            brioche_test_support::symlink("../fizz/broken.txt"),
+                        ),
+                        ("buzz/d.txt", brioche_test_support::symlink("../d.txt")),
+                        ("d.txt", brioche_test_support::file(d_blob, false)),
+                        ("d.lnk", brioche_test_support::symlink("d.txt")),
+                        ("e.txt", brioche_test_support::file(e_blob, false)),
+                        ("e.lnk", brioche_test_support::symlink("e.txt")),
+                    ],
+                )
+                .await,
+            ),
+        ],
+    )
+    .await;
+
+    let output = bake_without_meta(&brioche, recipe).await?;
+
+    assert_eq!(output, expected_output);
+
+    Ok(())
+}

--- a/crates/brioche-test-support/src/lib.rs
+++ b/crates/brioche-test-support/src/lib.rs
@@ -133,6 +133,9 @@ pub async fn load_rootfs_recipes(brioche: &Brioche, platform: brioche_core::plat
             Recipe::CollectReferences { recipe } => {
                 recipes.push_back(recipe.value);
             }
+            Recipe::AttachResources { recipe } => {
+                recipes.push_back(recipe.value);
+            }
             Recipe::Proxy(_) => unimplemented!(),
             Recipe::Sync { recipe } => {
                 recipes.push_back(recipe.value);


### PR DESCRIPTION
This PR adds a new `attach_resources` recipe. It takes a directory recipe, finds all files with resources, then tries to resolve the resources by looking for a `brioche-resources.d` directory. This is effectively the opposite operation from `collect_references` introduced in #57.

The main motivation for this change was while I was investigating #147. As outlined in [this comment](https://github.com/brioche-dev/brioche/issues/147#issuecomment-2543982526), the short-term plan was to tar then untar the `std.toolchain()` recipe. `collect_references` is suitable for tarring, but we needed an operation to re-add resources back into a recipe after untarring.

Locally, here's a little function I've been playing with, which I think will do the job:

```typescript

/**
 * Sync a recipe by creating an archive of it, then unarchiving it. When
 * fetched from the registry, the recipe will be downloaded as a single
 * compressed tarball, which may be faster than syncing lots of individual
 * files.
 */
function syncTarball(
  recipe: std.AsyncRecipe<std.Directory>,
): std.Recipe<std.Directory> {
  recipe = std.collectReferences(std.directory({ recipe }));

  const tarredRecipe = std
    .process({
      command: "tar",
      args: [
        "--zstd",
        "-cf",
        std.outputPath,
        "--hard-dereference",
        "-C",
        recipe,
        ".",
      ],
      dependencies: [tar(), zstd()],
    })
    .toFile();

  let untarredRecipe = tarredRecipe.unarchive("tar", "zstd");
  untarredRecipe = std.attachResources(untarredRecipe);
  //    new recipe ^^^^^^^^^^^^^^^^^^^

  return std.castToDirectory(untarredRecipe.get("recipe"));
}
```