### PR TITLE
Tweak LSP to keep unused dependencies when saving

### DIFF
--- a/crates/brioche-core/tests/lsp_on_save.rs
+++ b/crates/brioche-core/tests/lsp_on_save.rs
@@ -441,7 +441,7 @@ async fn test_lsp_on_save_fetches_dependency_and_updates_lockfile() -> anyhow::R
 }
 
 #[tokio::test]
-async fn test_lsp_on_save_only_updates_dependencies_in_lockfile() -> anyhow::Result<()> {
+async fn test_lsp_on_save_only_adds_new_dependencies_in_lockfile() -> anyhow::Result<()> {
     let cache = brioche_test_support::new_cache();
     let (_brioche, mut context, lsp) = brioche_test_support::brioche_lsp_test_with({
         let cache = cache.clone();
@@ -572,9 +572,12 @@ async fn test_lsp_on_save_only_updates_dependencies_in_lockfile() -> anyhow::Res
     let project_lockfile: brioche_core::project::Lockfile =
         serde_json::from_str(&project_lockfile_contents)?;
 
-    // Validate that the lockfile only updated the 'dependencies' list
+    // Validate that the lockfile only added 'foo' as a dependency. Statics
+    // and unused dependencies should not be touched when saving in the LSP
     let expected_updated_lockfile = brioche_core::project::Lockfile {
-        dependencies: [("foo".into(), foo_hash)].into_iter().collect(),
+        dependencies: [("foo".into(), foo_hash), ("bar".into(), bar_hash)]
+            .into_iter()
+            .collect(),
         ..project_initial_lockfile
     };
     assert_eq!(project_lockfile, expected_updated_lockfile);


### PR DESCRIPTION
This PR tweaks how lockfiles are updated when handling the `didSave` LSP event.

When the LSP client sends a `didSave` event, the LSP server will fetch dependencies and update the lockfile. If there's an existing lockfile, the current behavior is to completely override the `dependencies` section of the lockfile, leaving the `downloads` and `git_refs` sections in tact (since the LSP only fetches project dependencies, not statics).

Say you commented out a line like `import nodejs from "nodejs";` then hit save. The LSP would update the lockfile and remove the currently locked version of the `nodejs` dependency. Then, if you were to uncomment the line and hit save again, the LSP would fetch the latest version of `nodejs` and commit it to the lockfile, potentially locking to a new version unintentionally.

This PR tweaks it so the `didSave` LSP handler only adds _new_ dependencies to the lockfile-- existing dependencies are now left in place when saving, even if they are unused. I think this new behavior is more conservative and feels more appropriate for the LSP. This change does not affect the behavior of CLI commands like `brioche build`, which will still fully update the lockfile, removing any unused dependencies.