### PR TITLE
Tweak how cache fetch jobs are displayed in plain display format

### DIFF
--- a/crates/brioche-core/src/reporter/console.rs
+++ b/crates/brioche-core/src/reporter/console.rs
@@ -274,7 +274,7 @@ impl ConsoleReporter {
                         total_blobs: _,
                         started_at: _,
                     } => {
-                        eprintln!("Fetching baked artifact from cache");
+                        eprintln!("Fetching artifact from cache");
                     }
                     NewJob::CacheFetch {
                         kind: super::job::CacheFetchKind::Project,
@@ -432,9 +432,24 @@ impl ConsoleReporter {
                     UpdateJob::CacheFetchUpdate { .. } => {}
                     UpdateJob::CacheFetchFinish { finished_at } => {
                         let elapsed = finished_at.saturating_duration_since(job.created_at());
+
+                        let Job::CacheFetch {
+                            kind,
+                            downloaded_blobs,
+                            ..
+                        } = job
+                        else {
+                            panic!("tried to update non-cache job {id:?} with a cache update");
+                        };
+                        let fetch_kind = match kind {
+                            crate::reporter::job::CacheFetchKind::Bake => "artifact",
+                            crate::reporter::job::CacheFetchKind::Project => "project",
+                        };
+
                         eprintln!(
-                            "Finished fetching from registry in {}",
-                            DisplayDuration(elapsed)
+                            "Finished fetching {fetch_kind} with {downloaded_blobs} new blob{s} from cache in {}",
+                            DisplayDuration(elapsed),
+                            s = if *downloaded_blobs == 1 { "" } else { "s" }
                         );
                     }
                 }


### PR DESCRIPTION
This PR is a follow-up to #179, which tweaks how `CacheFetch` jobs are displayed when using the `--display plain` format for output. The messages are more detailed and more consistent with what the console output format shows.

Here's an example of the output you'd get when running `brioche build -r python` with this PR:

```
Fetching project from cache
Finished fetching project with 130 new blobs from cache in 0.05s
Fetching artifact from cache
Finished fetching artifact with 1 new blob from cache in 0.00s
Fetching artifact from cache
Finished fetching artifact with 1 new blob from cache in 0.00s
Fetching artifact from cache
Finished fetching artifact with 1 new blob from cache in 0.00s
Fetching artifact from cache
Finished fetching artifact with 6568 new blobs from cache in 13.02s
Build finished, completed 5 jobs in 16.15s
Result: 5ade288582b9b53fad0753bb813b84b3e2aea1ea2c865a3c9169b78f3dad7c53
```