### PR TITLE
Disable self-update command in packed Brioche builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,10 @@ jobs:
             echo "Re-run 'npm run build' and commit the results" >&2
             exit 1
           fi
+      - name: Check Brioche project
+        run: |
+          brioche check
+          brioche fmt --check
   test:
     name: Run tests
     strategy:
@@ -167,7 +171,7 @@ jobs:
       - name: Install Brioche
         uses: brioche-dev/setup-brioche@v1
       - name: Build Brioche
-        run: brioche build -o "brioche-packed-$PLATFORM"
+        run: brioche build --check -o "brioche-packed-$PLATFORM"
         env:
           PLATFORM: x86_64-linux
       - name: Prepare artifact

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,8 @@ jobs:
             echo "Re-run 'npm run build' and commit the results" >&2
             exit 1
           fi
+      - name: Install Brioche
+        uses: brioche-dev/setup-brioche@v1
       - name: Check Brioche project
         run: |
           brioche check

--- a/brioche.lock
+++ b/brioche.lock
@@ -1,12 +1,12 @@
 {
   "dependencies": {
-    "ca_certificates": "6e25a5d737897f500ff5ed01159c8c90b0fc6496d69db89f9617a2424603cbc9",
-    "curl": "dd37c7127fb3c7918f1e2bf0a73b9851d80def1205f1eda29c2461826bf2dd6e",
-    "git": "848d5148de450be55bd605bc358d4cb71cc56d338cdd052d95c741e3190606a8",
-    "nodejs": "f78af6398a48d14f561dddcc6f9054bb1c710374612f6a31152d5a0c3cb70b1c",
-    "openssl": "28463868d3bab04a0bfa662fa611853cdf8e16af85f333f9878a5f993926c20e",
-    "rust": "3d71bbee074f71ddf642458b25cb31276dd315dbe960039da295a03ddcce5218",
-    "std": "c61485184862a8ed1ec3fc12f3a6f5ea91c32b6f450cbe81cbc596c0c7e2a06d"
+    "ca_certificates": "06b40a3e2420c8169e081f76fc1bc99331cea0b944d7e96f69ca9f437f3c59e5",
+    "curl": "1c5afae754f3ad2b04d37dbc8666fac4c7fd826106ccde88c1c73f3c118a82a6",
+    "git": "5df81144d4d14dee789e3205c6c0ce5ea6a32e9bd7e7483cfba38b913c4ea097",
+    "nodejs": "777592fa0267a7d43ae844e2bed600b00bc50badb41b61094d0f04dc6bc6af25",
+    "openssl": "d3dd51deee9e45d0ca79be2484cc0018a6bd7445ad03f0e6970c61a255a10fc7",
+    "rust": "4352c62ebb3888443bdec518c527bd6e2c31fd6410239e11dbca76a1dc29bfbc",
+    "std": "a99b036cb234ab94b35a4a7c1bc68f0ea8d46061455b980022c4dcda948e0752"
   },
   "git_refs": {
     "https://github.com/launchbadge/sqlx.git": {

--- a/crates/brioche/Cargo.toml
+++ b/crates/brioche/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.3"
 edition = "2021"
 default-run = "brioche"
 
+[features]
+default = ["self-update"]
+self-update = []
+
 [dependencies]
 anyhow = { version = "1.0.95", features = ["backtrace"] }
 brioche-core = { path = "../brioche-core" }

--- a/crates/brioche/src/self_update.rs
+++ b/crates/brioche/src/self_update.rs
@@ -43,6 +43,11 @@ pub async fn self_update(args: SelfUpdateArgs) -> anyhow::Result<bool> {
     println!("  Platform: {platform}");
     println!("  Path: {}", brioche_path.display());
 
+    if !cfg!(feature = "self-update") {
+        println!("Self-updating is is disabled for this version of Brioche, please visit https://brioche.dev/help/manual-update for instructions on updating to the latest version");
+        return Ok(false);
+    }
+
     let should_update = if args.confirm {
         true
     } else {

--- a/crates/brioche/src/self_update.rs
+++ b/crates/brioche/src/self_update.rs
@@ -15,7 +15,9 @@ pub struct SelfUpdateArgs {
     confirm: bool,
 }
 
-const MANIFEST_URL: &str = "https://releases.brioche.dev/updates/update-manifest-v1.json";
+const CUSTOM_UPDATE_MANIFEST_URL: Option<&str> = option_env!("BRIOCHE_CUSTOM_UPDATE_MANIFEST_URL");
+
+const UPDATE_MANIFEST_URL: &str = "https://releases.brioche.dev/updates/update-manifest-v1.json";
 
 const CURRENT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
@@ -114,9 +116,16 @@ pub async fn self_update(args: SelfUpdateArgs) -> anyhow::Result<bool> {
 async fn get_update_version_manifest(
     client: &reqwest::Client,
 ) -> anyhow::Result<Option<SelfUpdateVersionManifest>> {
+    let manifest_url = match CUSTOM_UPDATE_MANIFEST_URL {
+        Some(manifest_url) => {
+            println!("Checking for updates from {manifest_url}");
+            manifest_url
+        }
+        None => UPDATE_MANIFEST_URL,
+    };
     // Download the manifest
     let response = client
-        .get(MANIFEST_URL)
+        .get(manifest_url)
         .timeout(std::time::Duration::from_secs(10))
         .send()
         .await

--- a/project.bri
+++ b/project.bri
@@ -7,7 +7,9 @@ import { gitCheckout } from "git";
 import openssl from "openssl";
 
 /**
- * Returns a recipe to build Brioche itself.
+ * Returns a recipe to build Brioche itself. This results in a packed build,
+ * which-- unlike a normal glibc-based build-- is portable and runs even
+ * if the host doesn't have glibc.
  */
 export default function (): std.Recipe<std.Directory> {
   let source = Brioche.glob(
@@ -39,9 +41,13 @@ export default function (): std.Recipe<std.Directory> {
     source,
     path: "crates/brioche",
     runnable: "bin/brioche",
-
-    // Network access is used for vendoring libraries (e.g. V8)
+    buildParams: {
+      // Disable self-updates. Currently, self updates aren't supported for
+      // packed builds.
+      defaultFeatures: false,
+    },
     unsafe: {
+      // Network access is used for vendoring libraries (e.g. V8)
       networking: true,
     },
     dependencies: [curl(), caCertificates()],


### PR DESCRIPTION
This PR makes changes to the `brioche` crate and to `project.bri` so that, when Brioche is used to build Brioche itself as a [packed executable](https://brioche.dev/docs/how-it-works/packed-executables/), the `brioche self-update` command is disabled in the resulting build of Brioche.

This change was done purely because `brioche self-update` assumes that Brioche is installed as a single, standalone executable, which is not true when it's distributed as a packed executable. Longer term, the better solution would definitely be to update `brioche self-update` to support updating either a standalone executable or a packed executable.

Here's what this PR changed:

- Update `brioche` crate with new `self-update` feature, which is enabled by default. When it's _disabled_, the `brioche self-update` command will still fetch the update manifest, but will print a message that the latest update can't be installed (and then prints a link to https://brioche.dev/help/manual-update with instructions on how to update)
- Update `project.bri` to disable the `self-update` feature during the build
- Update deps for `project.bri`. This was needed because the ability to disable default Rust features was just published in this PR: brioche-dev/brioche-packages#167
- Add a new `$BRIOCHE_CUSTOM_UPDATE_MANIFEST_URL` build-time env var, which can be used to test out a custom manifest file. I added this to make testing a little simpler.
- Update GitHub Actions workflow to run typechecks and format checks against `project.bri`