### PR TITLE
Use `$BRIOCHE_DATA_DIR` to set directory for Brioche files

### DIFF
--- a/crates/brioche-core/src/bake/process.rs
+++ b/crates/brioche-core/src/bake/process.rs
@@ -310,7 +310,7 @@ pub async fn bake_process(
 
     let hash = Recipe::CompleteProcess(process.clone()).hash();
 
-    let temp_dir = brioche.home.join("process-temp");
+    let temp_dir = brioche.data_dir.join("process-temp");
     let bake_dir = temp_dir.join(ulid::Ulid::new().to_string());
     let bake_dir = BakeDir::create(bake_dir).await?;
     let root_dir = bake_dir.path().join("root");
@@ -1423,7 +1423,7 @@ impl SandboxBackendSelector {
             crate::output::create_local_output(&brioche, &rootfs_artifacts.value).await?;
 
         let temp_dir = brioche
-            .home
+            .data_dir
             .join("process-temp")
             .join(format!("{}-setup", ulid::Ulid::new()));
         let temp_dir = BakeDir::create(temp_dir).await?;

--- a/crates/brioche-core/src/blob.rs
+++ b/crates/brioche-core/src/blob.rs
@@ -87,7 +87,7 @@ pub async fn save_blob<'a>(
         return Ok(blob_hash);
     }
 
-    let temp_dir = brioche.home.join("blobs-temp");
+    let temp_dir = brioche.data_dir.join("blobs-temp");
     tokio::fs::create_dir_all(&temp_dir).await.unwrap();
     let temp_path = temp_dir.join(ulid::Ulid::new().to_string());
 
@@ -135,7 +135,7 @@ where
         .as_ref()
         .map(|validate_hash| (validate_hash, super::Hasher::for_hash(validate_hash)));
 
-    let temp_dir = brioche.home.join("blobs-temp");
+    let temp_dir = brioche.data_dir.join("blobs-temp");
     tokio::fs::create_dir_all(&temp_dir).await.unwrap();
     let temp_path = temp_dir.join(ulid::Ulid::new().to_string());
     let mut temp_file = tokio::fs::File::create(&temp_path)
@@ -245,7 +245,7 @@ where
 
     let mut hasher = blake3::Hasher::new();
 
-    let temp_dir = brioche.home.join("blobs-temp");
+    let temp_dir = brioche.data_dir.join("blobs-temp");
     std::fs::create_dir_all(&temp_dir).unwrap();
     let temp_path = temp_dir.join(ulid::Ulid::new().to_string());
     let mut temp_file = std::fs::File::create(&temp_path).context("failed to open temp file")?;
@@ -533,7 +533,7 @@ pub async fn blob_path(
 
     let blob = brioche.registry_client.get_blob(blob_hash).await?;
 
-    let temp_dir = brioche.home.join("blobs-temp");
+    let temp_dir = brioche.data_dir.join("blobs-temp");
     tokio::fs::create_dir_all(&temp_dir).await?;
     let temp_path = temp_dir.join(ulid::Ulid::new().to_string());
 
@@ -563,7 +563,7 @@ pub async fn blob_path(
 }
 
 pub fn local_blob_path(brioche: &Brioche, blob_hash: BlobHash) -> PathBuf {
-    let blobs_dir = brioche.home.join("blobs");
+    let blobs_dir = brioche.data_dir.join("blobs");
     let blob_path = blobs_dir.join(hex::encode(blob_hash.0.as_bytes()));
     blob_path
 }

--- a/crates/brioche-core/src/lib.rs
+++ b/crates/brioche-core/src/lib.rs
@@ -50,7 +50,7 @@ pub struct Brioche {
     /// The directory where all of Brioche's data is stored. Usually configured
     /// to follow the platform's conventions for storing application data, such
     /// as `~/.local/share/brioche` on Linux.
-    pub home: PathBuf,
+    pub data_dir: PathBuf,
 
     /// Causes Brioche to call itself to execute processes in a sandbox, rather
     /// than using a `tokio::spawn_blocking` thread. This could allow for
@@ -108,7 +108,7 @@ pub struct BriocheBuilder {
     registry_client: Option<registry::RegistryClient>,
     vfs: vfs::Vfs,
     config: Option<BriocheConfig>,
-    home: Option<PathBuf>,
+    data_dir: Option<PathBuf>,
     sandbox_backend: Option<sandbox::SandboxBackend>,
     self_exec_processes: bool,
     keep_temps: bool,
@@ -122,7 +122,7 @@ impl BriocheBuilder {
             registry_client: None,
             vfs: vfs::Vfs::immutable(),
             config: None,
-            home: None,
+            data_dir: None,
             sandbox_backend: None,
             self_exec_processes: true,
             keep_temps: false,
@@ -135,8 +135,8 @@ impl BriocheBuilder {
         self
     }
 
-    pub fn home(mut self, home: PathBuf) -> Self {
-        self.home = Some(home);
+    pub fn data_dir(mut self, data_dir: PathBuf) -> Self {
+        self.data_dir = Some(data_dir);
         self
     }
 
@@ -182,14 +182,14 @@ impl BriocheBuilder {
             }
         };
 
-        let home = match (self.home, std::env::var_os("BRIOCHE_DATA_DIR")) {
-            (Some(home), _) => home,
-            (None, Some(home)) => PathBuf::from(home),
+        let data_dir = match (self.data_dir, std::env::var_os("BRIOCHE_DATA_DIR")) {
+            (Some(data_dir), _) => data_dir,
+            (None, Some(data_dir)) => PathBuf::from(data_dir),
             (None, None) => dirs.data_local_dir().to_owned(),
         };
-        tokio::fs::create_dir_all(&home).await?;
+        tokio::fs::create_dir_all(&data_dir).await?;
 
-        let database_path = home.join("brioche.db");
+        let database_path = data_dir.join("brioche.db");
 
         let db_conn_options = sqlx::sqlite::SqliteConnectOptions::new()
             .filename(&database_path)
@@ -282,7 +282,7 @@ impl BriocheBuilder {
             reporter: self.reporter,
             vfs: self.vfs,
             db_conn: Arc::new(Mutex::new(db_conn)),
-            home,
+            data_dir,
             self_exec_processes: self.self_exec_processes,
             keep_temps: self.keep_temps,
             sync_tx: Arc::new(sync_tx),

--- a/crates/brioche-core/src/lib.rs
+++ b/crates/brioche-core/src/lib.rs
@@ -182,11 +182,11 @@ impl BriocheBuilder {
             }
         };
 
-        let home = match self.home {
-            Some(home) => home,
-            None => dirs.data_local_dir().to_owned(),
+        let home = match (self.home, std::env::var_os("BRIOCHE_DATA_DIR")) {
+            (Some(home), _) => home,
+            (None, Some(home)) => PathBuf::from(home),
+            (None, None) => dirs.data_local_dir().to_owned(),
         };
-
         tokio::fs::create_dir_all(&home).await?;
 
         let database_path = home.join("brioche.db");

--- a/crates/brioche-core/src/output.rs
+++ b/crates/brioche-core/src/output.rs
@@ -335,7 +335,7 @@ async fn create_local_output_inner(
     lock: &tokio::sync::MutexGuard<'_, LocalOutputLock>,
     fetch_descendents: bool,
 ) -> anyhow::Result<LocalOutput> {
-    let local_dir = brioche.home.join("locals");
+    let local_dir = brioche.data_dir.join("locals");
     tokio::fs::create_dir_all(&local_dir).await?;
 
     let artifact_hash = artifact.hash();
@@ -348,7 +348,7 @@ async fn create_local_output_inner(
             fetch_descendent_artifact_blobs(brioche, artifact).await?;
         }
 
-        let local_temp_dir = brioche.home.join("locals-temp");
+        let local_temp_dir = brioche.data_dir.join("locals-temp");
         tokio::fs::create_dir_all(&local_temp_dir).await?;
         let temp_id = ulid::Ulid::new();
         let local_temp_path = local_temp_dir.join(temp_id.to_string());

--- a/crates/brioche-core/src/project.rs
+++ b/crates/brioche-core/src/project.rs
@@ -1030,14 +1030,20 @@ async fn fetch_project_from_registry(
     };
     let _guard = project_mutex.lock().await;
 
-    let local_path = brioche.home.join("projects").join(project_hash.to_string());
+    let local_path = brioche
+        .data_dir
+        .join("projects")
+        .join(project_hash.to_string());
 
     if tokio::fs::try_exists(&local_path).await? {
         return Ok(local_path);
     }
 
     let temp_id = ulid::Ulid::new();
-    let temp_project_path = brioche.home.join("projects-temp").join(temp_id.to_string());
+    let temp_project_path = brioche
+        .data_dir
+        .join("projects-temp")
+        .join(temp_id.to_string());
     tokio::fs::create_dir_all(&temp_project_path).await?;
 
     let project = brioche

--- a/crates/brioche-core/tests/project_load.rs
+++ b/crates/brioche-core/tests/project_load.rs
@@ -521,7 +521,10 @@ async fn test_project_load_with_remote_registry_dep() -> anyhow::Result<()> {
 
     let foo_dep_hash = project.dependency_hash("foo").unwrap();
     let foo_dep = projects.project(foo_dep_hash).unwrap();
-    let foo_path = brioche.data_dir.join("projects").join(foo_dep_hash.to_string());
+    let foo_path = brioche
+        .data_dir
+        .join("projects")
+        .join(foo_dep_hash.to_string());
     assert!(projects
         .local_paths(foo_dep_hash)
         .unwrap()
@@ -590,7 +593,10 @@ async fn test_project_load_with_remote_registry_dep_with_brioche_include() -> an
 
     let foo_dep_hash = project.dependency_hash("foo").unwrap();
     let foo_dep = projects.project(foo_dep_hash).unwrap();
-    let foo_path = brioche.data_dir.join("projects").join(foo_dep_hash.to_string());
+    let foo_path = brioche
+        .data_dir
+        .join("projects")
+        .join(foo_dep_hash.to_string());
     assert!(projects
         .local_paths(foo_dep_hash)
         .unwrap()
@@ -668,7 +674,10 @@ async fn test_project_load_with_remote_registry_dep_with_brioche_glob() -> anyho
 
     let foo_dep_hash = project.dependency_hash("foo").unwrap();
     let foo_dep = projects.project(foo_dep_hash).unwrap();
-    let foo_path = brioche.data_dir.join("projects").join(foo_dep_hash.to_string());
+    let foo_path = brioche
+        .data_dir
+        .join("projects")
+        .join(foo_dep_hash.to_string());
     assert!(projects
         .local_paths(foo_dep_hash)
         .unwrap()
@@ -745,7 +754,10 @@ async fn test_project_load_with_remote_registry_dep_with_brioche_download() -> a
 
     let foo_dep_hash = project.dependency_hash("foo").unwrap();
     let foo_dep = projects.project(foo_dep_hash).unwrap();
-    let foo_path = brioche.data_dir.join("projects").join(foo_dep_hash.to_string());
+    let foo_path = brioche
+        .data_dir
+        .join("projects")
+        .join(foo_dep_hash.to_string());
     assert!(projects
         .local_paths(foo_dep_hash)
         .unwrap()

--- a/crates/brioche-core/tests/project_load.rs
+++ b/crates/brioche-core/tests/project_load.rs
@@ -521,7 +521,7 @@ async fn test_project_load_with_remote_registry_dep() -> anyhow::Result<()> {
 
     let foo_dep_hash = project.dependency_hash("foo").unwrap();
     let foo_dep = projects.project(foo_dep_hash).unwrap();
-    let foo_path = brioche.home.join("projects").join(foo_dep_hash.to_string());
+    let foo_path = brioche.data_dir.join("projects").join(foo_dep_hash.to_string());
     assert!(projects
         .local_paths(foo_dep_hash)
         .unwrap()
@@ -590,7 +590,7 @@ async fn test_project_load_with_remote_registry_dep_with_brioche_include() -> an
 
     let foo_dep_hash = project.dependency_hash("foo").unwrap();
     let foo_dep = projects.project(foo_dep_hash).unwrap();
-    let foo_path = brioche.home.join("projects").join(foo_dep_hash.to_string());
+    let foo_path = brioche.data_dir.join("projects").join(foo_dep_hash.to_string());
     assert!(projects
         .local_paths(foo_dep_hash)
         .unwrap()
@@ -668,7 +668,7 @@ async fn test_project_load_with_remote_registry_dep_with_brioche_glob() -> anyho
 
     let foo_dep_hash = project.dependency_hash("foo").unwrap();
     let foo_dep = projects.project(foo_dep_hash).unwrap();
-    let foo_path = brioche.home.join("projects").join(foo_dep_hash.to_string());
+    let foo_path = brioche.data_dir.join("projects").join(foo_dep_hash.to_string());
     assert!(projects
         .local_paths(foo_dep_hash)
         .unwrap()
@@ -745,7 +745,7 @@ async fn test_project_load_with_remote_registry_dep_with_brioche_download() -> a
 
     let foo_dep_hash = project.dependency_hash("foo").unwrap();
     let foo_dep = projects.project(foo_dep_hash).unwrap();
-    let foo_path = brioche.home.join("projects").join(foo_dep_hash.to_string());
+    let foo_path = brioche.data_dir.join("projects").join(foo_dep_hash.to_string());
     assert!(projects
         .local_paths(foo_dep_hash)
         .unwrap()

--- a/crates/brioche-test-support/src/lib.rs
+++ b/crates/brioche-test-support/src/lib.rs
@@ -29,18 +29,18 @@ pub async fn brioche_test_with(
     let temp = tempdir::TempDir::new("brioche-test").unwrap();
     let registry_server = mockito::Server::new_async().await;
 
-    let brioche_home = temp.path().join("brioche-home");
-    tokio::fs::create_dir_all(&brioche_home)
+    let brioche_data_dir = temp.path().join("brioche-data");
+    tokio::fs::create_dir_all(&brioche_data_dir)
         .await
-        .expect("failed to create brioche home");
-    let brioche_home = tokio::fs::canonicalize(&brioche_home)
+        .expect("failed to create brioche data dir");
+    let brioche_data_dir = tokio::fs::canonicalize(&brioche_data_dir)
         .await
-        .expect("failed to canonicalize brioche home path");
+        .expect("failed to canonicalize brioche data dir path");
 
     let (reporter, reporter_guard) = brioche_core::reporter::start_test_reporter();
     let builder = BriocheBuilder::new(reporter)
         .config(brioche_core::config::BriocheConfig::default())
-        .home(brioche_home)
+        .data_dir(brioche_data_dir)
         .registry_client(brioche_core::registry::RegistryClient::new_with_client(
             reqwest_middleware::ClientBuilder::new(reqwest::Client::new()).build(),
             registry_server.url().parse().unwrap(),
@@ -645,7 +645,7 @@ impl TestContext {
         let (_, project_hash, temp_project_path) = self.temp_project(f).await;
 
         let project_path = self
-            .mkdir(format!("brioche-home/projects/{project_hash}"))
+            .mkdir(format!("brioche-data/projects/{project_hash}"))
             .await;
         tokio::fs::rename(&temp_project_path, &project_path)
             .await

--- a/crates/brioche/src/install.rs
+++ b/crates/brioche/src/install.rs
@@ -238,7 +238,7 @@ async fn run_install(
         directory.insert(brioche, b"brioche-run", None).await?;
 
         // Create the installation directory if it doesn't exist
-        let install_dir = brioche.home.join("installed");
+        let install_dir = brioche.data_dir.join("installed");
         tokio::fs::create_dir_all(&install_dir)
             .await
             .with_context(|| {


### PR DESCRIPTION
This PR updates the `Brioche` type to use the `$BRIOCHE_DATA_DIR` env var to set the base path for the local Brioche files. This overrides the paths used for storing artifacts, blobs, projects, installed packages, etc. (the default path is still `~/.local/share/brioche` on Linux, as determined by the method [ProjectDirs::data_local_dir](https://docs.rs/directories/6.0.0/directories/struct.ProjectDirs.html#method.data_local_dir) from the [`directories`](https://crates.io/crates/directories) crate).

Also, for consistency with this new env var, I renamed the field `Brioche.home` to `Brioche.data_dir` throughout the codebase. I thought this was more sensible since it's not really a "home directory" in any meaningful sense, and "data dir" is more consistent with the [XDG Base Directories spec](https://specifications.freedesktop.org/basedir-spec/latest/#variables) and `directories` naming conventions.

Personally, I've found this useful because I can try out Brioche with a secondary data dir to test with a completely blank slate, but without affecting my main installation.