### PR TITLE
Clean up tracing output

### DIFF
--- a/crates/brioche-core/src/bake.rs
+++ b/crates/brioche-core/src/bake.rs
@@ -49,7 +49,6 @@ pub enum BakeScope {
     Anonymous,
 }
 
-#[tracing::instrument(skip(brioche, recipe), fields(recipe_hash = %recipe.hash(), recipe_kind = ?recipe.kind(), bake_method))]
 pub async fn bake(
     brioche: &Brioche,
     recipe: WithMeta<Recipe>,
@@ -122,7 +121,6 @@ pub async fn bake(
 }
 
 #[async_recursion::async_recursion]
-#[tracing::instrument(skip(brioche, recipe), fields(recipe_hash = %recipe.hash(), recipe_kind = ?recipe.kind(), bake_method))]
 async fn bake_inner(
     brioche: &Brioche,
     recipe: WithMeta<Recipe>,
@@ -269,7 +267,7 @@ async fn bake_inner(
 
                     anyhow::Ok(baked)
                 }
-                .instrument(tracing::debug_span!("run_bake_task").or_current())
+                .instrument(tracing::Span::current())
             };
             tokio::spawn(bake_fut).await?.map_err(|error| BakeFailed {
                 message: format!("{error:#}"),
@@ -311,7 +309,6 @@ async fn bake_inner(
     }
 }
 
-#[tracing::instrument(skip_all, err)]
 async fn run_bake(brioche: &Brioche, recipe: Recipe, meta: &Arc<Meta>) -> anyhow::Result<Artifact> {
     let scope = BakeScope::Child {
         parent_hash: recipe.hash(),

--- a/crates/brioche-core/src/bake/process.rs
+++ b/crates/brioche-core/src/bake/process.rs
@@ -33,7 +33,6 @@ use crate::{
 const GUEST_UID_HINT: u32 = 1099;
 const GUEST_GID_HINT: u32 = 1099;
 
-#[tracing::instrument(skip(brioche, process))]
 pub async fn bake_lazy_process_to_process(
     brioche: &Brioche,
     scope: &super::BakeScope,
@@ -105,7 +104,6 @@ pub async fn bake_lazy_process_to_process(
     })
 }
 
-#[tracing::instrument(skip_all)]
 async fn bake_lazy_process_template_to_process_template(
     brioche: &Brioche,
     scope: &super::BakeScope,

--- a/crates/brioche-core/src/bake/process.rs
+++ b/crates/brioche-core/src/bake/process.rs
@@ -8,6 +8,7 @@ use anyhow::Context as _;
 use bstr::ByteVec as _;
 use futures::{StreamExt as _, TryStreamExt as _};
 use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+use tracing::Instrument as _;
 
 use crate::{
     process_events::{
@@ -1418,6 +1419,7 @@ impl SandboxBackendSelector {
             }),
             &super::BakeScope::Anonymous,
         )
+        .instrument(tracing::info_span!("bake_rootfs_artifacts"))
         .await?;
         let rootfs_recipes_output =
             crate::output::create_local_output(&brioche, &rootfs_artifacts.value).await?;
@@ -1688,6 +1690,7 @@ async fn default_proot_path(
         WithMeta::without_meta(proot_recipe.clone()),
         &super::BakeScope::Anonymous,
     )
+    .instrument(tracing::info_span!("bake_default_proot_path"))
     .await?;
 
     let proot_output = crate::output::create_local_output(brioche, &proot_artifact.value).await?;
@@ -1729,6 +1732,7 @@ async fn set_up_rootfs(
         }),
         &super::BakeScope::Anonymous,
     )
+    .instrument(tracing::info_span!("bake_sh_and_env"))
     .await?;
     crate::output::create_output(brioche, &sh_and_env.value, output_rootfs_options).await?;
 

--- a/crates/brioche-core/src/output.rs
+++ b/crates/brioche-core/src/output.rs
@@ -55,7 +55,6 @@ pub async fn create_output(
 
 #[allow(clippy::multiple_bound_locations)]
 #[async_recursion::async_recursion]
-#[tracing::instrument(skip(brioche, artifact, link_lock), fields(artifact_hash = %artifact.hash()), err)]
 async fn create_output_inner<'a: 'async_recursion>(
     brioche: &Brioche,
     artifact: &Artifact,

--- a/crates/brioche-core/src/output.rs
+++ b/crates/brioche-core/src/output.rs
@@ -419,6 +419,7 @@ pub struct LocalOutput {
     pub resource_dir: Option<PathBuf>,
 }
 
+#[tracing::instrument(skip_all, fields(artifact_hash = %artifact.hash()))]
 async fn fetch_descendent_artifact_blobs(
     brioche: &Brioche,
     artifact: &Artifact,

--- a/crates/brioche-core/src/references.rs
+++ b/crates/brioche-core/src/references.rs
@@ -270,6 +270,7 @@ pub fn referenced_recipes(recipe: &Recipe) -> Vec<RecipeHash> {
     }
 }
 
+#[tracing::instrument(skip_all)]
 pub async fn descendent_artifact_blobs(
     brioche: &Brioche,
     artifacts: impl IntoIterator<Item = Artifact>,

--- a/crates/brioche/src/build.rs
+++ b/crates/brioche/src/build.rs
@@ -121,6 +121,7 @@ pub async fn build(args: BuildArgs) -> anyhow::Result<ExitCode> {
                 export: args.export.to_string(),
             },
         )
+        .instrument(tracing::info_span!("bake"))
         .await?;
 
         guard.shutdown_console().await;

--- a/crates/brioche/src/install.rs
+++ b/crates/brioche/src/install.rs
@@ -207,6 +207,7 @@ async fn run_install(
                 export: export.to_string(),
             },
         )
+        .instrument(tracing::info_span!("bake"))
         .await?;
 
         let elapsed = DisplayDuration(reporter.elapsed());

--- a/crates/brioche/src/run.rs
+++ b/crates/brioche/src/run.rs
@@ -119,6 +119,7 @@ pub async fn run(args: RunArgs) -> anyhow::Result<ExitCode> {
                 export: args.export.to_string(),
             },
         )
+        .instrument(tracing::info_span!("bake"))
         .await?;
 
         guard.shutdown_console().await;


### PR DESCRIPTION
This PR cleans up the `#[tracing::instrument]` attributes and `.instrument()` futures calls to greatly improve how readable Brioche's OpenTelemetry output (i.e. when running Brioche with `$BRIOCHE_ENABLE_OTEL=1` and `$OTEL_EXPORTER_OTLP_ENDPOINT` set to an endpoint for Jaeger or another collector). Basically, I cut out deeply-nested recursive functions, since the extra output from nesting made the output completely unusable.

Here's an example of what the output looks like now:

![Screenshot of Jaeger, showing a Brioche build that took 1.12 seconds. 689ms is spent in the "evaluate" function, and "bake" takes 354ms](https://github.com/user-attachments/assets/37db2ab3-8d90-47f3-8f20-043d1429cada)