### PR TITLE
Update cargo workspace and resolve a few lints on darwin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = ["crates/brioche", "crates/brioche-core", "crates/brioche-pack", "crat
 resolver = "2"
 
 [workspace.lints.clippy]
-all = { level = "deny", priority = -1 }
+all = { level = "warn", priority = -1 }
 
 [profile.dev]
 # Enable optimizations for debug builds because the JS runs slow without it.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,12 @@
+[workspace.package]
+edition = "2021"
+
 [workspace]
 members = ["crates/brioche", "crates/brioche-core", "crates/brioche-pack", "crates/brioche-test-support"]
 resolver = "2"
+
+[workspace.lints.clippy]
+all = { level = "deny", priority = -1 }
 
 [profile.dev]
 # Enable optimizations for debug builds because the JS runs slow without it.

--- a/crates/brioche-core/Cargo.toml
+++ b/crates/brioche-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "brioche-core"
 version = "0.1.4"
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 anyhow = { version = "1.0.95", features = ["backtrace"] }
@@ -96,7 +96,5 @@ harness = false
 name = "input"
 harness = false
 
-[lints.clippy]
-# Temporarily ignore false positives from `tracing::instrument`, see:
-# https://github.com/rust-lang/rust-clippy/issues/12281
-blocks_in_conditions = "allow"
+[lints]
+workspace = true

--- a/crates/brioche-core/src/bake/process.rs
+++ b/crates/brioche-core/src/bake/process.rs
@@ -1392,6 +1392,7 @@ async fn auto_select_sandbox_backend(
     anyhow::bail!("could not find a working backend to run processes (see https://brioche.dev/help/sandbox-backend)");
 }
 
+#[cfg_attr(not(target_os = "linux"), expect(dead_code))]
 struct SandboxBackendSelector {
     brioche: Brioche,
     sandbox_config: SandboxExecutionConfig,

--- a/crates/brioche-core/src/bake/process.rs
+++ b/crates/brioche-core/src/bake/process.rs
@@ -1358,7 +1358,7 @@ async fn select_sandbox_backend(
     }
 }
 
-#[cfg_attr(not(target_os = "linux"), expect(unused_variable))]
+#[cfg_attr(not(target_os = "linux"), expect(unused_variables))]
 async fn auto_select_sandbox_backend(
     backend_selector: &mut SandboxBackendSelector,
 ) -> anyhow::Result<SandboxBackend> {

--- a/crates/brioche-core/src/sandbox.rs
+++ b/crates/brioche-core/src/sandbox.rs
@@ -109,6 +109,7 @@ impl From<std::process::ExitStatus> for ExitStatus {
     }
 }
 
+#[cfg_attr(not(target_os = "linux"), expect(unused_variables))]
 pub fn run_sandbox(
     backend: SandboxBackend,
     exec: SandboxExecutionConfig,

--- a/crates/brioche-core/src/sandbox/linux_namespace.rs
+++ b/crates/brioche-core/src/sandbox/linux_namespace.rs
@@ -1,7 +1,11 @@
-use std::{collections::HashMap, ffi::OsString, path::PathBuf};
+use std::path::PathBuf;
+#[cfg(target_os = "linux")]
+use std::{collections::HashMap, ffi::OsString};
 
+#[cfg(target_os = "linux")]
 use bstr::ByteSlice as _;
 
+#[cfg(target_os = "linux")]
 use super::{SandboxPath, SandboxPathOptions, SandboxTemplate, SandboxTemplateComponent};
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -220,6 +224,7 @@ pub fn run_sandbox(
     Ok(exit_status)
 }
 
+#[cfg(target_os = "linux")]
 fn build_template(
     template: &SandboxTemplate,
     host_paths: &mut HashMap<PathBuf, SandboxPathOptions>,

--- a/crates/brioche-pack/Cargo.toml
+++ b/crates/brioche-pack/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "brioche-pack"
 version = "0.1.4"
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 bincode = { version = "2.0.0-rc.3" }
@@ -10,3 +10,6 @@ serde = { version = "1.0.217", features = ["derive"] }
 serde_with = { version = "3.12.0" }
 thiserror = "2.0.11"
 tick-encoding = "0.1.2"
+
+[lints]
+workspace = true

--- a/crates/brioche-test-support/Cargo.toml
+++ b/crates/brioche-test-support/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "brioche-test-support"
 version = "0.1.4"
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 anyhow = { version = "1.0.95", features = ["backtrace"] }
@@ -19,3 +19,6 @@ toml = "0.8.19"
 tracing = "0.1.41"
 ulid = "1.1.4"
 zstd = "0.13.2"
+
+[lints]
+workspace = true

--- a/crates/brioche/Cargo.toml
+++ b/crates/brioche/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "brioche"
 version = "0.1.4"
-edition = "2021"
+edition.workspace = true
 default-run = "brioche"
 
 [features]
@@ -30,7 +30,5 @@ ulid = "1.1.4"
 url = { version = "2.5.4", features = ["serde"] }
 zstd-framed = { version = "0.1.1", features = ["tokio"] }
 
-[lints.clippy]
-# Temporarily ignore false positives from `tracing::instrument`, see:
-# https://github.com/rust-lang/rust-clippy/issues/12281
-blocks_in_conditions = "allow"
+[lints]
+workspace = true


### PR DESCRIPTION
This PR prepares for Rust Edition 2024 by refactoring the edition in the main Cargo file.

I also re-factored at root level the settings of cargo clippy without enabling new lint. And I also fixed a few lints found on darwin.

What could be done easier in a future with this approach:

- Defining the Rust version at root level
- Enabling new lints
