### PR TITLE
Fix debug printing and enable some more Clippy lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,8 @@ resolver = "2"
 
 [workspace.lints.clippy]
 all = { level = "warn", priority = -1 }
+print_stdout = { level = "warn" }
+print_stderr = { level = "warn" }
 
 [profile.dev]
 # Enable optimizations for debug builds because the JS runs slow without it.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ resolver = "2"
 all = { level = "warn", priority = -1 }
 print_stdout = { level = "warn" }
 print_stderr = { level = "warn" }
+unused_trait_names = { level = "warn" }
 
 [profile.dev]
 # Enable optimizations for debug builds because the JS runs slow without it.

--- a/crates/brioche-core/src/encoding.rs
+++ b/crates/brioche-core/src/encoding.rs
@@ -1,6 +1,6 @@
 use std::{borrow::Cow, path::PathBuf};
 
-use bstr::{ByteSlice, ByteVec as _};
+use bstr::{ByteSlice as _, ByteVec as _};
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct TickEncode<T>(pub T);

--- a/crates/brioche-core/src/object_store_utils.rs
+++ b/crates/brioche-core/src/object_store_utils.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use anyhow::Context as _;
-use aws_credential_types::provider::ProvideCredentials;
+use aws_credential_types::provider::ProvideCredentials as _;
 
 #[derive(Debug)]
 pub struct AwsS3CredentialProvider {

--- a/crates/brioche-core/src/output.rs
+++ b/crates/brioche-core/src/output.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use anyhow::Context as _;
-use bstr::ByteSlice;
+use bstr::ByteSlice as _;
 
 use super::{
     recipe::{Artifact, Directory, File},

--- a/crates/brioche-core/src/process_events/display.rs
+++ b/crates/brioche-core/src/process_events/display.rs
@@ -12,6 +12,7 @@ pub struct DisplayEventsOptions {
     pub follow_events: Option<std::sync::mpsc::Receiver<anyhow::Result<()>>>,
 }
 
+#[expect(clippy::print_stdout)]
 pub fn display_events<R>(
     reader: &mut ProcessEventReader<R>,
     options: DisplayEventsOptions,

--- a/crates/brioche-core/src/process_events/display.rs
+++ b/crates/brioche-core/src/process_events/display.rs
@@ -1,6 +1,6 @@
 use std::collections::VecDeque;
 
-use bstr::ByteSlice;
+use bstr::ByteSlice as _;
 
 use crate::{reporter::job::ProcessStream, utils::output_buffer::OutputBuffer};
 

--- a/crates/brioche-core/src/project.rs
+++ b/crates/brioche-core/src/project.rs
@@ -798,8 +798,6 @@ async fn load_project_inner(
                     projects.dirty_lockfiles.insert(lockfile_path, new_lockfile);
                 }
                 ProjectLocking::Locked => {
-                    println!("lockfile: {lockfile:?}");
-                    println!("new_lockfile: {new_lockfile:?}");
                     anyhow::bail!("lockfile at {} is out of date", lockfile_path.display());
                 }
             }

--- a/crates/brioche-core/src/project/artifact.rs
+++ b/crates/brioche-core/src/project/artifact.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use anyhow::Context as _;
-use bstr::ByteSlice;
+use bstr::ByteSlice as _;
 
 use crate::{
     recipe::{Artifact, ArtifactDiscriminants, Directory},

--- a/crates/brioche-core/src/reporter/console.rs
+++ b/crates/brioche-core/src/reporter/console.rs
@@ -4,10 +4,10 @@ use std::{
     sync::{atomic::AtomicUsize, Arc},
 };
 
-use bstr::ByteSlice;
+use bstr::ByteSlice as _;
 use opentelemetry::trace::TracerProvider as _;
-use opentelemetry_otlp::WithHttpConfig;
-use superconsole::style::Stylize;
+use opentelemetry_otlp::WithHttpConfig as _;
+use superconsole::style::Stylize as _;
 use tracing_subscriber::{layer::SubscriberExt as _, util::SubscriberInitExt as _, Layer as _};
 
 use crate::utils::{output_buffer::OutputBuffer, DisplayDuration};

--- a/crates/brioche-core/src/reporter/console.rs
+++ b/crates/brioche-core/src/reporter/console.rs
@@ -236,6 +236,7 @@ enum ConsoleReporter {
     },
 }
 
+#[expect(clippy::print_stderr)]
 impl ConsoleReporter {
     fn emit(&mut self, lines: superconsole::Lines) {
         match self {
@@ -482,6 +483,7 @@ impl ConsoleReporter {
     }
 }
 
+#[expect(clippy::print_stderr)]
 fn print_job_content(jobs: &HashMap<JobId, Job>, stream: &JobOutputStream, content: &[u8]) {
     let content = bstr::BStr::new(content);
 

--- a/crates/brioche-core/src/script/specifier.rs
+++ b/crates/brioche-core/src/script/specifier.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use anyhow::Context as _;
-use relative_path::{PathExt, RelativePathBuf};
+use relative_path::{PathExt as _, RelativePathBuf};
 
 use crate::{project::Projects, vfs::Vfs};
 

--- a/crates/brioche-core/src/sync/legacy_sync.rs
+++ b/crates/brioche-core/src/sync/legacy_sync.rs
@@ -10,6 +10,7 @@ use crate::{
 
 use super::SyncBakesResults;
 
+#[expect(clippy::print_stdout)]
 pub async fn sync_bakes(
     brioche: &Brioche,
     bakes: Vec<(crate::recipe::Recipe, crate::recipe::Artifact)>,
@@ -89,6 +90,7 @@ pub async fn sync_bakes(
     })
 }
 
+#[expect(clippy::print_stdout)]
 pub async fn sync_recipe_references(
     brioche: &Brioche,
     references: &RecipeReferences,
@@ -190,6 +192,7 @@ pub struct SyncRecipeReferencesResult {
     pub num_new_recipes: usize,
 }
 
+#[expect(clippy::print_stdout)]
 pub async fn sync_project_references(
     brioche: &Brioche,
     references: &ProjectReferences,

--- a/crates/brioche-core/src/sync/new_sync.rs
+++ b/crates/brioche-core/src/sync/new_sync.rs
@@ -4,6 +4,7 @@ use crate::{utils::DisplayDuration, Brioche};
 
 use super::SyncBakesResults;
 
+#[expect(clippy::print_stdout)]
 pub async fn sync_bakes(
     brioche: &Brioche,
     bakes: Vec<(crate::recipe::Recipe, crate::recipe::Artifact)>,

--- a/crates/brioche-core/tests/bake_process.rs
+++ b/crates/brioche-core/tests/bake_process.rs
@@ -2,7 +2,7 @@
 
 use std::{collections::BTreeMap, future::Future};
 
-use anyhow::Context;
+use anyhow::Context as _;
 use assert_matches::assert_matches;
 use pretty_assertions::assert_eq;
 

--- a/crates/brioche-core/tests/cache_client.rs
+++ b/crates/brioche-core/tests/cache_client.rs
@@ -327,17 +327,8 @@ async fn test_cache_client_load_artifact_chunk_mismatch_error() -> anyhow::Resul
 
         let chunks = list_chunks(&cache).await?;
         for chunk in &chunks {
-            eprintln!("Copying chunk {} to {chunk}", chunks[0]);
             cache.copy(&chunks[4], chunk).await?;
         }
-    }
-
-    let chunks = list_chunks(&cache).await?;
-    for chunk in &chunks {
-        let chunk_data = cache.get(chunk).await?.bytes().await?;
-        let chunk_data = zstd::decode_all(chunk_data.as_ref())?;
-        let chunk_data_hash = blake3::hash(&chunk_data);
-        eprintln!("hash of {chunk}: {chunk_data_hash}");
     }
 
     {

--- a/crates/brioche-core/tests/output.rs
+++ b/crates/brioche-core/tests/output.rs
@@ -1,4 +1,4 @@
-use std::{os::unix::prelude::PermissionsExt, path::Path};
+use std::{os::unix::prelude::PermissionsExt as _, path::Path};
 
 use assert_matches::assert_matches;
 use brioche_core::{output::create_local_output, recipe::Artifact, Brioche};

--- a/crates/brioche/src/build.rs
+++ b/crates/brioche/src/build.rs
@@ -48,6 +48,7 @@ pub struct BuildArgs {
     display: super::DisplayMode,
 }
 
+#[expect(clippy::print_stdout)]
 pub async fn build(args: BuildArgs) -> anyhow::Result<ExitCode> {
     let (reporter, mut guard) = brioche_core::reporter::console::start_console_reporter(
         args.display.to_console_reporter_kind(),

--- a/crates/brioche/src/build.rs
+++ b/crates/brioche/src/build.rs
@@ -3,7 +3,7 @@ use std::{path::PathBuf, process::ExitCode};
 use anyhow::Context as _;
 use brioche_core::{fs_utils, project::ProjectLocking, utils::DisplayDuration};
 use clap::Parser;
-use tracing::Instrument;
+use tracing::Instrument as _;
 
 #[derive(Debug, Parser)]
 pub struct BuildArgs {

--- a/crates/brioche/src/check.rs
+++ b/crates/brioche/src/check.rs
@@ -8,7 +8,7 @@ use brioche_core::project::Projects;
 use brioche_core::reporter::Reporter;
 use brioche_core::Brioche;
 use clap::Parser;
-use tracing::Instrument;
+use tracing::Instrument as _;
 
 use crate::consolidate_result;
 

--- a/crates/brioche/src/format.rs
+++ b/crates/brioche/src/format.rs
@@ -5,7 +5,7 @@ use brioche_core::{
     reporter::Reporter,
 };
 use clap::Parser;
-use tracing::Instrument;
+use tracing::Instrument as _;
 
 use crate::consolidate_result;
 

--- a/crates/brioche/src/install.rs
+++ b/crates/brioche/src/install.rs
@@ -10,7 +10,7 @@ use brioche_core::reporter::Reporter;
 use brioche_core::utils::DisplayDuration;
 use brioche_core::Brioche;
 use clap::Parser;
-use tracing::Instrument;
+use tracing::Instrument as _;
 
 use crate::consolidate_result;
 

--- a/crates/brioche/src/jobs/logs.rs
+++ b/crates/brioche/src/jobs/logs.rs
@@ -8,7 +8,7 @@ use brioche_core::{
     utils::io::NotSeekable,
 };
 use clap::Parser;
-use notify::Watcher;
+use notify::Watcher as _;
 
 #[derive(Debug, Parser)]
 pub struct LogsArgs {

--- a/crates/brioche/src/main.rs
+++ b/crates/brioche/src/main.rs
@@ -189,6 +189,7 @@ struct AnalyzeArgs {
     project: PathBuf,
 }
 
+#[expect(clippy::print_stdout)]
 async fn analyze(args: AnalyzeArgs) -> anyhow::Result<()> {
     let vfs = brioche_core::vfs::Vfs::immutable();
     let project = brioche_core::project::analyze::analyze_project(&vfs, &args.project).await?;
@@ -202,6 +203,7 @@ struct ExportProjectArgs {
     project: PathBuf,
 }
 
+#[expect(clippy::print_stdout)]
 async fn export_project(args: ExportProjectArgs) -> anyhow::Result<()> {
     #[derive(Debug, serde::Serialize, serde::Deserialize)]
     #[serde(rename_all = "camelCase")]

--- a/crates/brioche/src/migrate_registry_to_cache.rs
+++ b/crates/brioche/src/migrate_registry_to_cache.rs
@@ -30,6 +30,7 @@ pub struct MigrateRegistryToCacheArgs {
     cache_dir: PathBuf,
 }
 
+#[expect(clippy::print_stdout)]
 pub async fn migrate_registry_to_cache(args: MigrateRegistryToCacheArgs) -> anyhow::Result<()> {
     let (reporter, _guard) = brioche_core::reporter::console::start_console_reporter(
         brioche_core::reporter::console::ConsoleReporterKind::Plain,

--- a/crates/brioche/src/run.rs
+++ b/crates/brioche/src/run.rs
@@ -3,7 +3,7 @@ use std::process::ExitCode;
 use anyhow::Context as _;
 use brioche_core::{project::ProjectLocking, utils::DisplayDuration};
 use clap::Parser;
-use tracing::Instrument;
+use tracing::Instrument as _;
 
 #[derive(Debug, Parser)]
 pub struct RunArgs {

--- a/crates/brioche/src/run.rs
+++ b/crates/brioche/src/run.rs
@@ -43,6 +43,7 @@ pub struct RunArgs {
     args: Vec<std::ffi::OsString>,
 }
 
+#[expect(clippy::print_stderr)]
 pub async fn run(args: RunArgs) -> anyhow::Result<ExitCode> {
     let (reporter, mut guard) = if args.quiet {
         brioche_core::reporter::start_null_reporter()

--- a/crates/brioche/src/run_sandbox.rs
+++ b/crates/brioche/src/run_sandbox.rs
@@ -13,6 +13,7 @@ pub struct RunSandboxArgs {
     config: String,
 }
 
+#[expect(clippy::print_stderr)]
 pub fn run_sandbox(args: RunSandboxArgs) -> ExitCode {
     let backend = match serde_json::from_str::<SandboxBackend>(&args.backend) {
         Ok(backend) => backend,

--- a/crates/brioche/src/self_update.rs
+++ b/crates/brioche/src/self_update.rs
@@ -21,6 +21,7 @@ const UPDATE_MANIFEST_URL: &str = "https://releases.brioche.dev/updates/update-m
 
 const CURRENT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
+#[expect(clippy::print_stdout)]
 pub async fn self_update(args: SelfUpdateArgs) -> anyhow::Result<bool> {
     let client = reqwest::Client::builder()
         .user_agent(brioche_core::USER_AGENT)
@@ -118,6 +119,7 @@ pub async fn self_update(args: SelfUpdateArgs) -> anyhow::Result<bool> {
     Ok(true)
 }
 
+#[expect(clippy::print_stdout)]
 async fn get_update_version_manifest(
     client: &reqwest::Client,
 ) -> anyhow::Result<Option<SelfUpdateVersionManifest>> {
@@ -152,6 +154,7 @@ async fn get_update_version_manifest(
     Ok(Some(manifest))
 }
 
+#[expect(clippy::print_stdout)]
 async fn get_update_platform_manifest(
     client: &reqwest::Client,
     platform: brioche_core::platform::Platform,
@@ -188,6 +191,7 @@ async fn get_update_platform_manifest(
     Ok(Some(platform_manifest))
 }
 
+#[expect(clippy::print_stdout)]
 async fn confirm_update() -> anyhow::Result<bool> {
     let (tx, rx) = tokio::sync::oneshot::channel();
 

--- a/crates/brioche/src/self_update.rs
+++ b/crates/brioche/src/self_update.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::HashMap,
-    io::{IsTerminal, Write as _},
-    os::unix::fs::PermissionsExt,
+    io::{IsTerminal as _, Write as _},
+    os::unix::fs::PermissionsExt as _,
 };
 
 use anyhow::Context as _;


### PR DESCRIPTION
This PR fixes some debug `println!()` statements that slipped through #179. I was running into issues with the LSP erroring out do to these (since the LSP uses a special protocol over stdio, and random `println!()` statements interfere with this).

Additionally, I enabled the Clippy lints [`print_stdout`](https://rust-lang.github.io/rust-clippy/master/index.html#print_stdout) and [`print_stderr`](https://rust-lang.github.io/rust-clippy/master/index.html#print_stderr) to catch more cases like this. There are a lot of places where we still use `println!()` intentionally for output, so I added `#[expect]` attributes as appropriate. Over time, I'm hoping more and more of these will move to use either `tracing` or our reporter machinery, so this will also help us audit once we (hopefully) move everything over.

Finally, I also enabled the extra [`unused_trait_names`](https://rust-lang.github.io/rust-clippy/master/index.html#unused_trait_names) Clippy lint. I've tried to be consistent with using this already throughout the codebase, but there were quite a few places that I ended up fixing thanks to the lint (this is purely a style I like)