### PR TITLE
Increase concurrent blob and recipe downloads from registry

### DIFF
--- a/crates/brioche-core/src/blob.rs
+++ b/crates/brioche-core/src/blob.rs
@@ -14,7 +14,7 @@ pub struct SaveBlobPermit<'a> {
     _permit: tokio::sync::SemaphorePermit<'a>,
 }
 
-pub const MAX_CONCURRENT_BLOB_SAVES: usize = 10;
+pub const MAX_CONCURRENT_BLOB_SAVES: usize = 200;
 
 static SAVE_BLOB_SEMAPHORE: tokio::sync::Semaphore =
     tokio::sync::Semaphore::const_new(MAX_CONCURRENT_BLOB_SAVES);

--- a/crates/brioche-core/src/registry.rs
+++ b/crates/brioche-core/src/registry.rs
@@ -483,7 +483,7 @@ pub async fn fetch_recipes_deep(
         let new_recipes = Arc::new(tokio::sync::Mutex::new(vec![]));
         futures::stream::iter(unknown_recipes)
             .map(Ok)
-            .try_for_each_concurrent(25, |recipe| {
+            .try_for_each_concurrent(200, |recipe| {
                 let brioche = brioche.clone();
                 let new_recipes = new_recipes.clone();
                 async move {


### PR DESCRIPTION
Related to #147 

Pretty self-explanatory: this PR bumps the total number of concurrent blob downloads from 10 to 200, and the total number of concurrent recipe downloads from 25 to 200.

I tested this in the packages repo from [4f8fd12](https://github.com/brioche-dev/brioche-packages/commit/4f8fd12158f3871c51afabb766f27f3029603fbc) with this patch applied:

```diff
diff --git a/packages/std/toolchain/native/index.bri b/packages/std/toolchain/native/index.bri
index 174c2dc..6e814b9 100644
--- a/packages/std/toolchain/native/index.bri
+++ b/packages/std/toolchain/native/index.bri
@@ -440,6 +440,7 @@ function makePkgConfigPathsRelative(
 function syncTarball(
   recipe: std.AsyncRecipe<std.Directory>,
 ): std.Recipe<std.Directory> {
+  return std.recipe(recipe);
   recipe = std.collectReferences(std.directory({ recipe }));
 
   const tarredRecipe = std
```

Here's the total build times I got before and after this PR, starting with a totally empty Brioche dir each time:

| | Total build time |
|-|-----|
| Before | 7m 9s |
| After | 1m35s |