### PR TITLE
Update Dependabot and switch to ARM64 for aarch64 builds

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,15 @@
 version: 2
 updates:
-- package-ecosystem: "cargo"
-  directory: "/"
-  schedule:
-    interval: "weekly"
-    day: "friday"
-    time: "17:00"
-    timezone: "America/Los_Angeles"
-  groups:
-    cargo:
-      patterns:
-        - "*"
-      exclude-patterns:
-        - "biome_*"
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "friday"
+      time: "17:00"
+      timezone: "America/Los_Angeles"
+    groups:
+      cargo:
+        patterns:
+          - "*"
+ignore:
+  - dependency-name: "biome_*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,37 +56,55 @@ jobs:
           brioche check
           brioche fmt --check
   test:
-    name: Run tests [${{ matrix.platform.runs_on }}]
+    name: Run tests [${{ matrix.test.name }}]
     strategy:
       matrix:
-        platform:
-          - name: Ubuntu 22.04
+        test:
+          - name: x86-64 Ubuntu 22.04
             runs_on: ubuntu-22.04
 
-          - name: Ubuntu 22.04 + PRoot
+          - name: x86-64 Ubuntu 22.04 + PRoot
             runs_on: ubuntu-22.04
             setup: |
               echo 'BRIOCHE_TEST_SANDBOX=linux_namespace' >> "$GITHUB_ENV"
               echo 'BRIOCHE_TEST_SANDBOX_PROOT=true' >> "$GITHUB_ENV"
 
-          - name: Ubuntu 24.04
+          - name: x86-64 Ubuntu 24.04
             runs_on: ubuntu-24.04
 
-          - name: Ubuntu 24.04 + Namespaces
+          - name: x86-64 Ubuntu 24.04 + Namespaces
             runs_on: ubuntu-24.04
             setup: |
               echo 'kernel.apparmor_restrict_unprivileged_userns = 0' | sudo tee /etc/sysctl.d/99-userns.conf
               sudo sysctl --system
 
-          - name: macOS 14
+          - name: aarch64 Ubuntu 22.04
+            runs_on: ubuntu-22.04-arm
+
+          - name: aarch64 Ubuntu 22.04 + PRoot
+            runs_on: ubuntu-22.04-arm
+            setup: |
+              echo 'BRIOCHE_TEST_SANDBOX=linux_namespace' >> "$GITHUB_ENV"
+              echo 'BRIOCHE_TEST_SANDBOX_PROOT=true' >> "$GITHUB_ENV"
+
+          - name: aarch64 Ubuntu 24.04
+            runs_on: ubuntu-24.04-arm
+
+          - name: aarch64 Ubuntu 24.04 + Namespaces
+            runs_on: ubuntu-24.04-arm
+            setup: |
+              echo 'kernel.apparmor_restrict_unprivileged_userns = 0' | sudo tee /etc/sysctl.d/99-userns.conf
+              sudo sysctl --system
+
+          - name: aarch64 macOS 14
             runs_on: macos-14
-    runs-on: ${{ matrix.platform.runs_on }}
+    runs-on: ${{ matrix.test.runs_on }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Set up runner
-        if: matrix.platform.setup
-        run: ${{ matrix.platform.setup }}
+        if: matrix.test.setup
+        run: ${{ matrix.test.setup }}
       # Run tests in release mode. Running tests in debug mode uses a lot
       # more disk space, so much so that it can cause the run to fail
       - name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,7 @@ jobs:
         run: |
           brioche check
           brioche fmt --check
+
   test:
     name: Run tests [${{ matrix.test.name }}]
     strategy:
@@ -109,6 +110,15 @@ jobs:
       # more disk space, so much so that it can cause the run to fail
       - name: Run tests
         run: cargo test --all --release
+
+  # Extra job that succeeds when all test jobs succeed (useful for PR requirements)
+  all-tests-passed:
+    name: All tests passed
+    needs: [test]
+    runs-on: ubuntu-24.04
+    steps:
+      - run: ':'
+
   build:
     name: Build artifacts [${{ matrix.platform.name }}]
     if: github.event_name == 'push'
@@ -176,6 +186,7 @@ jobs:
           name: brioche-${{ matrix.platform.name }}
           if-no-files-found: error
           path: artifacts/brioche
+
   build-packed:
     name: Build packed artifacts
     if: github.event_name == 'push'
@@ -209,10 +220,11 @@ jobs:
           name: brioche-packed-x86_64-linux
           if-no-files-found: error
           path: artifacts/brioche-packed
+
   push:
     name: Push artifacts
     if: github.event_name == 'push' && github.repository == 'brioche-dev/brioche'
-    needs: [check, test, build, build-packed]
+    needs: [check, all-tests-passed, build, build-packed]
     runs-on: ubuntu-24.04
     steps:
       - name: Install AWS CLI

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,31 +56,30 @@ jobs:
           brioche check
           brioche fmt --check
   test:
-    name: Run tests
+    name: Run tests [${{ matrix.platform.runs_on }}]
     strategy:
       matrix:
         platform:
-          # Ubuntu 22.04
-          - runs_on: ubuntu-22.04
+          - name: Ubuntu 22.04
+            runs_on: ubuntu-22.04
 
-          # Ubuntu 22.04 but configured to use PRoot explicitly
-          - runs_on: ubuntu-22.04
+          - name: Ubuntu 22.04 + PRoot
+            runs_on: ubuntu-22.04
             setup: |
               echo 'BRIOCHE_TEST_SANDBOX=linux_namespace' >> "$GITHUB_ENV"
               echo 'BRIOCHE_TEST_SANDBOX_PROOT=true' >> "$GITHUB_ENV"
 
-          # Ubuntu 24.04 with default config, which restricts user namespaces.
-          # So, this test should fallback to using PRoot by default
-          - runs_on: ubuntu-24.04
+          - name: Ubuntu 24.04
+            runs_on: ubuntu-24.04
 
-          # Ubuntu 24.04, but enabling unrestricted user namespaces
-          - runs_on: ubuntu-24.04
+          - name: Ubuntu 24.04 + Namespaces
+            runs_on: ubuntu-24.04
             setup: |
               echo 'kernel.apparmor_restrict_unprivileged_userns = 0' | sudo tee /etc/sysctl.d/99-userns.conf
               sudo sysctl --system
 
-          # macOS 14
-          - runs_on: macos-14
+          - name: macOS 14
+            runs_on: macos-14
     runs-on: ${{ matrix.platform.runs_on }}
     steps:
       - name: Checkout code
@@ -93,7 +92,7 @@ jobs:
       - name: Run tests
         run: cargo test --all --release
   build:
-    name: Build artifacts
+    name: Build artifacts [${{ matrix.platform.name }}]
     if: github.event_name == 'push'
     strategy:
       matrix:
@@ -102,12 +101,8 @@ jobs:
             runs_on: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
           - name: aarch64-linux
-            runs_on: ubuntu-22.04
+            runs_on: ubuntu-22.04-arm
             target: aarch64-unknown-linux-gnu
-            features: openssl/vendored
-            install_deps: |
-              sudo apt-get install -y gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu
-              echo 'CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc' >> $GITHUB_ENV
           - name: x86_64-macos
             runs_on: macos-14
             target: x86_64-apple-darwin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,24 +79,6 @@ jobs:
               echo 'kernel.apparmor_restrict_unprivileged_userns = 0' | sudo tee /etc/sysctl.d/99-userns.conf
               sudo sysctl --system
 
-          - name: aarch64 Ubuntu 22.04
-            runs_on: ubuntu-22.04-arm
-
-          - name: aarch64 Ubuntu 22.04 + PRoot
-            runs_on: ubuntu-22.04-arm
-            setup: |
-              echo 'BRIOCHE_TEST_SANDBOX=linux_namespace' >> "$GITHUB_ENV"
-              echo 'BRIOCHE_TEST_SANDBOX_PROOT=true' >> "$GITHUB_ENV"
-
-          - name: aarch64 Ubuntu 24.04
-            runs_on: ubuntu-24.04-arm
-
-          - name: aarch64 Ubuntu 24.04 + Namespaces
-            runs_on: ubuntu-24.04-arm
-            setup: |
-              echo 'kernel.apparmor_restrict_unprivileged_userns = 0' | sudo tee /etc/sysctl.d/99-userns.conf
-              sudo sysctl --system
-
           - name: aarch64 macOS 14
             runs_on: macos-14
     runs-on: ${{ matrix.test.runs_on }}

--- a/crates/brioche-core/src/bake/process.rs
+++ b/crates/brioche-core/src/bake/process.rs
@@ -609,7 +609,7 @@ pub async fn bake_process(
         Err(error) => {
             return Err(error).with_context(|| {
                 format!(
-                    "process failed, view full output by runing `brioche jobs logs {}`",
+                    "process failed, view full output by runinng `brioche jobs logs {}`",
                     events_path.display(),
                 )
             });


### PR DESCRIPTION
This PR is a minimal update to the "CI" GitHub Actions workflow and to the Dependabot config:

- Fix Dependabot exclusions introduced in #193 (the previous config excluded `biome` dependencies from the grouped Dependabot PR, which led to separate PRs for each `biome` update... the change here should actually ignore these dependencies now)
- Switch to the new `ubuntu-22.04-arm` GitHub Actions runner type when running aarch64 Brioche builds
- ~~Run tests in CI for Linux on both aarch64 and x86-64~~
  - Removed due to test failures in `bake_process` tests, see: https://github.com/brioche-dev/brioche/actions/runs/13611821322/job/38049997140
- Clean up GH Actions job labels
- Add a new "All tests passed" job to the GH Actions workflow-- this can be used to simplify how PR requirements are configured
- Fix a random typo I spotted ("runing" → "running")