### PR TITLE
Add `cache.allow_http` config setting to allow HTTP-only cache requests

### DIFF
--- a/crates/brioche-core/src/cache.rs
+++ b/crates/brioche-core/src/cache.rs
@@ -64,8 +64,12 @@ pub async fn cache_client_from_config_or_default(
         max_retries: 5,
         ..Default::default()
     };
-    let client_options = object_store::ClientOptions::new()
+
+    let mut client_options = object_store::ClientOptions::new()
         .with_user_agent(http::HeaderValue::from_static(crate::USER_AGENT));
+    if let Some(allow_http) = config.and_then(|config| config.allow_http) {
+        client_options = client_options.with_allow_http(allow_http);
+    }
 
     let store: Arc<dyn object_store::ObjectStore> = match url.scheme() {
         "http" | "https" => {

--- a/crates/brioche-core/src/config.rs
+++ b/crates/brioche-core/src/config.rs
@@ -79,6 +79,8 @@ pub struct CacheConfig {
 
     #[serde(default)]
     pub read_only: bool,
+
+    pub allow_http: Option<bool>,
 }
 
 fn default_cache_max_concurrent_operations() -> usize {

--- a/crates/brioche-core/src/lib.rs
+++ b/crates/brioche-core/src/lib.rs
@@ -275,10 +275,21 @@ impl BriocheBuilder {
                             }
                             None => cache::DEFAULT_CACHE_MAX_CONCURRENT_OPERATIONS,
                         };
+                        let allow_http = match std::env::var_os("BRIOCHE_CACHE_ALLOW_HTTP") {
+                            Some(value) if value.to_str() == Some("true") => Some(true),
+                            Some(value) if value.to_str() == Some("false") => Some(false),
+                            Some(value) => {
+                                anyhow::bail!(
+                                    "invalid value for $BRIOCHE_CACHE_ALLOW_HTTP: {value:?}"
+                                );
+                            }
+                            None => None,
+                        };
                         Some(config::CacheConfig {
                             url,
                             read_only,
                             max_concurrent_operations,
+                            allow_http,
                         })
                     }
                     None => config.cache.clone(),


### PR DESCRIPTION
This PR is a follow-up to #179. As noted in the "Future improvements" section from that PR, `object_store` defaults to preventing requests to HTTP-based servers (in other words, it only allows HTTPS). The new `cache.allow_http` option and `$BRIOCHE_CACHE_ALLOW_HTTP` environment variable allow for optionally allowing HTTP requests.

I considered allowing this by default, or based on the URL scheme / S3 endpoint or similar, but decided to require explicit opt-in for now. I've definitely typo'd `https://` URLs as `http://` before, so I feel that trying to catch that is worth the trade-off.