### PR TITLE
Enable conditional PUTs for S3 object store

### DIFF
--- a/crates/brioche-core/src/cache.rs
+++ b/crates/brioche-core/src/cache.rs
@@ -95,6 +95,7 @@ pub async fn cache_client_from_config_or_default(
             )
             .with_credentials(Arc::new(store_credentials))
             .with_bucket_name(bucket)
+            .with_conditional_put(object_store::aws::S3ConditionalPut::ETagMatch)
             .with_client_options(client_options)
             .with_retry(retry_config)
             .build()?;


### PR DESCRIPTION
This PR is a followup to #179 to enable conditional PUTs using ETags when using S3 as a backend for the cache. Previously, no option was set for conditional PUTs. Because we always use `PutMode::Create` when creating new objects through `object_store`, this meant that all cache writes for S3 would fail.

`object_store` doesn't enable this option by default because not all S3 backends have historically supported using ETags for conditional PUTs-- the most notable being actual Amazon S3. As of August 2024, Amazon S3 supports conditional PUTs now, and at least R2 does as well, so I think it should be fairly sensible to enable it by default. In the future, it might make sense to add an option to disable conditional PUTs for the cache, in case there are S3-compatible providers that don't support it.