### PR TITLE
Update installation snippet in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ export default () => {
 Run this in your terminal for quick installation:
 
 ```sh
-curl --proto '=https' --tlsv1.2 -sSfL 'https://brioche.dev/install.sh' | bash
+curl --proto '=https' --tlsv1.2 -sSfL 'https://brioche.dev/install.sh' | sh
 ```
 
 ...or check out the official docs on [Installation](https://brioche.dev/docs/installation) more installation options.


### PR DESCRIPTION
This PR updates the installation script in `README.md` to use `curl ... | sh` rather than `curl ... | bash`.

We can make this change thanks to the installation script changes in brioche-dev/brioche.dev#12, and the new snippet in this PR matches the snippet that's now used on https://brioche.dev.