### PR TITLE
Add initial support for `aarch64-linux`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,13 @@ jobs:
           - name: x86_64-linux
             runs_on: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
+          - name: aarch64-linux
+            runs_on: ubuntu-22.04
+            target: aarch64-unknown-linux-gnu
+            features: openssl/vendored
+            install_deps: |
+              sudo apt-get install -y gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu
+              echo 'CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc' >> $GITHUB_ENV
           - name: x86_64-macos
             runs_on: macos-14
             target: x86_64-apple-darwin
@@ -83,19 +90,28 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      - name: Install dependencies
+        if: matrix.platform.install_deps
+        run: ${{ matrix.platform.install_deps }}
       - name: Install Rust targets
         run: rustup target add "$TARGET"
         env:
           TARGET: ${{ matrix.platform.target }}
       - name: Build Brioche
         run: |
-            cargo build \
-              --all \
-              --bin brioche \
-              --release \
-              --target="$TARGET"
+          extra_args=()
+          if [ -n "$FEATURES" ]; then
+            extra_args+=(--features "$FEATURES")
+          fi
+          cargo build \
+            --all \
+            --bin brioche \
+            --release \
+            --target="$TARGET" \
+            "${extra_args[@]}"
         env:
           TARGET: ${{ matrix.platform.target }}
+          FEATURES: ${{ matrix.platform.features }}
       - name: Prepare artifact
         run: |
           mkdir -p "artifacts/brioche/$PLATFORM/"
@@ -129,6 +145,11 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: brioche-x86_64-linux
+          path: artifacts/brioche
+      - name: Download artifacts (aarch64-linux)
+        uses: actions/download-artifact@v4
+        with:
+          name: brioche-aarch64-linux
           path: artifacts/brioche
       - name: Download artifacts (x86_64-macos)
         uses: actions/download-artifact@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -817,6 +817,7 @@ dependencies = [
  "futures",
  "hex",
  "notify",
+ "openssl",
  "reqwest",
  "serde",
  "serde_json",

--- a/crates/brioche-core/src/bake/process.rs
+++ b/crates/brioche-core/src/bake/process.rs
@@ -1357,5 +1357,25 @@ pub fn process_rootfs_recipes(platform: crate::platform::Platform) -> ProcessRoo
 
             ProcessRootfsRecipes { sh, env }
         }
+        crate::platform::Platform::Aarch64Linux => {
+            let sh = Recipe::Unarchive(Unarchive {
+                archive: ArchiveFormat::Tar,
+                compression: CompressionFormat::Zstd,
+                file: Box::new(WithMeta::without_meta(Recipe::Download(DownloadRecipe {
+                    url: "https://development-content.brioche.dev/github.com/tangramdotdev/bootstrap/2023-07-06/dash_arm64_linux.tar.zstd".parse().unwrap(),
+                    hash: crate::Hash::Sha256 { value: hex::decode("29ac173dee09ff377fd49d3451a382d79273c79780b8841c9860dfc2d4b353d2").unwrap() }
+                }))),
+            });
+            let env = Recipe::Unarchive(Unarchive {
+                archive: ArchiveFormat::Tar,
+                compression: CompressionFormat::Zstd,
+                file: Box::new(WithMeta::without_meta(Recipe::Download(DownloadRecipe {
+                    url: "https://development-content.brioche.dev/github.com/tangramdotdev/bootstrap/2023-07-06/env_arm64_linux.tar.zstd".parse().unwrap(),
+                    hash: crate::Hash::Sha256 { value: hex::decode("0b84d04b2768b6803aee78da8d54393ccbfe8730950b3cc305e8347fff5ad3d7").unwrap() }
+                }))),
+            });
+
+            ProcessRootfsRecipes { sh, env }
+        }
     }
 }

--- a/crates/brioche-core/src/bake/process.rs
+++ b/crates/brioche-core/src/bake/process.rs
@@ -291,6 +291,13 @@ pub async fn bake_process(
     meta: &Arc<Meta>,
     process: CompleteProcessRecipe,
 ) -> anyhow::Result<Artifact> {
+    let current_platform = crate::platform::current_platform();
+    anyhow::ensure!(
+        process.platform == current_platform,
+        "tried to bake process for platform {}, but only {current_platform} is supported",
+        process.platform,
+    );
+
     tracing::debug!("acquiring process semaphore permit");
     let _permit = brioche.process_semaphore.acquire().await;
     tracing::debug!("acquired process semaphore permit");

--- a/crates/brioche-core/src/platform.rs
+++ b/crates/brioche-core/src/platform.rs
@@ -13,11 +13,15 @@
 pub enum Platform {
     #[strum(serialize = "x86_64-linux")]
     X86_64Linux,
+    #[strum(serialize = "aarch64-linux")]
+    Aarch64Linux,
 }
 
 pub fn current_platform() -> Platform {
     if cfg!(all(target_os = "linux", target_arch = "x86_64")) {
         Platform::X86_64Linux
+    } else if cfg!(all(target_os = "linux", target_arch = "aarch64")) {
+        Platform::Aarch64Linux
     } else {
         unimplemented!("unsupported platform");
     }

--- a/crates/brioche/Cargo.toml
+++ b/crates/brioche/Cargo.toml
@@ -12,6 +12,7 @@ clap = { version = "4.5.21", features = ["derive"] }
 futures = "0.3.31"
 hex = "0.4.3"
 notify = "7.0.0"
+openssl = { version = "0.10.68", optional = true }
 reqwest = { version = "0.12.9", default-features = false, features = ["rustls-tls", "zstd", "json"] }
 serde = { version = "1.0.215", features = ["derive"] }
 serde_json = "1.0.133"


### PR DESCRIPTION
This PR adds initial support for process recipes with `aarch64-linux` as a platform. This basically entailed 3 minor changes:

1. Added `aarch64-linux` as a new platform enum, which can be returned by the `current_platform` function.
2. Added process rootfs recipes for `aarch64-linux`. These were pre-existing downloads that were already saved under the `development-content.brioche.dev` site, so it was just a matter of selecting the right URL and hash based on the platform.
3. Tweaked the `bake_process` function to validate the platform. This was an oversight where there was no validation that we were actually building for the platform specified by the `platform` field in the process recipe!

Also as part of this PR, I updated the CI/CD pipeline to build Brioche for `aarch64-linux`