### PR TITLE
feat: update Rust version to 1.84 in Cargo.toml files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace.package]
 edition = "2021"
+rust-version = "1.84" # To align with the rust-toolchain.toml
 
 [workspace]
 members = ["crates/brioche", "crates/brioche-core", "crates/brioche-pack", "crates/brioche-test-support"]

--- a/crates/brioche-core/Cargo.toml
+++ b/crates/brioche-core/Cargo.toml
@@ -2,6 +2,7 @@
 name = "brioche-core"
 version = "0.1.4"
 edition.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 anyhow = { version = "1.0.95", features = ["backtrace"] }

--- a/crates/brioche-pack/Cargo.toml
+++ b/crates/brioche-pack/Cargo.toml
@@ -2,6 +2,7 @@
 name = "brioche-pack"
 version = "0.1.4"
 edition.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 bincode = { version = "2.0.0-rc.3" }

--- a/crates/brioche-test-support/Cargo.toml
+++ b/crates/brioche-test-support/Cargo.toml
@@ -2,6 +2,7 @@
 name = "brioche-test-support"
 version = "0.1.4"
 edition.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 anyhow = { version = "1.0.95", features = ["backtrace"] }

--- a/crates/brioche/Cargo.toml
+++ b/crates/brioche/Cargo.toml
@@ -2,6 +2,7 @@
 name = "brioche"
 version = "0.1.4"
 edition.workspace = true
+rust-version.workspace = true
 default-run = "brioche"
 
 [features]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.83"
+channel = "1.84"
 profile = "default"
 targets = ["x86_64-unknown-linux-musl"]


### PR DESCRIPTION
Set the `rust-version` workspace field to make it easier to update it in the future.