### PR TITLE
Fix occasional error when an inline cache archive contains an empty blob

### DIFF
--- a/crates/brioche-core/tests/cache_client.rs
+++ b/crates/brioche-core/tests/cache_client.rs
@@ -412,14 +412,14 @@ async fn build_artifact_with_some_small_files(
         )
         .await
         .unwrap();
-    // directory
-    //     .insert(
-    //         brioche,
-    //         b"little-files/empty.txt",
-    //         Some(brioche_test_support::file(empty_blob, false)),
-    //     )
-    //     .await
-    //     .unwrap();
+    directory
+        .insert(
+            brioche,
+            b"little-files/empty.txt",
+            Some(brioche_test_support::file(empty_blob, false)),
+        )
+        .await
+        .unwrap();
 
     Artifact::Directory(directory)
 }


### PR DESCRIPTION
This PR fixes a bug introduced with the new cache in #179, where an archive in the cache containing an empty blob could sometimes fail to be read, resulting in the following error:

```
internal error: entered unreachable code: needed blobs are out of order
```

This recently caused a build failure in Brioche Packages in [CI #597](https://github.com/brioche-dev/brioche-packages/actions/runs/13560586298/job/37903036788) (commit https://github.com/brioche-dev/brioche-packages/commit/2b5e48222806ba6a7ebe3e0902e013800b48aae1, failed while building `packages/amber`)

The failure wasn't always consistent because (1) the contents of the archive had to be small enough that it fit inline within the archive (meaning the total size of all blobs had to be less than 2 MB), and (2) the blob had to come after another blob in the archive. This didn't cause problems when the archive was broken up into chunks, since that code path already accounted for empty blobs explicitly.

I decided to fix it by special-casing empty blobs before reading _any_ blobs from the archive. This also helped to clean up the chunk fetching code a bit. I also un-commented a commented-out test case that would've caught this bug before (I think I hit the same bug previously, commented the test case out while working on another issue, and either forgot to uncomment it or thought the test failure wasn't relevant in some way)