### PR TITLE
Speed up outputs and fetching blobs

### DIFF
--- a/crates/brioche-core/src/output.rs
+++ b/crates/brioche-core/src/output.rs
@@ -175,9 +175,13 @@ async fn create_output_inner<'a: 'async_recursion>(
                 });
 
                 if let Some(link_lock) = link_lock {
-                    let local_path =
-                        create_local_output_inner(brioche, &artifact_without_resources, link_lock)
-                            .await?;
+                    let local_path = create_local_output_inner(
+                        brioche,
+                        &artifact_without_resources,
+                        link_lock,
+                        false,
+                    )
+                    .await?;
                     crate::fs_utils::try_remove(options.output_path).await?;
                     tokio::fs::hard_link(&local_path.path, options.output_path)
                         .await
@@ -276,7 +280,7 @@ async fn create_output_inner<'a: 'async_recursion>(
                         // for the file, then hardlink to it
 
                         let local_output =
-                            create_local_output_inner(brioche, &entry, link_lock).await?;
+                            create_local_output_inner(brioche, &entry, link_lock, false).await?;
                         crate::fs_utils::try_remove(&entry_path).await?;
                         tokio::fs::hard_link(&local_output.path, &entry_path)
                             .await
@@ -320,11 +324,8 @@ pub async fn create_local_output(
     // TODO: Make this function parallelizable
     let lock = LOCAL_OUTPUT_MUTEX.lock().await;
 
-    // Fetch all blobs before creating the output
-    fetch_descendent_artifact_blobs(brioche, artifact).await?;
-
     // Create the output
-    let result = create_local_output_inner(brioche, artifact, &lock).await?;
+    let result = create_local_output_inner(brioche, artifact, &lock, true).await?;
 
     Ok(result)
 }
@@ -333,6 +334,7 @@ async fn create_local_output_inner(
     brioche: &Brioche,
     artifact: &Artifact,
     lock: &tokio::sync::MutexGuard<'_, LocalOutputLock>,
+    fetch_descendents: bool,
 ) -> anyhow::Result<LocalOutput> {
     let local_dir = brioche.home.join("locals");
     tokio::fs::create_dir_all(&local_dir).await?;
@@ -342,6 +344,11 @@ async fn create_local_output_inner(
     let local_resource_dir = local_dir.join(format!("{artifact_hash}-resources.d"));
 
     if !try_exists_and_ensure_local_meta(&local_path).await? {
+        // Fetch all blobs before creating the output if needed
+        if fetch_descendents {
+            fetch_descendent_artifact_blobs(brioche, artifact).await?;
+        }
+
         let local_temp_dir = brioche.home.join("locals-temp");
         tokio::fs::create_dir_all(&local_temp_dir).await?;
         let temp_id = ulid::Ulid::new();

--- a/crates/brioche-core/src/output.rs
+++ b/crates/brioche-core/src/output.rs
@@ -429,7 +429,7 @@ async fn fetch_descendent_artifact_blobs(
     crate::references::descendent_artifact_blobs(brioche, [artifact.clone()], &mut blobs).await?;
 
     // Fetch all referenced blobs
-    crate::registry::fetch_blobs(brioche.clone(), &blobs).await?;
+    crate::registry::fetch_blobs(brioche.clone(), blobs).await?;
 
     Ok(())
 }

--- a/crates/brioche-core/src/project.rs
+++ b/crates/brioche-core/src/project.rs
@@ -1134,7 +1134,7 @@ async fn fetch_project_from_registry(
         .values()
         .map(|file_id| file_id.as_blob_hash())
         .collect::<anyhow::Result<HashSet<_>>>()?;
-    crate::registry::fetch_blobs(brioche.clone(), &blobs).await?;
+    crate::registry::fetch_blobs(brioche.clone(), blobs).await?;
 
     for (module_path, file_id) in &project.modules {
         anyhow::ensure!(


### PR DESCRIPTION
This PR makes two quick and easy optimizations, mostly affecting cache hits:

1. Check for existing blobs in `fetch_blobs` using a `tokio::task::spawn_blocking` task, rather than running lots of futures concurrently. Since Tokio filesystem I/O is inherently blocking, trying to split out the work into more parallelism ended up creating a lot of overhead, so just doing the checks in a single blocking function turned out to be _a lot_ faster
2. Update `create_local_output` to only fetch descendent blobs if the local output doesn't already exist. If the local output already exists, we can short-circuit sooner, which turns out to be a big speedup

For testing, I was trying builds against `xplr` from this commit: https://github.com/brioche-dev/brioche-packages/commit/ff64f2d8edc4e814c0c419aae5f497ddc6f7c359. The build (expectedly) fails each iteration, but since the process's inputs were supposed to be fast cache hits, it was helpful to see why it was taking so long on each attempt.

Here's a few screenshots of Jaeger before and after this PR (using the changes from #168 to make the output more readable):

Before (15.51s):
![Screenshot of Jaeger, showing a Brioche build that took 15.51 seconds. The bulk of the time is taken by a call to "bake_process", which spawns a waterfall of "fetch_descendent_blobs" calls that go beyond the edge of the screen](https://github.com/user-attachments/assets/d4aebde2-f02f-47ae-9193-dc7711883018)


After (1.12s):
![Screenshot of Jaeger, showing a Brioche build that took 1.12 seconds. 689ms is spent in the "evaluate" function, and "bake" takes 354ms. It looks very similar to the previous screenshot, but without the cascade of "fetch_descendent_blobs" calls](https://github.com/user-attachments/assets/37db2ab3-8d90-47f3-8f20-043d1429cada)
