### PR TITLE
Fix miscellaneous bugs in LSP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1274,7 +1274,9 @@ version = "0.1.4"
 dependencies = [
  "anyhow",
  "brioche-core",
+ "bstr",
  "directories",
+ "futures",
  "hex",
  "mockito",
  "object_store",
@@ -1284,7 +1286,9 @@ dependencies = [
  "serde_json",
  "tempdir",
  "tokio",
+ "tokio-util",
  "toml",
+ "tower-lsp",
  "tracing",
  "ulid",
  "zstd",
@@ -7825,6 +7829,7 @@ dependencies = [
  "futures-util",
  "hashbrown 0.14.5",
  "pin-project-lite",
+ "slab",
  "tokio",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1286,6 +1286,7 @@ dependencies = [
  "serde_json",
  "tempdir",
  "tokio",
+ "tokio-stream",
  "tokio-util",
  "toml",
  "tower-lsp",
@@ -7815,6 +7816,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1291,6 +1291,7 @@ dependencies = [
  "tower-lsp",
  "tracing",
  "ulid",
+ "url",
  "zstd",
 ]
 

--- a/crates/brioche-core/runtime/src/compat/console.ts
+++ b/crates/brioche-core/runtime/src/compat/console.ts
@@ -1,0 +1,74 @@
+const ops = (globalThis as any).Deno.core.ops;
+
+function logLevel(level: string, ...args: unknown[]) {
+  ops.op_brioche_console(level, displayAll(...args).join(" "));
+}
+
+export function displayAll(...values: unknown[]): string[] {
+  if (values.length === 0) {
+    return [];
+  }
+
+  const displayed = [];
+  const remaining = [...values];
+  if (typeof remaining[0] === "string") {
+    displayed.push(remaining.shift() as string);
+  }
+
+  for (const value of remaining) {
+    displayed.push(display(value));
+  }
+
+  return displayed;
+}
+
+export function display(value: unknown): string {
+  switch (typeof value) {
+    case "string":
+      return JSON.stringify(value);
+    case "number":
+    case "bigint":
+    case "boolean":
+    case "symbol":
+      return value.toString();
+    case "undefined":
+      return "undefined";
+    case "function":
+      return "[function]";
+    case "object":
+      if (value === null) {
+        return "null";
+      } else if (value instanceof Error) {
+        return value.stack ?? value.message;
+      } else if (value instanceof RegExp) {
+        return value.toString();
+      } else if (value instanceof Date) {
+        return value.toISOString();
+      } else if (Array.isArray(value)) {
+        const items = value.map(display);
+        return `[${items.join(", ")}]`;
+      } else {
+        const entries = Object.entries(value).map(
+          ([key, value]) => `${JSON.stringify(key)}: ${display(value)}`,
+        );
+        return `{${entries.join(", ")}}`;
+      }
+  }
+}
+
+(globalThis as any).console ??= {};
+globalThis.console.log = (...args: unknown[]) => {
+  logLevel("log", ...args);
+};
+globalThis.console.debug = (...args: unknown[]) => {
+  logLevel("debug", ...args);
+};
+globalThis.console.info = (...args: unknown[]) => {
+  logLevel("info", ...args);
+};
+globalThis.console.warn = (...args: unknown[]) => {
+  logLevel("warn", ...args);
+};
+globalThis.console.error = (...args: unknown[]) => {
+  logLevel("error", ...args);
+};

--- a/crates/brioche-core/runtime/src/compat/setup.cjs
+++ b/crates/brioche-core/runtime/src/compat/setup.cjs
@@ -1,3 +1,4 @@
+import "./console";
 import { TextEncoder, TextDecoder } from "./text-encoding";
 
 globalThis["TextEncoder"] = TextEncoder;

--- a/crates/brioche-core/runtime/src/lsp.ts
+++ b/crates/brioche-core/runtime/src/lsp.ts
@@ -47,7 +47,12 @@ class BriocheLanguageServiceHost implements ts.LanguageServiceHost {
   }
 
   readFile(fileName: string): string | undefined {
-    return brioche.readFile(brioche.fromTsUrl(fileName));
+    const uri = brioche.fromTsUrl(fileName);
+    if (fileName.startsWith("file://")) {
+      this.files.add(uri);
+    }
+
+    return brioche.readFile(uri);
   }
 
   getSourceFile(fileName: string): ts.SourceFile {
@@ -130,7 +135,6 @@ class Lsp {
   diagnostic(params: lsp.DocumentDiagnosticParams): lsp.Diagnostic[] {
     const fileName = params.textDocument.uri;
     const tsUrl = brioche.toTsUrl(fileName);
-    this.host.files.add(fileName);
 
     const sourceFile = this.host.getSourceFile(fileName);
     const tsLangaugeDiagnostics = this.languageService.getSemanticDiagnostics(tsUrl);

--- a/crates/brioche-core/runtime/src/lsp.ts
+++ b/crates/brioche-core/runtime/src/lsp.ts
@@ -301,7 +301,7 @@ class Lsp {
       return null;
     }
 
-    const position = ts.getPositionOfLineAndCharacter(
+    const position = tryGetPositionOfLineAndCharacter(
       sourceFile,
       params.position.line,
       params.position.character,
@@ -370,11 +370,15 @@ class Lsp {
       return null;
     }
 
-    const position = ts.getPositionOfLineAndCharacter(
+    const position = tryGetPositionOfLineAndCharacter(
       sourceFile,
       params.position.line,
       params.position.character,
     );
+    if (position == null) {
+      return null;
+    }
+
     const rename = this.languageService.findRenameLocations(brioche.toTsUrl(fileName), position, false, false, {});
     if (rename == null) {
       return null;

--- a/crates/brioche-core/src/script/compiler_host.rs
+++ b/crates/brioche-core/src/script/compiler_host.rs
@@ -42,6 +42,18 @@ impl BriocheCompilerHost {
         }
     }
 
+    pub async fn is_document_loaded(
+        &self,
+        specifier: &BriocheModuleSpecifier,
+    ) -> anyhow::Result<bool> {
+        let documents = self
+            .documents
+            .read()
+            .map_err(|_| anyhow::anyhow!("failed to acquire lock on documents"))?;
+
+        Ok(documents.contains_key(specifier))
+    }
+
     pub async fn load_documents(
         &self,
         specifiers: Vec<BriocheModuleSpecifier>,

--- a/crates/brioche-core/src/script/compiler_host.rs
+++ b/crates/brioche-core/src/script/compiler_host.rs
@@ -143,9 +143,13 @@ impl BriocheCompilerHost {
                     }
                 };
 
-                let resolved = self
-                    .bridge
-                    .resolve_specifier(import_specifier.clone(), specifier.clone());
+                let resolved = tokio::task::spawn_blocking({
+                    let bridge = self.bridge.clone();
+                    let specifier = specifier.clone();
+                    move || bridge.resolve_specifier(import_specifier, specifier)
+                })
+                .await?;
+
                 let resolved = match resolved {
                     Ok(resolved) => resolved,
                     Err(error) => {

--- a/crates/brioche-core/src/script/lsp.rs
+++ b/crates/brioche-core/src/script/lsp.rs
@@ -135,9 +135,14 @@ impl LanguageServer for BriocheLspServer {
 
         tracing::info!(uri = %text_document_uri, "did open");
 
-        let load_result = self.load_document(text_document_uri).await;
-        if let Err(error) = load_result {
-            tracing::warn!("failed to load document {text_document_uri}: {error:#}",);
+        let result = self
+            .compiler_host
+            .update_document(text_document_uri, &params.text_document.text)
+            .await;
+        if let Err(error) = result {
+            tracing::warn!(
+                "failed to update document {text_document_uri} while opening: {error:#}",
+            );
         }
 
         let diagnostics = self

--- a/crates/brioche-core/src/script/lsp.rs
+++ b/crates/brioche-core/src/script/lsp.rs
@@ -18,7 +18,7 @@ use super::specifier::BriocheModuleSpecifier;
 
 /// The maximum time we spend resolving projects when regenerating a
 /// lockfile in the Language Server
-const LOCKFILE_LOAD_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
+const LOCKFILE_LOAD_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(20);
 
 pub type BuildBriocheFn = dyn Fn() -> futures::future::BoxFuture<'static, anyhow::Result<BriocheBuilder>>
     + Send

--- a/crates/brioche-core/tests/lsp_basic.rs
+++ b/crates/brioche-core/tests/lsp_basic.rs
@@ -1,0 +1,48 @@
+use assert_matches::assert_matches;
+use tower_lsp::lsp_types::{self, TextDocumentSyncKind};
+
+#[tokio::test]
+async fn test_lsp_basic_initialize() -> anyhow::Result<()> {
+    let (_brioche, _context, lsp) = brioche_test_support::brioche_lsp_test().await;
+
+    // Validate that the LSP server returned some of the capabilities we expect
+
+    assert_matches!(
+        lsp.initialize_result.capabilities.completion_provider,
+        Some(_)
+    );
+    assert_matches!(
+        lsp.initialize_result.capabilities.definition_provider,
+        Some(_)
+    );
+    assert_matches!(
+        lsp.initialize_result.capabilities.diagnostic_provider,
+        Some(_)
+    );
+    assert_matches!(lsp.initialize_result.capabilities.hover_provider, Some(_));
+    assert_eq!(
+        lsp.initialize_result.capabilities.text_document_sync,
+        Some(lsp_types::TextDocumentSyncCapability::Kind(
+            TextDocumentSyncKind::FULL
+        ))
+    );
+    assert_matches!(
+        lsp.initialize_result.capabilities.references_provider,
+        Some(_)
+    );
+    assert_matches!(
+        lsp.initialize_result
+            .capabilities
+            .document_highlight_provider,
+        Some(_)
+    );
+    assert_matches!(lsp.initialize_result.capabilities.rename_provider, Some(_));
+    assert_matches!(
+        lsp.initialize_result
+            .capabilities
+            .document_formatting_provider,
+        Some(_)
+    );
+
+    Ok(())
+}

--- a/crates/brioche-core/tests/lsp_completions.rs
+++ b/crates/brioche-core/tests/lsp_completions.rs
@@ -1,0 +1,136 @@
+use tower_lsp::lsp_types::{
+    self, notification, request, Position, TextDocumentIdentifier, TextDocumentItem,
+    TextDocumentPositionParams,
+};
+use url::Url;
+
+#[tokio::test]
+async fn test_lsp_completions_simple() -> anyhow::Result<()> {
+    let (_brioche, context, lsp) = brioche_test_support::brioche_lsp_test().await;
+
+    let project_root_contents = indoc::indoc! {r#"
+        function exampleFunction(): string {
+            return "hello world!";
+        }
+
+        exampleFunc // <-- completion here
+    "#};
+    let project_root = context
+        .write_file("myproject/project.bri", project_root_contents)
+        .await;
+
+    lsp.notify::<notification::DidOpenTextDocument>(lsp_types::DidOpenTextDocumentParams {
+        text_document: TextDocumentItem::new(
+            Url::from_file_path(&project_root).unwrap(),
+            "brioche".to_string(),
+            1,
+            project_root_contents.to_string(),
+        ),
+    })
+    .await;
+
+    let completion_response = lsp
+        .request::<request::Completion>(lsp_types::CompletionParams {
+            text_document_position: TextDocumentPositionParams::new(
+                TextDocumentIdentifier::new(Url::from_file_path(&project_root).unwrap()),
+                Position::new(4, 11),
+            ),
+            context: None,
+            partial_result_params: Default::default(),
+            work_done_progress_params: Default::default(),
+        })
+        .await
+        .expect("no completion response returned");
+    let completion_items = match completion_response {
+        lsp_types::CompletionResponse::Array(completion_items) => completion_items,
+        lsp_types::CompletionResponse::List(completion_list) => {
+            assert!(
+                !completion_list.is_incomplete,
+                "expected complete completion list"
+            );
+            completion_list.items
+        }
+    };
+    assert!(!completion_items.is_empty(), "no completions returned");
+
+    let top_completion_item = &completion_items[0];
+    assert_eq!(
+        top_completion_item,
+        &lsp_types::CompletionItem {
+            label: "exampleFunction".to_string(),
+            ..Default::default()
+        },
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_lsp_completions_from_import() -> anyhow::Result<()> {
+    let (_brioche, context, lsp) = brioche_test_support::brioche_lsp_test().await;
+
+    context
+        .write_file(
+            "myproject/other.bri",
+            indoc::indoc! {r#"
+                export function exampleFunctionFromOther() {
+                    return "hello world!";
+                }
+            "#},
+        )
+        .await;
+
+    let project_root_contents = indoc::indoc! {r#"
+        import * as other from "./other.bri";
+
+        other.exampleFunctionFromO // <-- completion here
+    "#};
+    let project_root = context
+        .write_file("myproject/project.bri", project_root_contents)
+        .await;
+
+    lsp.notify::<notification::DidOpenTextDocument>(lsp_types::DidOpenTextDocumentParams {
+        text_document: TextDocumentItem::new(
+            Url::from_file_path(&project_root).unwrap(),
+            "brioche".to_string(),
+            1,
+            project_root_contents.to_string(),
+        ),
+    })
+    .await;
+
+    let completion_response = lsp
+        .request::<request::Completion>(lsp_types::CompletionParams {
+            text_document_position: TextDocumentPositionParams::new(
+                TextDocumentIdentifier::new(Url::from_file_path(&project_root).unwrap()),
+                Position::new(2, 26),
+            ),
+            context: None,
+            partial_result_params: Default::default(),
+            work_done_progress_params: Default::default(),
+        })
+        .await
+        .expect("no completion response returned");
+    let completion_items = match completion_response {
+        lsp_types::CompletionResponse::Array(completion_items) => completion_items,
+        lsp_types::CompletionResponse::List(completion_list) => {
+            assert!(
+                !completion_list.is_incomplete,
+                "expected complete completion list"
+            );
+            completion_list.items
+        }
+    };
+    assert!(!completion_items.is_empty(), "no completions returned");
+
+    let top_completion_item = &completion_items[0];
+    assert_eq!(
+        top_completion_item,
+        &lsp_types::CompletionItem {
+            label: "exampleFunctionFromOther".to_string(),
+            ..Default::default()
+        },
+    );
+
+    Ok(())
+}

--- a/crates/brioche-core/tests/lsp_completions.rs
+++ b/crates/brioche-core/tests/lsp_completions.rs
@@ -406,3 +406,73 @@ async fn test_lsp_completions_from_workspace_import() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn test_lsp_completions_in_unsaved_edited_file() -> anyhow::Result<()> {
+    let (_brioche, context, lsp) = brioche_test_support::brioche_lsp_test().await;
+
+    let project_root = context
+        .write_file(
+            "myproject/project.bri",
+            indoc::indoc! {r#"
+                // File on disk is effectively empty
+            "#},
+        )
+        .await;
+
+    // The existing file exists but doesn't match the content provided by
+    // the LSP client. This happens e.g. when re-opening a VS Code window
+    // that has unsaved file changes. In this case, we should use the client's
+    // view of the file's contents instead of what's actually on disk
+    lsp.notify::<notification::DidOpenTextDocument>(lsp_types::DidOpenTextDocumentParams {
+        text_document: TextDocumentItem::new(
+            Url::from_file_path(&project_root).unwrap(),
+            "brioche".to_string(),
+            1,
+            indoc::indoc! {r#"
+                function exampleFunction(): string {
+                    return "hello world!";
+                }
+
+                exampleFunc // <-- completion here
+            "#}
+            .to_string(),
+        ),
+    })
+    .await;
+
+    let completion_response = lsp
+        .request::<request::Completion>(lsp_types::CompletionParams {
+            text_document_position: TextDocumentPositionParams::new(
+                TextDocumentIdentifier::new(Url::from_file_path(&project_root).unwrap()),
+                Position::new(4, 11),
+            ),
+            context: None,
+            partial_result_params: Default::default(),
+            work_done_progress_params: Default::default(),
+        })
+        .await
+        .expect("no completion response returned");
+    let completion_items = match completion_response {
+        lsp_types::CompletionResponse::Array(completion_items) => completion_items,
+        lsp_types::CompletionResponse::List(completion_list) => {
+            assert!(
+                !completion_list.is_incomplete,
+                "expected complete completion list"
+            );
+            completion_list.items
+        }
+    };
+    assert!(!completion_items.is_empty(), "no completions returned");
+
+    let top_completion_item = &completion_items[0];
+    assert_eq!(
+        top_completion_item,
+        &lsp_types::CompletionItem {
+            label: "exampleFunction".to_string(),
+            ..Default::default()
+        },
+    );
+
+    Ok(())
+}

--- a/crates/brioche-core/tests/lsp_completions.rs
+++ b/crates/brioche-core/tests/lsp_completions.rs
@@ -1,8 +1,14 @@
+use brioche_core::cache::CacheClient;
+use futures::TryStreamExt as _;
 use tower_lsp::lsp_types::{
     self, notification, request, Position, TextDocumentIdentifier, TextDocumentItem,
     TextDocumentPositionParams,
 };
 use url::Url;
+
+// Timeout used to wait for messages back from the LSP. This is mainly used
+// as a sanity check to prevent a test from hanging forever
+const WAIT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
 #[tokio::test]
 async fn test_lsp_completions_simple() -> anyhow::Result<()> {
@@ -128,6 +134,272 @@ async fn test_lsp_completions_from_import() -> anyhow::Result<()> {
         top_completion_item,
         &lsp_types::CompletionItem {
             label: "exampleFunctionFromOther".to_string(),
+            ..Default::default()
+        },
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_lsp_completions_from_local_registry_import() -> anyhow::Result<()> {
+    let (_brioche, context, lsp) = brioche_test_support::brioche_lsp_test().await;
+
+    let (foo_hash, _) = context
+        .local_registry_project(|path| async move {
+            tokio::fs::write(
+                path.join("project.bri"),
+                r#"
+                    export function fooFunction() {
+                        return "hello world!";
+                    }
+                "#,
+            )
+            .await
+            .unwrap();
+        })
+        .await;
+
+    let project_dir = context.mkdir("myproject").await;
+
+    // Use a lockfile where 'foo' points to a project we already have locally
+    let lockfile = brioche_core::project::Lockfile {
+        dependencies: [("foo".to_string(), foo_hash)].into_iter().collect(),
+        ..Default::default()
+    };
+    context
+        .write_lockfile(project_dir.join("brioche.lock"), &lockfile)
+        .await;
+
+    let project_root_contents = indoc::indoc! {r#"
+        import * as foo from "foo";
+
+        foo.fooFunctio // <-- completion here
+    "#};
+    let project_root = context
+        .write_file(project_dir.join("project.bri"), project_root_contents)
+        .await;
+
+    lsp.notify::<notification::DidOpenTextDocument>(lsp_types::DidOpenTextDocumentParams {
+        text_document: TextDocumentItem::new(
+            Url::from_file_path(&project_root).unwrap(),
+            "brioche".to_string(),
+            1,
+            project_root_contents.to_string(),
+        ),
+    })
+    .await;
+
+    // Get completions. This should be able to complete the function from
+    // 'foo' since it's already saved locally
+    let completion_response = lsp
+        .request::<request::Completion>(lsp_types::CompletionParams {
+            text_document_position: TextDocumentPositionParams::new(
+                TextDocumentIdentifier::new(Url::from_file_path(&project_root).unwrap()),
+                Position::new(2, 14),
+            ),
+            context: None,
+            partial_result_params: Default::default(),
+            work_done_progress_params: Default::default(),
+        })
+        .await
+        .expect("no completion response returned");
+    let completion_items = match completion_response {
+        lsp_types::CompletionResponse::Array(completion_items) => completion_items,
+        lsp_types::CompletionResponse::List(completion_list) => {
+            assert!(
+                !completion_list.is_incomplete,
+                "expected complete completion list"
+            );
+            completion_list.items
+        }
+    };
+    assert!(!completion_items.is_empty(), "no completions returned");
+    let top_completion_item = &completion_items[0];
+    assert_eq!(
+        top_completion_item,
+        &lsp_types::CompletionItem {
+            label: "fooFunction".to_string(),
+            ..Default::default()
+        },
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_lsp_completions_from_remote_registry_import() -> anyhow::Result<()> {
+    let cache = brioche_test_support::new_cache();
+    let (_brioche, mut context, lsp) = brioche_test_support::brioche_lsp_test_with({
+        let cache = cache.clone();
+        move |builder| {
+            builder.cache_client(CacheClient {
+                store: Some(cache.clone()),
+                ..Default::default()
+            })
+        }
+    })
+    .await;
+
+    let foo_hash = context
+        .cached_registry_project(&cache, |path| async move {
+            tokio::fs::write(
+                path.join("project.bri"),
+                r#"
+                    export function fooFunction() {
+                        return "hello world!";
+                    }
+                "#,
+            )
+            .await
+            .unwrap();
+        })
+        .await;
+
+    let project_dir = context.mkdir("myproject").await;
+
+    let lockfile = brioche_core::project::Lockfile {
+        dependencies: [("foo".to_string(), foo_hash)].into_iter().collect(),
+        ..Default::default()
+    };
+    context
+        .write_lockfile(project_dir.join("brioche.lock"), &lockfile)
+        .await;
+
+    let project_root_contents = indoc::indoc! {r#"
+        import * as foo from "foo";
+
+        foo.fooFunctio // <-- completion here
+    "#};
+    let project_root = context
+        .write_file(project_dir.join("project.bri"), project_root_contents)
+        .await;
+
+    // Subscribe to diagnostics messages from the LSP server
+    let diagnostics_stream = lsp.subscribe_to_notifications::<notification::PublishDiagnostics>();
+    let mut diagnostics_stream = std::pin::pin!(diagnostics_stream);
+
+    lsp.notify::<notification::DidOpenTextDocument>(lsp_types::DidOpenTextDocumentParams {
+        text_document: TextDocumentItem::new(
+            Url::from_file_path(&project_root).unwrap(),
+            "brioche".to_string(),
+            1,
+            project_root_contents.to_string(),
+        ),
+    })
+    .await;
+
+    // Consume a diagnostics notification triggered by opening the document
+    tokio::time::timeout(WAIT_TIMEOUT, diagnostics_stream.try_next())
+        .await
+        .unwrap()
+        .unwrap();
+
+    // Trigger completions before 'foo' has been pulled from the cache. This
+    // should not find any completions, since the LSP should not pull from
+    // the cache just by triggering completions
+    let completion_response = lsp
+        .request::<request::Completion>(lsp_types::CompletionParams {
+            text_document_position: TextDocumentPositionParams::new(
+                TextDocumentIdentifier::new(Url::from_file_path(&project_root).unwrap()),
+                Position::new(2, 14),
+            ),
+            context: None,
+            partial_result_params: Default::default(),
+            work_done_progress_params: Default::default(),
+        })
+        .await
+        .expect("no completion response returned");
+    let completion_items = match completion_response {
+        lsp_types::CompletionResponse::Array(completion_items) => completion_items,
+        lsp_types::CompletionResponse::List(completion_list) => {
+            assert!(
+                !completion_list.is_incomplete,
+                "expected complete completion list"
+            );
+            completion_list.items
+        }
+    };
+    assert!(
+        completion_items.is_empty(),
+        "expected no completions: {completion_items:#?}"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_lsp_completions_from_workspace_import() -> anyhow::Result<()> {
+    let (_brioche, context, lsp) = brioche_test_support::brioche_lsp_test().await;
+
+    context
+        .write_toml(
+            "myworkspace/brioche_workspace.toml",
+            &brioche_core::project::WorkspaceDefinition {
+                members: vec!["./foo".parse().unwrap()],
+            },
+        )
+        .await;
+
+    context
+        .write_file(
+            "myworkspace/foo/project.bri",
+            indoc::indoc! {r#"
+                export function workspaceFunction() {
+                    return "hello world!";
+                }
+            "#},
+        )
+        .await;
+
+    let project_root_contents = indoc::indoc! {r#"
+        import * as foo from "foo";
+
+        foo.workspaceFunctio // <-- completion here
+    "#};
+    let project_root = context
+        .write_file("myworkspace/myproject/project.bri", project_root_contents)
+        .await;
+
+    lsp.notify::<notification::DidOpenTextDocument>(lsp_types::DidOpenTextDocumentParams {
+        text_document: TextDocumentItem::new(
+            Url::from_file_path(&project_root).unwrap(),
+            "brioche".to_string(),
+            1,
+            project_root_contents.to_string(),
+        ),
+    })
+    .await;
+
+    let completion_response = lsp
+        .request::<request::Completion>(lsp_types::CompletionParams {
+            text_document_position: TextDocumentPositionParams::new(
+                TextDocumentIdentifier::new(Url::from_file_path(&project_root).unwrap()),
+                Position::new(2, 20),
+            ),
+            context: None,
+            partial_result_params: Default::default(),
+            work_done_progress_params: Default::default(),
+        })
+        .await
+        .expect("no completion response returned");
+    let completion_items = match completion_response {
+        lsp_types::CompletionResponse::Array(completion_items) => completion_items,
+        lsp_types::CompletionResponse::List(completion_list) => {
+            assert!(
+                !completion_list.is_incomplete,
+                "expected complete completion list"
+            );
+            completion_list.items
+        }
+    };
+    assert!(!completion_items.is_empty(), "no completions returned");
+
+    let top_completion_item = &completion_items[0];
+    assert_eq!(
+        top_completion_item,
+        &lsp_types::CompletionItem {
+            label: "workspaceFunction".to_string(),
             ..Default::default()
         },
     );

--- a/crates/brioche-core/tests/lsp_on_save.rs
+++ b/crates/brioche-core/tests/lsp_on_save.rs
@@ -1,0 +1,583 @@
+use brioche_core::cache::CacheClient;
+use futures::TryStreamExt as _;
+use tower_lsp::lsp_types::{
+    self, notification, request, Position, TextDocumentIdentifier, TextDocumentItem,
+    TextDocumentPositionParams,
+};
+use url::Url;
+
+// Timeout used to wait for messages back from the LSP. This is mainly used
+// as a sanity check to prevent a test from hanging forever
+const WAIT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
+#[tokio::test]
+async fn test_lsp_on_save_respects_existing_lock() -> anyhow::Result<()> {
+    let (_brioche, context, lsp) = brioche_test_support::brioche_lsp_test().await;
+
+    let (foo_hash, _) = context
+        .local_registry_project(|path| async move {
+            tokio::fs::write(
+                path.join("project.bri"),
+                r#"
+                    export function fooFunction() {
+                        return "hello world!";
+                    }
+                "#,
+            )
+            .await
+            .unwrap();
+        })
+        .await;
+
+    let project_dir = context.mkdir("myproject").await;
+
+    let lockfile = brioche_core::project::Lockfile {
+        dependencies: [("foo".to_string(), foo_hash)].into_iter().collect(),
+        ..Default::default()
+    };
+    context
+        .write_lockfile(project_dir.join("brioche.lock"), &lockfile)
+        .await;
+
+    let project_root_contents = indoc::indoc! {r#"
+        import * as foo from "foo";
+
+        foo.fooFunctio // <-- completion here
+    "#};
+    let project_root = context
+        .write_file(project_dir.join("project.bri"), project_root_contents)
+        .await;
+
+    lsp.notify::<notification::DidOpenTextDocument>(lsp_types::DidOpenTextDocumentParams {
+        text_document: TextDocumentItem::new(
+            Url::from_file_path(&project_root).unwrap(),
+            "brioche".to_string(),
+            1,
+            project_root_contents.to_string(),
+        ),
+    })
+    .await;
+
+    let completion_response = lsp
+        .request::<request::Completion>(lsp_types::CompletionParams {
+            text_document_position: TextDocumentPositionParams::new(
+                TextDocumentIdentifier::new(Url::from_file_path(&project_root).unwrap()),
+                Position::new(2, 14),
+            ),
+            context: None,
+            partial_result_params: Default::default(),
+            work_done_progress_params: Default::default(),
+        })
+        .await
+        .expect("no completion response returned");
+    let completion_items = match completion_response {
+        lsp_types::CompletionResponse::Array(completion_items) => completion_items,
+        lsp_types::CompletionResponse::List(completion_list) => {
+            assert!(
+                !completion_list.is_incomplete,
+                "expected complete completion list"
+            );
+            completion_list.items
+        }
+    };
+    assert!(!completion_items.is_empty(), "no completions returned");
+
+    let top_completion_item = &completion_items[0];
+    assert_eq!(
+        top_completion_item,
+        &lsp_types::CompletionItem {
+            label: "fooFunction".to_string(),
+            ..Default::default()
+        },
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_lsp_on_save_fetches_locked_dependency() -> anyhow::Result<()> {
+    let cache = brioche_test_support::new_cache();
+    let (brioche, mut context, lsp) = brioche_test_support::brioche_lsp_test_with({
+        let cache = cache.clone();
+        move |builder| {
+            builder.cache_client(CacheClient {
+                store: Some(cache.clone()),
+                ..Default::default()
+            })
+        }
+    })
+    .await;
+
+    let foo_hash = context
+        .cached_registry_project(&cache, |path| async move {
+            tokio::fs::write(
+                path.join("project.bri"),
+                r#"
+                    export function fooFunction() {
+                        return "hello world!";
+                    }
+                "#,
+            )
+            .await
+            .unwrap();
+        })
+        .await;
+
+    let project_dir = context.mkdir("myproject").await;
+
+    let lockfile = brioche_core::project::Lockfile {
+        dependencies: [("foo".to_string(), foo_hash)].into_iter().collect(),
+        ..Default::default()
+    };
+    context
+        .write_lockfile(project_dir.join("brioche.lock"), &lockfile)
+        .await;
+
+    let project_root_contents = indoc::indoc! {r#"
+        import * as foo from "foo";
+
+        foo.fooFunctio // <-- completion here
+    "#};
+    let project_root = context
+        .write_file(project_dir.join("project.bri"), project_root_contents)
+        .await;
+
+    // Subscribe to diagnostics messages from the LSP server
+    let diagnostics_stream = lsp.subscribe_to_notifications::<notification::PublishDiagnostics>();
+    let mut diagnostics_stream = std::pin::pin!(diagnostics_stream);
+
+    lsp.notify::<notification::DidOpenTextDocument>(lsp_types::DidOpenTextDocumentParams {
+        text_document: TextDocumentItem::new(
+            Url::from_file_path(&project_root).unwrap(),
+            "brioche".to_string(),
+            1,
+            project_root_contents.to_string(),
+        ),
+    })
+    .await;
+
+    // Consume a diagnostics notification triggered by opening the document
+    tokio::time::timeout(WAIT_TIMEOUT, diagnostics_stream.try_next())
+        .await
+        .unwrap()
+        .unwrap();
+
+    // Trigger completions before 'foo' has been pulled from the cache. This
+    // should not find any completions, since the LSP should not pull from
+    // the cache until the user saves
+    let completion_response = lsp
+        .request::<request::Completion>(lsp_types::CompletionParams {
+            text_document_position: TextDocumentPositionParams::new(
+                TextDocumentIdentifier::new(Url::from_file_path(&project_root).unwrap()),
+                Position::new(2, 14),
+            ),
+            context: None,
+            partial_result_params: Default::default(),
+            work_done_progress_params: Default::default(),
+        })
+        .await
+        .expect("no completion response returned");
+    let completion_items = match completion_response {
+        lsp_types::CompletionResponse::Array(completion_items) => completion_items,
+        lsp_types::CompletionResponse::List(completion_list) => {
+            assert!(
+                !completion_list.is_incomplete,
+                "expected complete completion list"
+            );
+            completion_list.items
+        }
+    };
+    assert!(
+        completion_items.is_empty(),
+        "expected no completions: {completion_items:#?}"
+    );
+
+    // Trigger a save to make the LSP fetch 'foo' from the cache
+    lsp.notify::<notification::DidSaveTextDocument>(lsp_types::DidSaveTextDocumentParams {
+        text_document: TextDocumentIdentifier::new(Url::from_file_path(&project_root).unwrap()),
+        text: None,
+    })
+    .await;
+
+    // Wait for the server to publish diagnostics after saving. This is
+    // the most reliable indicator currently that the server finished
+    // fetching 'foo' after saving (but relies on the implementation detail
+    // that the LSP server publishes diagnostics at this point)
+    tokio::time::timeout(WAIT_TIMEOUT, diagnostics_stream.try_next())
+        .await
+        .unwrap()
+        .unwrap();
+
+    // Ensure 'foo' was downloaded
+    let foo_path = brioche.data_dir.join("projects").join(foo_hash.to_string());
+    assert!(
+        tokio::fs::try_exists(&foo_path).await.unwrap(),
+        "expected remote project 'foo' to be saved after saving in LSP"
+    );
+
+    // Validate the hash of 'foo'
+    {
+        let (brioche, _context) = brioche_test_support::brioche_test().await;
+        let (_projects, project_hash) = brioche_test_support::load_project(&brioche, &foo_path)
+            .await
+            .expect("failed to load remote project 'foo' after saving project in LSP");
+        assert_eq!(project_hash, foo_hash);
+    }
+
+    // Trigger completions again. This should include completions from 'foo'
+    // now that 'foo' has been downloaded from the cache
+    let completion_response = lsp
+        .request::<request::Completion>(lsp_types::CompletionParams {
+            text_document_position: TextDocumentPositionParams::new(
+                TextDocumentIdentifier::new(Url::from_file_path(&project_root).unwrap()),
+                Position::new(2, 14),
+            ),
+            context: None,
+            partial_result_params: Default::default(),
+            work_done_progress_params: Default::default(),
+        })
+        .await
+        .expect("no completion response returned");
+    let completion_items = match completion_response {
+        lsp_types::CompletionResponse::Array(completion_items) => completion_items,
+        lsp_types::CompletionResponse::List(completion_list) => {
+            assert!(
+                !completion_list.is_incomplete,
+                "expected complete completion list"
+            );
+            completion_list.items
+        }
+    };
+    assert!(!completion_items.is_empty(), "no completions returned");
+
+    let top_completion_item = &completion_items[0];
+    assert_eq!(
+        top_completion_item,
+        &lsp_types::CompletionItem {
+            label: "fooFunction".to_string(),
+            ..Default::default()
+        },
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_lsp_on_save_fetches_dependency_and_updates_lockfile() -> anyhow::Result<()> {
+    let cache = brioche_test_support::new_cache();
+    let (brioche, mut context, lsp) = brioche_test_support::brioche_lsp_test_with({
+        let cache = cache.clone();
+        move |builder| {
+            builder.cache_client(CacheClient {
+                store: Some(cache.clone()),
+                ..Default::default()
+            })
+        }
+    })
+    .await;
+
+    let foo_hash = context
+        .cached_registry_project(&cache, |path| async move {
+            tokio::fs::write(
+                path.join("project.bri"),
+                r#"
+                    export function fooFunction() {
+                        return "hello world!";
+                    }
+                "#,
+            )
+            .await
+            .unwrap();
+        })
+        .await;
+    context
+        .mock_registry_publish_tag("foo", "latest", foo_hash)
+        .create_async()
+        .await;
+
+    let project_dir = context.mkdir("myproject").await;
+
+    let project_root_contents = indoc::indoc! {r#"
+        import * as foo from "foo";
+
+        foo.fooFunctio // <-- completion here
+    "#};
+    let project_root = context
+        .write_file(project_dir.join("project.bri"), project_root_contents)
+        .await;
+
+    // Subscribe to diagnostics messages from the LSP server
+    let diagnostics_stream = lsp.subscribe_to_notifications::<notification::PublishDiagnostics>();
+    let mut diagnostics_stream = std::pin::pin!(diagnostics_stream);
+
+    lsp.notify::<notification::DidOpenTextDocument>(lsp_types::DidOpenTextDocumentParams {
+        text_document: TextDocumentItem::new(
+            Url::from_file_path(&project_root).unwrap(),
+            "brioche".to_string(),
+            1,
+            project_root_contents.to_string(),
+        ),
+    })
+    .await;
+
+    // Consume a diagnostics notification triggered by opening the document
+    tokio::time::timeout(WAIT_TIMEOUT, diagnostics_stream.try_next())
+        .await
+        .unwrap()
+        .unwrap();
+
+    // Trigger completions before 'foo' has been pulled from the cache. This
+    // should not find any completions, since the LSP should not pull from
+    // the cache / registry until the user saves
+    let completion_response = lsp
+        .request::<request::Completion>(lsp_types::CompletionParams {
+            text_document_position: TextDocumentPositionParams::new(
+                TextDocumentIdentifier::new(Url::from_file_path(&project_root).unwrap()),
+                Position::new(2, 14),
+            ),
+            context: None,
+            partial_result_params: Default::default(),
+            work_done_progress_params: Default::default(),
+        })
+        .await
+        .expect("no completion response returned");
+    let completion_items = match completion_response {
+        lsp_types::CompletionResponse::Array(completion_items) => completion_items,
+        lsp_types::CompletionResponse::List(completion_list) => {
+            assert!(
+                !completion_list.is_incomplete,
+                "expected complete completion list"
+            );
+            completion_list.items
+        }
+    };
+    assert!(
+        completion_items.is_empty(),
+        "expected no completions: {completion_items:#?}"
+    );
+
+    // Trigger a save to make the LSP fetch 'foo' from the cache
+    lsp.notify::<notification::DidSaveTextDocument>(lsp_types::DidSaveTextDocumentParams {
+        text_document: TextDocumentIdentifier::new(Url::from_file_path(&project_root).unwrap()),
+        text: None,
+    })
+    .await;
+
+    // Wait for the server to publish diagnostics after saving. This is
+    // the most reliable indicator currently that the server finished
+    // fetching 'foo' after saving (but relies on the implementation detail
+    // that the LSP server publishes diagnostics at this point)
+    tokio::time::timeout(WAIT_TIMEOUT, diagnostics_stream.try_next())
+        .await
+        .unwrap()
+        .unwrap();
+
+    // Ensure 'foo' was downloaded
+    let foo_path = brioche.data_dir.join("projects").join(foo_hash.to_string());
+    assert!(
+        tokio::fs::try_exists(&foo_path).await.unwrap(),
+        "expected remote project 'foo' to be saved after saving in LSP"
+    );
+
+    // Validate the hash of 'foo'
+    {
+        let (brioche, _context) = brioche_test_support::brioche_test().await;
+        let (_projects, project_hash) = brioche_test_support::load_project(&brioche, &foo_path)
+            .await
+            .expect("failed to load remote project 'foo' after saving project in LSP");
+        assert_eq!(project_hash, foo_hash);
+    }
+
+    // Validate that the lockfile was created properly
+    let project_lockfile_path = project_dir.join("brioche.lock");
+    assert!(tokio::fs::try_exists(&project_lockfile_path).await.unwrap());
+    let project_lockfile_contents = tokio::fs::read_to_string(&project_lockfile_path).await?;
+    let project_lockfile: brioche_core::project::Lockfile =
+        serde_json::from_str(&project_lockfile_contents)?;
+    assert_eq!(
+        project_lockfile,
+        brioche_core::project::Lockfile {
+            dependencies: [("foo".into(), foo_hash)].into_iter().collect(),
+            ..Default::default()
+        },
+    );
+
+    // Trigger completions again. This should include completions from 'foo'
+    // now that 'foo' has been downloaded from the cache
+    let completion_response = lsp
+        .request::<request::Completion>(lsp_types::CompletionParams {
+            text_document_position: TextDocumentPositionParams::new(
+                TextDocumentIdentifier::new(Url::from_file_path(&project_root).unwrap()),
+                Position::new(2, 14),
+            ),
+            context: None,
+            partial_result_params: Default::default(),
+            work_done_progress_params: Default::default(),
+        })
+        .await
+        .expect("no completion response returned");
+    let completion_items = match completion_response {
+        lsp_types::CompletionResponse::Array(completion_items) => completion_items,
+        lsp_types::CompletionResponse::List(completion_list) => {
+            assert!(
+                !completion_list.is_incomplete,
+                "expected complete completion list"
+            );
+            completion_list.items
+        }
+    };
+    assert!(!completion_items.is_empty(), "no completions returned");
+
+    let top_completion_item = &completion_items[0];
+    assert_eq!(
+        top_completion_item,
+        &lsp_types::CompletionItem {
+            label: "fooFunction".to_string(),
+            ..Default::default()
+        },
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_lsp_on_save_only_updates_dependencies_in_lockfile() -> anyhow::Result<()> {
+    let cache = brioche_test_support::new_cache();
+    let (_brioche, mut context, lsp) = brioche_test_support::brioche_lsp_test_with({
+        let cache = cache.clone();
+        move |builder| {
+            builder.cache_client(CacheClient {
+                store: Some(cache.clone()),
+                ..Default::default()
+            })
+        }
+    })
+    .await;
+
+    let foo_hash = context
+        .cached_registry_project(&cache, |path| async move {
+            tokio::fs::write(
+                path.join("project.bri"),
+                r#"
+                    export function fooFunction() {
+                        return "hello world!";
+                    }
+                "#,
+            )
+            .await
+            .unwrap();
+        })
+        .await;
+    context
+        .mock_registry_publish_tag("foo", "latest", foo_hash)
+        .create_async()
+        .await;
+
+    let bar_hash = context
+        .cached_registry_project(&cache, |path| async move {
+            tokio::fs::write(
+                path.join("project.bri"),
+                r#"
+                    export function barFunction() {
+                        return "hello world!";
+                    }
+                "#,
+            )
+            .await
+            .unwrap();
+        })
+        .await;
+
+    let project_dir = context.mkdir("myproject").await;
+
+    let project_root_contents = indoc::indoc! {r#"
+        import * as foo from "foo";
+
+        Brioche.download("https://example.org/");
+        Brioche.gitRef({
+            repository: "https://example.org/repo.git",
+            ref: "main",
+        });
+    "#};
+    let project_root = context
+        .write_file(project_dir.join("project.bri"), project_root_contents)
+        .await;
+
+    // Initial lockfile contains out-of-date dependencies, downloads, and
+    // git refs
+    let project_initial_lockfile = brioche_core::project::Lockfile {
+        dependencies: [("bar".into(), bar_hash)].into_iter().collect(),
+        downloads: [(
+            "https://example.com/".parse().unwrap(),
+            brioche_core::Hasher::new_sha256().finish().unwrap(),
+        )]
+        .into_iter()
+        .collect(),
+        git_refs: [(
+            "https://example.com/repo.git".parse().unwrap(),
+            [(
+                "main".into(),
+                "bb43d030babf4df990d7294f10f74ef7e23f7c21".into(),
+            )]
+            .into_iter()
+            .collect(),
+        )]
+        .into_iter()
+        .collect(),
+    };
+    context
+        .write_lockfile(project_dir.join("brioche.lock"), &project_initial_lockfile)
+        .await;
+
+    // Subscribe to diagnostics messages from the LSP server
+    let diagnostics_stream = lsp.subscribe_to_notifications::<notification::PublishDiagnostics>();
+    let mut diagnostics_stream = std::pin::pin!(diagnostics_stream);
+
+    lsp.notify::<notification::DidOpenTextDocument>(lsp_types::DidOpenTextDocumentParams {
+        text_document: TextDocumentItem::new(
+            Url::from_file_path(&project_root).unwrap(),
+            "brioche".to_string(),
+            1,
+            project_root_contents.to_string(),
+        ),
+    })
+    .await;
+
+    // Consume a diagnostics notification triggered by opening the document
+    tokio::time::timeout(WAIT_TIMEOUT, diagnostics_stream.try_next())
+        .await
+        .unwrap()
+        .unwrap();
+
+    // Trigger a save, which should make the LSP partially update the lockfile
+    lsp.notify::<notification::DidSaveTextDocument>(lsp_types::DidSaveTextDocumentParams {
+        text_document: TextDocumentIdentifier::new(Url::from_file_path(&project_root).unwrap()),
+        text: None,
+    })
+    .await;
+
+    // Wait for the server to publish diagnostics after saving. This is
+    // the most reliable indicator currently that the LSP finished with saving
+    tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        diagnostics_stream.try_next(),
+    )
+    .await
+    .unwrap()
+    .unwrap();
+
+    let project_lockfile_path = project_dir.join("brioche.lock");
+    assert!(tokio::fs::try_exists(&project_lockfile_path).await.unwrap());
+    let project_lockfile_contents = tokio::fs::read_to_string(&project_lockfile_path).await?;
+    let project_lockfile: brioche_core::project::Lockfile =
+        serde_json::from_str(&project_lockfile_contents)?;
+
+    // Validate that the lockfile only updated the 'dependencies' list
+    let expected_updated_lockfile = brioche_core::project::Lockfile {
+        dependencies: [("foo".into(), foo_hash)].into_iter().collect(),
+        ..project_initial_lockfile
+    };
+    assert_eq!(project_lockfile, expected_updated_lockfile);
+
+    Ok(())
+}

--- a/crates/brioche-test-support/Cargo.toml
+++ b/crates/brioche-test-support/Cargo.toml
@@ -24,6 +24,7 @@ toml = "0.8.20"
 tower-lsp = "0.20.0"
 tracing = "0.1.41"
 ulid = "1.2.0"
+url = "2.5.4"
 zstd = "0.13.2"
 
 [lints]

--- a/crates/brioche-test-support/Cargo.toml
+++ b/crates/brioche-test-support/Cargo.toml
@@ -7,7 +7,9 @@ rust-version.workspace = true
 [dependencies]
 anyhow = { version = "1.0.95", features = ["backtrace"] }
 brioche-core = { path = "../brioche-core" }
+bstr = "1.11.3"
 directories = "6.0.0"
+futures = "0.3.31"
 hex = "0.4.3"
 mockito = "1.6.1"
 object_store = { git = "https://github.com/brioche-dev/arrow-rs.git", branch = "object-store-disable-all-compression-formats" }
@@ -17,7 +19,9 @@ serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1.0.138"
 tempdir = "0.3.7"
 tokio = { version = "1.43.0", features = ["full", "tracing"] }
+tokio-util = { version = "0.7.13", features = ["full"] }
 toml = "0.8.20"
+tower-lsp = "0.20.0"
 tracing = "0.1.41"
 ulid = "1.2.0"
 zstd = "0.13.2"

--- a/crates/brioche-test-support/Cargo.toml
+++ b/crates/brioche-test-support/Cargo.toml
@@ -19,6 +19,7 @@ serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1.0.138"
 tempdir = "0.3.7"
 tokio = { version = "1.43.0", features = ["full", "tracing"] }
+tokio-stream = { version = "0.1.17", features = ["sync"] }
 tokio-util = { version = "0.7.13", features = ["full"] }
 toml = "0.8.20"
 tower-lsp = "0.20.0"

--- a/crates/brioche-test-support/src/lib.rs
+++ b/crates/brioche-test-support/src/lib.rs
@@ -858,6 +858,7 @@ pub async fn brioche_lsp_test() -> (Brioche, TestContext, LspContext) {
     let (brioche, context) = brioche_test_with(|builder| {
         builder
             .registry_client(brioche_core::registry::RegistryClient::disabled())
+            .cache_client(brioche_core::cache::CacheClient::default())
             .vfs(brioche_core::vfs::Vfs::mutable())
     })
     .await;

--- a/crates/brioche/src/lsp.rs
+++ b/crates/brioche/src/lsp.rs
@@ -19,6 +19,7 @@ pub async fn lsp(_args: LspArgs) -> anyhow::Result<()> {
             let (reporter, _guard) = brioche_core::reporter::start_lsp_reporter(client.clone());
             let brioche = brioche_core::BriocheBuilder::new(reporter)
                 .registry_client(brioche_core::registry::RegistryClient::disabled())
+                .cache_client(brioche_core::cache::CacheClient::default())
                 .vfs(brioche_core::vfs::Vfs::mutable())
                 .build()
                 .await?;


### PR DESCRIPTION
Fixes #186

This PR includes various bugfixes from the LSP. This originally stemmed from the regressions mentioned in #186, but I decided to tackle this issue by writing some integration tests for the LSP and kept running into various other (longstanding) bugs too.

So, there are a number of integration tests for the LSP now. It's not super comprehensive (mostly covering completions and handling the `didSave` notification), but I feel it's a good start.

Here's an overview of the bugs fixed in this PR:

- Fix regression where LSP would always try to download dependencies from the cache (and fail) during normal LSP requests (`didChange`, `completions`, etc.). Now, dependencies are only fetched if not already saved locally, and remote cache access is only enabled when handling the `didSave` notification (just like registry access). This resolves #186
- Update various LSP requests to load documents if not already loaded
- Fix potential deadlock in `BriocheCompilerHost.load_documents()`
  - I only hit this when running integration tests, so this may be a quirk of how the Tokio runtime is configured in tests vs. in the CLI. Still good to fix properly though
- Fix imports not always resolving properly when handling `didSave` notification, by re-loading the saved document
- Fix `console.log`, etc. calls from LSP JS bridge code writing to stdout/stderr, corrupting the LSP's stdio communication
- Fix some exceptions from LSP JS bridge code when line/column values are out of range. This should fix some cases where the LSP would need to be restarted due to repeated "channel closed" errors
- Fix LSP ignoring file contents from client's `didOpen` notification
  - I ran into this when re-opening a VS Code workspace that had unsaved changes. The on-disk file will differ from the contents provided by `didOpen` in this case, leading to a desync between the LSP client and server
- Increase project loading timeout when handling `didSave` notification. This gives more time for the LSP to pull dependencies from the cache