### PR TITLE
Update tokio-utils features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6997,7 +6997,6 @@ dependencies = [
  "futures-util",
  "hashbrown 0.14.5",
  "pin-project-lite",
- "slab",
  "tokio",
 ]
 

--- a/crates/brioche-core/Cargo.toml
+++ b/crates/brioche-core/Cargo.toml
@@ -52,7 +52,7 @@ superconsole = "0.2.0"
 thiserror = "2.0.11"
 tick-encoding = "0.1.2"
 tokio = { version = "1.43.0", features = ["full", "tracing"] }
-tokio-util = { version = "0.7.13", features = ["compat", "full"] }
+tokio-util = { version = "0.7.13", features = ["compat", "io-util", "rt"] }
 toml = "0.8.19"
 tower-lsp = "0.20.0"
 tracing = "0.1.41"

--- a/crates/brioche/Cargo.toml
+++ b/crates/brioche/Cargo.toml
@@ -24,7 +24,7 @@ serde_json = "1.0.137"
 sha2 = "0.10.8"
 superconsole = "0.2.0"
 tokio = { version = "1.43.0", features = ["full", "tracing"] }
-tokio-util = { version = "0.7.13", features = ["compat", "full"] }
+tokio-util = "0.7.13"
 tower-lsp = "0.20.0"
 tracing = "0.1.41"
 ulid = "1.1.4"


### PR DESCRIPTION
Just to clean up the features we are using from tokio-utils. I would prefer to enable the feature one by one instead of just setting the flag "full". I'll I think do the same thing, later, for the tokio dependency.   