### PR TITLE
Support using more expressions when evaluating statics in project analysis

### DIFF
--- a/crates/brioche-core/src/project/analyze.rs
+++ b/crates/brioche-core/src/project/analyze.rs
@@ -796,11 +796,26 @@ fn expression_to_json(
 
             Ok(value.clone())
         }
-        Expr::JsParenthesizedExpression(_) => todo!(),
-        Expr::TsAsExpression(_) => todo!(),
-        Expr::TsNonNullAssertionExpression(_) => todo!(),
-        Expr::TsSatisfiesExpression(_) => todo!(),
-        Expr::TsTypeAssertionExpression(_) => todo!(),
+        Expr::JsParenthesizedExpression(expr) => {
+            let value = expression_to_json(&expr.expression()?, env)?;
+            Ok(value)
+        }
+        Expr::TsAsExpression(expr) => {
+            let value = expression_to_json(&expr.expression()?, env)?;
+            Ok(value)
+        }
+        Expr::TsNonNullAssertionExpression(expr) => {
+            let value = expression_to_json(&expr.expression()?, env)?;
+            Ok(value)
+        }
+        Expr::TsSatisfiesExpression(expr) => {
+            let value = expression_to_json(&expr.expression()?, env)?;
+            Ok(value)
+        }
+        Expr::TsTypeAssertionExpression(expr) => {
+            let value = expression_to_json(&expr.expression()?, env)?;
+            Ok(value)
+        }
         _ => {
             anyhow::bail!("unsupported expression");
         }


### PR DESCRIPTION
This PR updates the project analysis to support converting several more types of constant JS expressions to JSON values, which lets these expressions be used for [statics](https://brioche.dev/docs/core-concepts/projects/#statics).

In this case, these are all fairly "boring" types of expressions (`as` casts, `satisfies`, etc.), but it can be convenient e.g. to use `satisfies` to validate the `project` export. Also, each of these expressions were marked with `todo!()`s already, I think I previously just forgot to implement them...