### PR TITLE
Add `project.bri` to build Brioche with Brioche

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,4 +2,3 @@
 brioche.lock linguist-generated
 crates/brioche/runtime/dist/** linguist-generated
 **/.sqlx/query-*.json linguist-generated
-

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,5 @@
+*.bri linguist-language=TypeScript
+brioche.lock linguist-generated
 crates/brioche/runtime/dist/** linguist-generated
+**/.sqlx/query-*.json linguist-generated
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,10 +143,43 @@ jobs:
           name: brioche-${{ matrix.platform.name }}
           if-no-files-found: error
           path: artifacts/brioche
+  build-packed:
+    name: Build packed artifacts
+    if: github.event_name == 'push'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Install Brioche
+        uses: brioche-dev/setup-brioche@v1
+      - name: Build Brioche
+        run: brioche build -o "brioche-packed-$PLATFORM"
+        env:
+          PLATFORM: x86_64-linux
+      - name: Prepare artifact
+        run: |
+          mkdir -p "artifacts/brioche-packed/$PLATFORM"
+          tar -czf "artifacts/brioche-packed/$PLATFORM/brioche-packed-$PLATFORM.tar.gz" "brioche-packed-$PLATFORM"
+
+          if command -v sha256sum &> /dev/null; then
+            find artifacts/ -type f | xargs sha256sum
+          fi
+
+          if command -v tree &> /dev/null; then
+            tree --du -h artifacts/brioche-packed
+          fi
+        env:
+          PLATFORM: x86_64-linux
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: brioche-packed-x86_64-linux
+          if-no-files-found: error
+          path: artifacts/brioche-packed
   push:
     name: Push artifacts
     if: github.event_name == 'push' && github.repository == 'brioche-dev/brioche'
-    needs: [check, test, build]
+    needs: [check, test, build, build-packed]
     runs-on: ubuntu-24.04
     steps:
       - name: Download artifacts (x86_64-linux)
@@ -169,11 +202,17 @@ jobs:
         with:
           name: brioche-aarch64-macos
           path: artifacts/brioche
+      - name: Download artifacts (x86_64-linux packed)
+        uses: actions/download-artifact@v4
+        with:
+          name: brioche-aarch64-macos
+          path: artifacts/brioche-packed
       # Upload the Brioche build for the current branch
       - name: Prepare upload
         run: |
-          mkdir -p artifacts/uploads/branch
+          mkdir -p artifacts/uploads/branch/brioche-packed
           cp -r artifacts/brioche/* artifacts/uploads/branch/
+          cp -r artifacts/brioche-packed/* artifacts/uploads/branch/brioche-packed/
 
           if command -v tree &> /dev/null; then
             tree --du -h artifacts/uploads/branch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,7 +205,7 @@ jobs:
       - name: Download artifacts (x86_64-linux packed)
         uses: actions/download-artifact@v4
         with:
-          name: brioche-aarch64-macos
+          name: brioche-packed-x86_64-linux
           path: artifacts/brioche-packed
       # Upload the Brioche build for the current branch
       - name: Prepare upload

--- a/brioche.lock
+++ b/brioche.lock
@@ -2,7 +2,15 @@
   "dependencies": {
     "ca_certificates": "6e25a5d737897f500ff5ed01159c8c90b0fc6496d69db89f9617a2424603cbc9",
     "curl": "dd37c7127fb3c7918f1e2bf0a73b9851d80def1205f1eda29c2461826bf2dd6e",
+    "git": "848d5148de450be55bd605bc358d4cb71cc56d338cdd052d95c741e3190606a8",
+    "nodejs": "f78af6398a48d14f561dddcc6f9054bb1c710374612f6a31152d5a0c3cb70b1c",
+    "openssl": "28463868d3bab04a0bfa662fa611853cdf8e16af85f333f9878a5f993926c20e",
     "rust": "3d71bbee074f71ddf642458b25cb31276dd315dbe960039da295a03ddcce5218",
     "std": "c61485184862a8ed1ec3fc12f3a6f5ea91c32b6f450cbe81cbc596c0c7e2a06d"
+  },
+  "git_refs": {
+    "https://github.com/launchbadge/sqlx.git": {
+      "v0.7.4": "635dba5b2682033101a1271e9fb4bf2516c0b840"
+    }
   }
 }

--- a/brioche.lock
+++ b/brioche.lock
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "ca_certificates": "6e25a5d737897f500ff5ed01159c8c90b0fc6496d69db89f9617a2424603cbc9",
+    "curl": "dd37c7127fb3c7918f1e2bf0a73b9851d80def1205f1eda29c2461826bf2dd6e",
+    "rust": "3d71bbee074f71ddf642458b25cb31276dd315dbe960039da295a03ddcce5218",
+    "std": "c61485184862a8ed1ec3fc12f3a6f5ea91c32b6f450cbe81cbc596c0c7e2a06d"
+  }
+}

--- a/project.bri
+++ b/project.bri
@@ -6,13 +6,21 @@ import nodejs, { npmInstall } from "nodejs";
 import { gitCheckout } from "git";
 import openssl from "openssl";
 
+/**
+ * Returns a recipe to build Brioche itself.
+ */
 export default function (): std.Recipe<std.Directory> {
   let source = Brioche.glob(
+    // Cargo project files
     "crates/**/*.rs",
     "**/Cargo.toml",
     "Cargo.lock",
+
+    // SQLx files
     "crates/brioche-core/.sqlx",
     "crates/brioche-core/migrations",
+
+    // JS runtime files
     "crates/brioche-core/runtime/package.json",
     "crates/brioche-core/runtime/package-lock.json",
     "crates/brioche-core/runtime/tsconfig.json",
@@ -20,6 +28,8 @@ export default function (): std.Recipe<std.Directory> {
     "crates/brioche-core/runtime/src",
     "crates/brioche-core/runtime/tslib",
     "crates/brioche-core/runtime/dist",
+
+    // Makefiles for miscellaneous tasks
     "**/Makefile",
   );
   source = validateRuntime(source);
@@ -38,6 +48,10 @@ export default function (): std.Recipe<std.Directory> {
   });
 }
 
+/**
+ * Use the SQLx CLI to validate that the prepared SQLx metadata is up-to-date
+ * with all of the database migrations and queries.
+ */
 function validateSqlxMetadata(
   source: std.Recipe<std.Directory>,
 ): std.Recipe<std.Directory> {
@@ -63,6 +77,11 @@ function validateSqlxMetadata(
   });
 }
 
+/**
+ * Validate that the source of the JS runtime project under
+ * `crates/brioche-core/runtime` matches the output `dist/` directory.
+ * This ensures the source and build don't go out of sync.
+ */
 function validateRuntime(
   source: std.Recipe<std.Directory>,
 ): std.Recipe<std.Directory> {
@@ -83,6 +102,11 @@ function validateRuntime(
   });
 }
 
+/**
+ * Build the JS runtime project under `crates/brioche-core/runtime`. Returns
+ * the built directory, which is expected to be stored under the directory
+ * `crates/brioche-core/runtime/dist`.
+ */
 export function runtime(): std.Recipe<std.Directory> {
   const source = Brioche.glob(
     "crates/brioche-core/runtime/package.json",
@@ -124,6 +148,15 @@ interface ValidateOptions {
   validation: std.Recipe<std.Directory>;
 }
 
+/**
+ * Add a validation to a recipe. When the recipe is baked, the validation
+ * will also be baked, and will fail if the validation fails. The validation
+ * should be a process recipe that returns an empty directory on success.
+ *
+ * Internally, this just merges the validation and recipe results together.
+ * This results in a new recipe that depends on both the original recipe
+ * and the validation.
+ */
 function validate(options: ValidateOptions): std.Recipe<std.Directory> {
   return std.merge(options.validation, options.recipe);
 }

--- a/project.bri
+++ b/project.bri
@@ -1,0 +1,25 @@
+import * as std from "std";
+import { cargoBuild } from "rust";
+import curl from "curl";
+import caCertificates from "ca_certificates";
+
+export default function (): std.Recipe<std.Directory> {
+  return cargoBuild({
+    source: Brioche.glob(
+      "crates/**/*.rs",
+      "**/Cargo.toml",
+      "Cargo.lock",
+      "crates/brioche-core/.sqlx",
+      "crates/brioche-core/migrations",
+      "crates/brioche-core/runtime",
+    ),
+    path: "crates/brioche",
+    runnable: "bin/brioche",
+
+    // Network access is used for vendoring libraries (e.g. V8)
+    unsafe: {
+      networking: true,
+    },
+    dependencies: [curl(), caCertificates()],
+  });
+}

--- a/project.bri
+++ b/project.bri
@@ -1,18 +1,32 @@
 import * as std from "std";
-import { cargoBuild } from "rust";
+import rust, { cargoBuild, vendorCrate } from "rust";
 import curl from "curl";
 import caCertificates from "ca_certificates";
+import nodejs, { npmInstall } from "nodejs";
+import { gitCheckout } from "git";
+import openssl from "openssl";
 
 export default function (): std.Recipe<std.Directory> {
+  let source = Brioche.glob(
+    "crates/**/*.rs",
+    "**/Cargo.toml",
+    "Cargo.lock",
+    "crates/brioche-core/.sqlx",
+    "crates/brioche-core/migrations",
+    "crates/brioche-core/runtime/package.json",
+    "crates/brioche-core/runtime/package-lock.json",
+    "crates/brioche-core/runtime/tsconfig.json",
+    "crates/brioche-core/runtime/build.ts",
+    "crates/brioche-core/runtime/src",
+    "crates/brioche-core/runtime/tslib",
+    "crates/brioche-core/runtime/dist",
+    "**/Makefile",
+  );
+  source = validateRuntime(source);
+  source = validateSqlxMetadata(source);
+
   return cargoBuild({
-    source: Brioche.glob(
-      "crates/**/*.rs",
-      "**/Cargo.toml",
-      "Cargo.lock",
-      "crates/brioche-core/.sqlx",
-      "crates/brioche-core/migrations",
-      "crates/brioche-core/runtime",
-    ),
+    source,
     path: "crates/brioche",
     runnable: "bin/brioche",
 
@@ -22,4 +36,94 @@ export default function (): std.Recipe<std.Directory> {
     },
     dependencies: [curl(), caCertificates()],
   });
+}
+
+function validateSqlxMetadata(
+  source: std.Recipe<std.Directory>,
+): std.Recipe<std.Directory> {
+  const vendoredSource = vendorCrate({ source });
+
+  // Run `make check-db-schema` to ensure the database schema is up-to-date.
+  return validate({
+    recipe: source,
+    validation: std.runBash`
+      make check-db-schema
+    `
+      .workDir(vendoredSource)
+      .dependencies(
+        rust(),
+        sqlxCli(),
+        std.toolchain(),
+        curl(),
+        caCertificates(),
+      )
+      .unsafe({ networking: true })
+      .outputScaffold(std.directory())
+      .toDirectory(),
+  });
+}
+
+function validateRuntime(
+  source: std.Recipe<std.Directory>,
+): std.Recipe<std.Directory> {
+  return validate({
+    recipe: source,
+    validation: std.runBash`
+      if ! diff -r "$current_runtime" "$runtime"; then
+        echo "Error: 'crates/brioche-core/runtime/dist' does not match!" >&2
+        exit 1
+      fi
+    `
+      .env({
+        current_runtime: source.get("crates/brioche-core/runtime/dist"),
+        runtime: runtime(),
+      })
+      .outputScaffold(std.directory())
+      .toDirectory(),
+  });
+}
+
+export function runtime(): std.Recipe<std.Directory> {
+  const source = Brioche.glob(
+    "crates/brioche-core/runtime/package.json",
+    "crates/brioche-core/runtime/package-lock.json",
+    "crates/brioche-core/runtime/tsconfig.json",
+    "crates/brioche-core/runtime/build.ts",
+    "crates/brioche-core/runtime/src",
+    "crates/brioche-core/runtime/tslib",
+  ).peel(3);
+  const npmPackage = npmInstall({ source });
+
+  return std.runBash`
+    npm run build
+    mv dist "$BRIOCHE_OUTPUT"
+  `
+    .dependencies(nodejs())
+    .workDir(npmPackage)
+    .toDirectory();
+}
+
+export function sqlxCli() {
+  const source = gitCheckout(
+    Brioche.gitRef({
+      repository: "https://github.com/launchbadge/sqlx.git",
+      ref: "v0.7.4",
+    }),
+  );
+
+  return cargoBuild({
+    source,
+    path: "sqlx-cli",
+    dependencies: [openssl()],
+    runnable: "bin/sqlx",
+  });
+}
+
+interface ValidateOptions {
+  recipe: std.Recipe<std.Directory>;
+  validation: std.Recipe<std.Directory>;
+}
+
+function validate(options: ValidateOptions): std.Recipe<std.Directory> {
+  return std.merge(options.validation, options.recipe);
 }


### PR DESCRIPTION
Part of #51

This PR adds a `project.bri` file to the repo root, which defines a [Brioche project](https://brioche.dev/docs/core-concepts/projects/) for Brioche itself. Running `brioche build` within the repo will build a full release build of Brioche.

Since this build is built with Brioche, this packs Brioche itself as a [packed executable](https://brioche.dev/docs/how-it-works/packed-executables/)! The result should be able to run on any x86-64 Linux environment, even those without a normal glibc environment (e.g. Alpine, NixOS, etc).

This PR also updates the GitHub Actions workflow to run the build, and also to upload it as a tarball under `https://development-content.brioche.dev` (although I'd strongly recommend _not_ directly referring to this URL for anything important!)

There are also a few helpful tools exported in `project.bri`:

- `runtime`: Builds the runtime NPM project under `crates/brioche-core/runtime`
  - Example: update the `dist/` directory in the repo: `brioche build -e runtime -o crates/brioche-core/runtime/dist --replace`
- `sqlxCli`: Builds the SQLx CLI, which is useful for creating and running migrations, etc.
  - Example: `brioche run -e sqlxCli -- migrate add some_new_migration` 