### PR TITLE
Update GitHub Actions workflow to use Ubuntu 22.04 for build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,7 @@ jobs:
     strategy:
       matrix:
         platform:
+          - runs_on: ubuntu-22.04
           - runs_on: ubuntu-24.04
             # Allow unprivileged user namespaces
             setup: |
@@ -78,10 +79,10 @@ jobs:
       matrix:
         platform:
           - name: x86_64-linux
-            runs_on: ubuntu-24.04
+            runs_on: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
           - name: aarch64-linux
-            runs_on: ubuntu-24.04
+            runs_on: ubuntu-22.04
             target: aarch64-unknown-linux-gnu
             features: openssl/vendored
             install_deps: |


### PR DESCRIPTION
After merging #151, I caught a build failure in the `brioche-packages` repo (still using Ubuntu 22.04 currently). The build failure looked to be caused by the latest Brioche build depending on a newer version of glibc. As a simple workaround, this PR updates the GitHub Actions workflow so the Brioche binary is once again built on Ubuntu 22.04 instead of Ubuntu 24.04.

Other workflows still use Ubuntu 24.04 as appropriate, and additionally tests now run with both Ubuntu 22.04 and 24.04.

Once #51 is addressed, this should no longer be an issue (as Brioche itself would no longer directly depend on the system's glibc).