### PR TITLE
Tweak Dependabot config to ignore `biome` package updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,5 @@ updates:
     cargo:
       patterns:
         - "*"
+      exclude-patterns:
+        - "biome_*"


### PR DESCRIPTION
This PR tweaks the Dependabot config so Dependabot doesn't try to update any of our Biome dependencies. Biome's published Cargo packages don't seem to follow the general semver semantics used by most packages on https://crates.io (i.e. Biome has had breaking changes going from `0.x.y` to `0.x.z`), so it doesn't seem like we'll be able to smoothly use Dependabot to manage updates for them. See #184 for more context.