### PR TITLE
Enable more Clippy lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,14 +3,56 @@ edition = "2024"
 rust-version = "1.85" # To align with the rust-toolchain.toml
 
 [workspace]
-members = ["crates/brioche", "crates/brioche-core", "crates/brioche-pack", "crates/brioche-test-support"]
+members = [
+    "crates/brioche",
+    "crates/brioche-core",
+    "crates/brioche-pack",
+    "crates/brioche-test-support",
+]
 resolver = "3"
 
 [workspace.lints.clippy]
 all = { level = "warn", priority = -1 }
-print_stdout = { level = "warn" }
-print_stderr = { level = "warn" }
-unused_trait_names = { level = "warn" }
+allow_attributes = "warn"
+cast_lossless = "warn"
+cast_possible_truncation = "warn"
+cast_possible_wrap = "warn"
+checked_conversions = "warn"
+dbg_macro = "warn"
+explicit_deref_methods = "warn"
+explicit_into_iter_loop = "warn"
+explicit_iter_loop = "warn"
+filter_map_next = "warn"
+flat_map_option = "warn"
+if_not_else = "warn"
+implicit_clone = "warn"
+large_const_arrays = "warn"
+large_futures = "warn"
+large_stack_frames = "warn"
+manual_assert = "warn"
+manual_is_variant_and = "warn"
+manual_let_else = "warn"
+map_unwrap_or = "warn"
+needless_continue = "warn"
+needless_for_each = "warn"
+needless_pass_by_ref_mut = "warn"
+needless_pass_by_value = "warn"
+option_as_ref_cloned = "warn"
+print_stderr = "warn"
+print_stdout = "warn"
+redundant_clone = "warn"
+ref_option = "warn"
+ref_option_ref = "warn"
+semicolon_if_nothing_returned = "warn"
+trivially_copy_pass_by_ref = "warn"
+uninlined_format_args = "warn"
+unnecessary_wraps = "warn"
+unnested_or_patterns = "warn"
+unused_async = "warn"
+unused_self = "warn"
+unused_trait_names = "warn"
+used_underscore_binding = "warn"
+used_underscore_items = "warn"
 
 [profile.dev]
 # Enable optimizations for debug builds because the JS runs slow without it.

--- a/crates/brioche-core/benches/bake.rs
+++ b/crates/brioche-core/benches/bake.rs
@@ -27,7 +27,7 @@ fn cached_bake_deep_dir(bencher: divan::Bencher) {
             .await
             .unwrap();
         });
-    })
+    });
 }
 
 #[divan::bench]
@@ -50,7 +50,7 @@ fn cached_bake_wide_dir(bencher: divan::Bencher) {
             .await
             .unwrap();
         });
-    })
+    });
 }
 
 #[divan::bench]
@@ -73,7 +73,7 @@ fn cached_bake_deep_merge(bencher: divan::Bencher) {
             .await
             .unwrap();
         });
-    })
+    });
 }
 
 #[divan::bench]
@@ -96,7 +96,7 @@ fn cached_bake_wide_merge(bencher: divan::Bencher) {
             .await
             .unwrap();
         });
-    })
+    });
 }
 
 fn set_up_bench() -> RecipesContext {

--- a/crates/brioche-core/src/cache.rs
+++ b/crates/brioche-core/src/cache.rs
@@ -48,8 +48,9 @@ pub async fn cache_client_from_config_or_default(
     config: Option<&crate::config::CacheConfig>,
 ) -> anyhow::Result<CacheClient> {
     let max_concurrent_operations = config
-        .map(|config| config.max_concurrent_operations)
-        .unwrap_or(DEFAULT_CACHE_MAX_CONCURRENT_OPERATIONS);
+        .map_or(DEFAULT_CACHE_MAX_CONCURRENT_OPERATIONS, |config| {
+            config.max_concurrent_operations
+        });
     let (url, writable) = match config {
         Some(config) => (config.url.clone(), !config.read_only),
         None => (DEFAULT_CACHE_URL.parse()?, false),

--- a/crates/brioche-core/src/cache/archive.rs
+++ b/crates/brioche-core/src/cache/archive.rs
@@ -1003,8 +1003,8 @@ impl ArtifactBuilder {
                 };
 
                 Artifact::File(crate::recipe::File {
-                    executable,
                     content_blob,
+                    executable,
                     resources,
                 })
             }

--- a/crates/brioche-core/src/download.rs
+++ b/crates/brioche-core/src/download.rs
@@ -7,6 +7,7 @@ use crate::{
     reporter::job::{NewJob, UpdateJob},
 };
 
+#[expect(clippy::cast_possible_truncation)]
 #[tracing::instrument(skip(brioche, expected_hash))]
 pub async fn download(
     brioche: &Brioche,

--- a/crates/brioche-core/src/lib.rs
+++ b/crates/brioche-core/src/lib.rs
@@ -287,8 +287,8 @@ impl BriocheBuilder {
                         };
                         Some(config::CacheConfig {
                             url,
-                            read_only,
                             max_concurrent_operations,
+                            read_only,
                             allow_http,
                         })
                     }

--- a/crates/brioche-core/src/output.rs
+++ b/crates/brioche-core/src/output.rs
@@ -53,7 +53,7 @@ pub async fn create_output(
     Ok(())
 }
 
-#[allow(clippy::multiple_bound_locations)]
+#[expect(clippy::multiple_bound_locations)]
 #[async_recursion::async_recursion]
 async fn create_output_inner<'a: 'async_recursion>(
     brioche: &Brioche,
@@ -390,7 +390,7 @@ async fn create_local_output_inner(
             Artifact::Directory(_) => {
                 set_directory_permissions(&local_path, SetDirectoryPermissions { readonly: true })
                     .await
-                    .context("failed to set permissions for local output directory")?
+                    .context("failed to set permissions for local output directory")?;
             }
             Artifact::Symlink { .. } => {}
         }

--- a/crates/brioche-core/src/process_events/display.rs
+++ b/crates/brioche-core/src/process_events/display.rs
@@ -15,7 +15,7 @@ pub struct DisplayEventsOptions {
 #[expect(clippy::print_stdout)]
 pub fn display_events<R>(
     reader: &mut ProcessEventReader<R>,
-    options: DisplayEventsOptions,
+    options: &DisplayEventsOptions,
 ) -> anyhow::Result<()>
 where
     R: std::io::Read + std::io::Seek,
@@ -124,16 +124,16 @@ where
                     };
 
                     let Some(line_number) = stack_frame.line_number else {
-                        println!("- {}", file_name);
+                        println!("- {file_name}");
                         continue;
                     };
 
                     let Some(column_number) = stack_frame.column_number else {
-                        println!("- {}:{}", file_name, line_number);
+                        println!("- {file_name}:{line_number}");
                         continue;
                     };
 
-                    println!("- {}:{}:{}", file_name, line_number, column_number);
+                    println!("- {file_name}:{line_number}:{column_number}");
                 }
 
                 if stack_frames.is_empty() {

--- a/crates/brioche-core/src/process_events/reader.rs
+++ b/crates/brioche-core/src/process_events/reader.rs
@@ -200,7 +200,7 @@ where
                 .length
                 .try_into()
                 .map_err(|_| ProcessEventReadError::LengthOutOfRange {
-                    length: end_marker.length as _,
+                    length: end_marker.length.try_into().unwrap_or_default(),
                 })?;
 
         // Get the position of the start marker for the event by subtracting
@@ -249,7 +249,7 @@ where
             .checked_add(PROCESS_EVENT_MARKER_LENGTH)
             .and_then(|offset| offset.try_into().ok())
             .ok_or(ProcessEventReadError::LengthOutOfRange {
-                length: marker.length as _,
+                length: marker.length.try_into().unwrap_or_default(),
             })?;
 
         self.reader
@@ -274,7 +274,7 @@ where
             .checked_add(PROCESS_EVENT_MARKER_LENGTH)
             .and_then(|offset| offset.try_into().ok())
             .ok_or(ProcessEventReadError::LengthOutOfRange {
-                length: marker.length as _,
+                length: marker.length.try_into().unwrap_or_default(),
             })?;
 
         self.reader.seek(std::io::SeekFrom::Start(

--- a/crates/brioche-core/src/process_events/writer.rs
+++ b/crates/brioche-core/src/process_events/writer.rs
@@ -147,9 +147,10 @@ where
         Ok(4)
     }
 
+    #[expect(clippy::cast_possible_truncation)]
     async fn write_duration(&mut self, duration: Duration) -> anyhow::Result<usize> {
         let milliseconds = duration.as_millis();
-        let milliseconds = std::cmp::min(milliseconds, u32::MAX as _);
+        let milliseconds = std::cmp::min(milliseconds, u32::MAX.into());
         let milliseconds = milliseconds as u32;
 
         let length = self.write_u32(milliseconds).await?;

--- a/crates/brioche-core/src/project.rs
+++ b/crates/brioche-core/src/project.rs
@@ -157,7 +157,7 @@ impl Projects {
         Ok(loaded_project_hash)
     }
 
-    pub async fn clear(&self, project_hash: ProjectHash) -> anyhow::Result<bool> {
+    pub fn clear(&self, project_hash: ProjectHash) -> anyhow::Result<bool> {
         let mut projects = self
             .inner
             .write()
@@ -184,7 +184,7 @@ impl Projects {
             .projects_to_paths
             .get(&project_hash)
             .and_then(|paths| paths.iter().next())
-            .with_context(|| format!("project root not found for hash {}", project_hash))?;
+            .with_context(|| format!("project root not found for hash {project_hash}"))?;
         Ok(project_root.clone())
     }
 
@@ -491,11 +491,8 @@ impl ProjectsInner {
         specifier: &super::script::specifier::BriocheModuleSpecifier,
         static_: &StaticQuery,
     ) -> anyhow::Result<Option<StaticOutput>> {
-        let path = match specifier {
-            super::script::specifier::BriocheModuleSpecifier::File { path } => path,
-            _ => {
-                anyhow::bail!("could not get static for specifier {specifier}");
-            }
+        let super::script::specifier::BriocheModuleSpecifier::File { path } = specifier else {
+            anyhow::bail!("could not get static for specifier {specifier}");
         };
 
         let project_hash = self
@@ -826,7 +823,7 @@ async fn load_project_inner(
     Ok((project_hash, project, errors))
 }
 
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 async fn try_load_path_dependency_with_errors(
     projects: &Projects,
     brioche: &Brioche,

--- a/crates/brioche-core/src/project/artifact.rs
+++ b/crates/brioche-core/src/project/artifact.rs
@@ -185,7 +185,7 @@ pub async fn save_projects_from_artifact(
             loaded_projects.insert(project_hash);
         } else {
             // Project has not been loaded, so queue it to be loaded
-            unloaded_projects.push((project_hash, local_path, entry))
+            unloaded_projects.push((project_hash, local_path, entry));
         }
     }
 
@@ -201,7 +201,7 @@ pub async fn save_projects_from_artifact(
         } else {
             // Project does not exist (or has a different hash), so we
             // should save it from the artifact
-            needed_paths.push((project_hash, local_path, artifact))
+            needed_paths.push((project_hash, local_path, artifact));
         }
     }
 

--- a/crates/brioche-core/src/recipe.rs
+++ b/crates/brioche-core/src/recipe.rs
@@ -458,10 +458,10 @@ impl std::fmt::Display for StackFrame {
         let file_name = self.file_name.as_deref().unwrap_or("<unknown>");
         match (self.line_number, self.column_number) {
             (Some(line), Some(column)) => {
-                write!(f, "{file_name}:{}:{}", line, column)
+                write!(f, "{file_name}:{line}:{column}")
             }
             (Some(line), None) => {
-                write!(f, "{file_name}:{}", line)
+                write!(f, "{file_name}:{line}")
             }
             (None, _) => {
                 write!(f, "{file_name}")

--- a/crates/brioche-core/src/reporter.rs
+++ b/crates/brioche-core/src/reporter.rs
@@ -95,7 +95,6 @@ pub fn start_null_reporter() -> (Reporter, ReporterGuard) {
     (reporter, guard)
 }
 
-#[cfg_attr(not(test), allow(unused))]
 pub fn start_test_reporter() -> (Reporter, ReporterGuard) {
     let (tx, _) = tokio::sync::mpsc::unbounded_channel();
 

--- a/crates/brioche-core/src/sandbox.rs
+++ b/crates/brioche-core/src/sandbox.rs
@@ -96,7 +96,6 @@ impl From<std::process::ExitStatus> for ExitStatus {
     fn from(status: std::process::ExitStatus) -> Self {
         use std::os::unix::process::ExitStatusExt as _;
 
-        #[allow(clippy::manual_map)]
         if let Some(signal) = status.signal() {
             Self::Signal(signal)
         } else if let Some(code) = status.code() {

--- a/crates/brioche-core/src/script.rs
+++ b/crates/brioche-core/src/script.rs
@@ -77,11 +77,7 @@ impl BriocheModuleLoader {
             },
         )?;
 
-        if let Entry::Vacant(entry) = self
-            .sources
-            .borrow_mut()
-            .entry(brioche_module_specifier.clone())
-        {
+        if let Entry::Vacant(entry) = self.sources.borrow_mut().entry(brioche_module_specifier) {
             let source_map = transpiled
                 .clone()
                 .into_source()
@@ -105,7 +101,7 @@ impl BriocheModuleLoader {
         &self,
         specifier: &str,
         referrer: &str,
-        kind: deno_core::ResolutionKind,
+        kind: &deno_core::ResolutionKind,
     ) -> anyhow::Result<deno_core::ModuleSpecifier> {
         if let deno_core::ResolutionKind::MainModule = kind {
             let resolved = specifier.parse()?;
@@ -134,7 +130,7 @@ impl deno_core::ModuleLoader for BriocheModuleLoader {
         referrer: &str,
         kind: deno_core::ResolutionKind,
     ) -> Result<deno_core::ModuleSpecifier, deno_core::error::ModuleLoaderError> {
-        self.resolve_module(specifier, referrer, kind)
+        self.resolve_module(specifier, referrer, &kind)
             .map_err(|error| AnyError(error).into())
     }
 

--- a/crates/brioche-core/src/script/bridge.rs
+++ b/crates/brioche-core/src/script/bridge.rs
@@ -120,7 +120,7 @@ impl RuntimeBridge {
                             };
 
                             if let Some(project) = project {
-                                let result = projects.clear(project).await;
+                                let result = projects.clear(project);
                                 match result {
                                     Ok(_) => {}
                                     Err(error) => {

--- a/crates/brioche-core/src/script/compiler_host.rs
+++ b/crates/brioche-core/src/script/compiler_host.rs
@@ -236,40 +236,6 @@ impl BriocheCompilerHost {
             });
         }
 
-        //     let mut documents = self
-        //     .documents
-        //     .write()
-        //     .map_err(|_| anyhow::anyhow!("failed to acquire lock on documents"))?;
-        // documents.entry(specifier.clone()).and_modify(|doc| {
-        //     doc.version += 1;
-        // });
-
-        // match &specifier {
-        //     BriocheModuleSpecifier::File { path } => {
-        //         let project = self
-        //             .projects
-        //             .find_containing_project(path)
-        //             .with_context(|| format!("no project found for path '{}'", path.display()))?;
-
-        //         if let Some(project) = project {
-        //             self.projects.clear(project).await?;
-        //         }
-
-        //         self.projects
-        //             .load_from_module_path(&self.brioche, path, false)
-        //             .await?;
-
-        //         let mut documents = self
-        //             .documents
-        //             .write()
-        //             .map_err(|_| anyhow::anyhow!("failed to acquire lock on documents"))?;
-        //         documents.entry(specifier.clone()).and_modify(|doc| {
-        //             doc.version += 1;
-        //         });
-        //     }
-        //     BriocheModuleSpecifier::Runtime { .. } => {}
-        // }
-
         Ok(())
     }
 }

--- a/crates/brioche-core/src/script/compiler_host.rs
+++ b/crates/brioche-core/src/script/compiler_host.rs
@@ -1,3 +1,5 @@
+#![expect(clippy::needless_pass_by_value)]
+
 use std::{
     cell::RefCell,
     collections::{HashMap, HashSet},
@@ -22,7 +24,7 @@ pub struct BriocheCompilerHost {
 }
 
 impl BriocheCompilerHost {
-    pub async fn new(bridge: RuntimeBridge) -> Self {
+    pub fn new(bridge: RuntimeBridge) -> Self {
         let documents: HashMap<_, _> = specifier::runtime_specifiers_with_contents()
             .map(|(specifier, contents)| {
                 let contents = std::str::from_utf8(&contents)
@@ -42,10 +44,7 @@ impl BriocheCompilerHost {
         }
     }
 
-    pub async fn is_document_loaded(
-        &self,
-        specifier: &BriocheModuleSpecifier,
-    ) -> anyhow::Result<bool> {
+    pub fn is_document_loaded(&self, specifier: &BriocheModuleSpecifier) -> anyhow::Result<bool> {
         let documents = self
             .documents
             .read()
@@ -203,14 +202,14 @@ impl BriocheCompilerHost {
 
     pub fn read_loaded_document<R>(
         &self,
-        specifier: BriocheModuleSpecifier,
+        specifier: &BriocheModuleSpecifier,
         f: impl FnOnce(&BriocheDocument) -> R,
     ) -> anyhow::Result<Option<R>> {
         let documents = self
             .documents
             .read()
             .map_err(|_| anyhow::anyhow!("failed to acquire lock on documents"))?;
-        let Some(document) = documents.get(&specifier) else {
+        let Some(document) = documents.get(specifier) else {
             return Ok(None);
         };
 
@@ -261,7 +260,9 @@ deno_core::extension!(brioche_compiler_host,
     },
 );
 
-fn brioche_compiler_host_state(state: Rc<RefCell<OpState>>) -> anyhow::Result<BriocheCompilerHost> {
+fn brioche_compiler_host_state(
+    state: &Rc<RefCell<OpState>>,
+) -> anyhow::Result<BriocheCompilerHost> {
     let state = state.try_borrow()?;
     let compiler_host = state
         .try_borrow::<BriocheCompilerHost>()
@@ -277,11 +278,11 @@ pub fn op_brioche_file_read(
     state: Rc<RefCell<OpState>>,
     #[string] path: &str,
 ) -> Result<Option<Arc<String>>, super::AnyError> {
-    let compiler_host = brioche_compiler_host_state(state)?;
+    let compiler_host = brioche_compiler_host_state(&state)?;
 
     let specifier: BriocheModuleSpecifier = path.parse()?;
 
-    let contents = compiler_host.read_loaded_document(specifier, |doc| doc.contents.clone())?;
+    let contents = compiler_host.read_loaded_document(&specifier, |doc| doc.contents.clone())?;
     Ok(contents)
 }
 
@@ -290,11 +291,11 @@ pub fn op_brioche_file_exists(
     state: Rc<RefCell<OpState>>,
     #[string] path: &str,
 ) -> Result<bool, super::AnyError> {
-    let compiler_host = brioche_compiler_host_state(state)?;
+    let compiler_host = brioche_compiler_host_state(&state)?;
 
     let specifier: BriocheModuleSpecifier = path.parse()?;
 
-    let result = compiler_host.read_loaded_document(specifier, |_| ())?;
+    let result = compiler_host.read_loaded_document(&specifier, |_| ())?;
     Ok(result.is_some())
 }
 
@@ -304,11 +305,11 @@ pub fn op_brioche_file_version(
     state: Rc<RefCell<OpState>>,
     #[string] path: &str,
 ) -> Result<Option<u64>, super::AnyError> {
-    let compiler_host = brioche_compiler_host_state(state)?;
+    let compiler_host = brioche_compiler_host_state(&state)?;
 
     let specifier: BriocheModuleSpecifier = path.parse()?;
 
-    let version = compiler_host.read_loaded_document(specifier, |doc| doc.version)?;
+    let version = compiler_host.read_loaded_document(&specifier, |doc| doc.version)?;
     Ok(version)
 }
 
@@ -319,7 +320,7 @@ pub fn op_brioche_resolve_module(
     #[string] specifier: &str,
     #[string] referrer: &str,
 ) -> Option<String> {
-    let compiler_host = brioche_compiler_host_state(state).ok()?;
+    let compiler_host = brioche_compiler_host_state(&state).ok()?;
 
     let referrer: BriocheModuleSpecifier = referrer.parse().ok()?;
     let specifier: BriocheImportSpecifier = specifier.parse().ok()?;

--- a/crates/brioche-core/src/script/evaluate.rs
+++ b/crates/brioche-core/src/script/evaluate.rs
@@ -104,17 +104,14 @@ async fn evaluate_with_deno(
 
                 let result = export_value.call(&mut js_scope, module_namespace.into(), &[]);
 
-                let result = match result {
-                    Some(result) => result,
-                    None => {
-                        if let Some(exception) = js_scope.exception() {
-                            return Err(anyhow::anyhow!(
-                                deno_core::error::JsError::from_v8_exception(&mut js_scope, exception)
-                            ))
-                            .with_context(|| format!("error when calling {export}"));
-                        } else {
-                            anyhow::bail!("unknown error when calling {export}");
-                        }
+                let Some(result) = result else {
+                    if let Some(exception) = js_scope.exception() {
+                        return Err(anyhow::anyhow!(
+                            deno_core::error::JsError::from_v8_exception(&mut js_scope, exception)
+                        ))
+                        .with_context(|| format!("error when calling {export}"));
+                    } else {
+                        anyhow::bail!("unknown error when calling {export}");
                     }
                 };
                 deno_core::v8::Global::new(&mut js_scope, result)
@@ -144,18 +141,14 @@ async fn evaluate_with_deno(
                     .context("expected `briocheSerialize` to be a function")?;
 
                 let serialized_result = result_serialize.call(&mut js_scope, resolved_result.into(), &[]);
-
-                let serialized_result = match serialized_result {
-                    Some(serialized_result) => serialized_result,
-                    None => {
-                        if let Some(exception) = js_scope.exception() {
-                            return Err(anyhow::anyhow!(
-                                deno_core::error::JsError::from_v8_exception(&mut js_scope, exception)
-                            ))
-                            .with_context(|| format!("error when serializing result from {export}"));
-                        } else {
-                            anyhow::bail!("unknown error when serializing result from {export}");
-                        }
+                let Some(serialized_result) = serialized_result else {
+                    if let Some(exception) = js_scope.exception() {
+                        return Err(anyhow::anyhow!(
+                            deno_core::error::JsError::from_v8_exception(&mut js_scope, exception)
+                        ))
+                        .with_context(|| format!("error when serializing result from {export}"));
+                    } else {
+                        anyhow::bail!("unknown error when serializing result from {export}");
                     }
                 };
 

--- a/crates/brioche-core/src/script/js.rs
+++ b/crates/brioche-core/src/script/js.rs
@@ -33,13 +33,13 @@ fn op_brioche_version() -> String {
 }
 
 #[deno_core::op2]
-fn op_brioche_console(#[serde] level: ConsoleLevel, #[string] message: String) {
+fn op_brioche_console(#[serde] level: ConsoleLevel, #[string] message: &str) {
     match level {
-        ConsoleLevel::Log => tracing::info!("{}", message),
-        ConsoleLevel::Debug => tracing::debug!("{}", message),
-        ConsoleLevel::Info => tracing::info!("{}", message),
-        ConsoleLevel::Warn => tracing::warn!("{}", message),
-        ConsoleLevel::Error => tracing::error!("{}", message),
+        ConsoleLevel::Log => tracing::info!("{message}"),
+        ConsoleLevel::Debug => tracing::debug!("{message}"),
+        ConsoleLevel::Info => tracing::info!("{message}"),
+        ConsoleLevel::Warn => tracing::warn!("{message}"),
+        ConsoleLevel::Error => tracing::error!("{message}"),
     }
 }
 

--- a/crates/brioche-core/src/sync/new_sync.rs
+++ b/crates/brioche-core/src/sync/new_sync.rs
@@ -26,7 +26,7 @@ pub async fn sync_bakes(
         .buffer_unordered(25)
         .try_fold(0, |mut sum, is_new_artifact| async move {
             if is_new_artifact {
-                sum += 1
+                sum += 1;
             }
 
             Ok(sum)
@@ -45,7 +45,7 @@ pub async fn sync_bakes(
         .buffer_unordered(25)
         .try_fold(0, |mut sum, is_new_bake| async move {
             if is_new_bake {
-                sum += 1
+                sum += 1;
             }
 
             Ok(sum)

--- a/crates/brioche-core/src/utils.rs
+++ b/crates/brioche-core/src/utils.rs
@@ -15,6 +15,7 @@ const SECS_PRECISION: usize = 2;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DisplayDuration(pub std::time::Duration);
 
+#[expect(clippy::cast_possible_truncation)]
 impl std::fmt::Display for DisplayDuration {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let max_width = f.precision().unwrap_or(usize::MAX);
@@ -35,7 +36,7 @@ impl std::fmt::Display for DisplayDuration {
                 .saturating_sub(2);
 
             let secs_precision = std::cmp::min(secs_fractional_width, SECS_PRECISION);
-            write!(&mut unaligned, "{secs:.0$}s", secs_precision)?;
+            write!(&mut unaligned, "{secs:.secs_precision$}s")?;
         } else {
             // Use the rounded seconds, and break them up into hours,
             // minutes, and days

--- a/crates/brioche-core/src/utils/io.rs
+++ b/crates/brioche-core/src/utils/io.rs
@@ -67,7 +67,7 @@ where
     }
 
     fn consume(&mut self, amt: usize) {
-        self.0.consume(amt)
+        self.0.consume(amt);
     }
 }
 

--- a/crates/brioche-core/src/utils/output_buffer.rs
+++ b/crates/brioche-core/src/utils/output_buffer.rs
@@ -68,8 +68,7 @@ where
         let new_total_bytes = self.total_bytes.saturating_add(content.len());
         let mut drop_bytes = self
             .max_bytes
-            .map(|max_bytes| new_total_bytes.saturating_sub(max_bytes))
-            .unwrap_or(0);
+            .map_or(0, |max_bytes| new_total_bytes.saturating_sub(max_bytes));
         while drop_bytes > 0 {
             // Get the oldest content
             let oldest_content = self
@@ -178,8 +177,7 @@ where
                     let content_start = complete.len().saturating_sub(remaining_bytes);
                     &complete[content_start..]
                 });
-                let complete_content_length =
-                    complete_content.map(|complete| complete.len()).unwrap_or(0);
+                let complete_content_length = complete_content.map_or(0, |complete| complete.len());
 
                 // If we have a separator (newline) to add, truncate it
                 // so it fits within the remaining space
@@ -188,7 +186,7 @@ where
                     let separator_start = separator.len().saturating_sub(remaining_bytes);
                     &separator[separator_start..]
                 });
-                let separator_length = separator.map(|separator| separator.len()).unwrap_or(0);
+                let separator_length = separator.map_or(0, |separator| separator.len());
 
                 // Truncate the partial content to fit within whatever
                 // space we have left over
@@ -204,8 +202,8 @@ where
         self.total_bytes = self
             .total_bytes
             .saturating_add(partial_content.len())
-            .saturating_add(complete_content.map(|content| content.len()).unwrap_or(0))
-            .saturating_add(separator.map(|separator| separator.len()).unwrap_or(0));
+            .saturating_add(complete_content.map_or(0, |content| content.len()))
+            .saturating_add(separator.map_or(0, |separator| separator.len()));
 
         if let Some(complete_content) = complete_content {
             let prior_partial = self.partial_prepend.remove(&stream);

--- a/crates/brioche-core/src/vfs.rs
+++ b/crates/brioche-core/src/vfs.rs
@@ -75,7 +75,7 @@ impl Vfs {
             .inner
             .write()
             .map_err(|_| anyhow::anyhow!("failed to acquire VFS lock"))?;
-        vfs.contents.insert(file_id, contents.clone());
+        vfs.contents.insert(file_id, contents);
 
         let locations = vfs.ids_to_locations.get_mut(&file_id).unwrap();
         for location in locations.iter() {
@@ -166,7 +166,7 @@ impl std::fmt::Display for FileId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Hash(hash) => write!(f, "{hash}"),
-            Self::Mutable(ulid) => write!(f, "{}", ulid),
+            Self::Mutable(ulid) => write!(f, "{ulid}"),
         }
     }
 }

--- a/crates/brioche-core/tests/lsp_completions.rs
+++ b/crates/brioche-core/tests/lsp_completions.rs
@@ -32,8 +32,7 @@ async fn test_lsp_completions_simple() -> anyhow::Result<()> {
             1,
             project_root_contents.to_string(),
         ),
-    })
-    .await;
+    });
 
     let completion_response = lsp
         .request::<request::Completion>(lsp_types::CompletionParams {
@@ -102,8 +101,7 @@ async fn test_lsp_completions_from_import() -> anyhow::Result<()> {
             1,
             project_root_contents.to_string(),
         ),
-    })
-    .await;
+    });
 
     let completion_response = lsp
         .request::<request::Completion>(lsp_types::CompletionParams {
@@ -187,8 +185,7 @@ async fn test_lsp_completions_from_local_registry_import() -> anyhow::Result<()>
             1,
             project_root_contents.to_string(),
         ),
-    })
-    .await;
+    });
 
     // Get completions. This should be able to complete the function from
     // 'foo' since it's already saved locally
@@ -286,8 +283,7 @@ async fn test_lsp_completions_from_remote_registry_import() -> anyhow::Result<()
             1,
             project_root_contents.to_string(),
         ),
-    })
-    .await;
+    });
 
     // Consume a diagnostics notification triggered by opening the document
     tokio::time::timeout(WAIT_TIMEOUT, diagnostics_stream.try_next())
@@ -368,8 +364,7 @@ async fn test_lsp_completions_from_workspace_import() -> anyhow::Result<()> {
             1,
             project_root_contents.to_string(),
         ),
-    })
-    .await;
+    });
 
     let completion_response = lsp
         .request::<request::Completion>(lsp_types::CompletionParams {
@@ -438,8 +433,7 @@ async fn test_lsp_completions_in_unsaved_edited_file() -> anyhow::Result<()> {
             "#}
             .to_string(),
         ),
-    })
-    .await;
+    });
 
     let completion_response = lsp
         .request::<request::Completion>(lsp_types::CompletionParams {

--- a/crates/brioche-core/tests/lsp_on_save.rs
+++ b/crates/brioche-core/tests/lsp_on_save.rs
@@ -55,8 +55,7 @@ async fn test_lsp_on_save_respects_existing_lock() -> anyhow::Result<()> {
             1,
             project_root_contents.to_string(),
         ),
-    })
-    ;
+    });
 
     let completion_response = lsp
         .request::<request::Completion>(lsp_types::CompletionParams {
@@ -153,8 +152,7 @@ async fn test_lsp_on_save_fetches_locked_dependency() -> anyhow::Result<()> {
             1,
             project_root_contents.to_string(),
         ),
-    })
-    ;
+    });
 
     // Consume a diagnostics notification triggered by opening the document
     tokio::time::timeout(WAIT_TIMEOUT, diagnostics_stream.try_next())
@@ -196,8 +194,7 @@ async fn test_lsp_on_save_fetches_locked_dependency() -> anyhow::Result<()> {
     lsp.notify::<notification::DidSaveTextDocument>(lsp_types::DidSaveTextDocumentParams {
         text_document: TextDocumentIdentifier::new(Url::from_file_path(&project_root).unwrap()),
         text: None,
-    })
-    ;
+    });
 
     // Wait for the server to publish diagnostics after saving. This is
     // the most reliable indicator currently that the server finished
@@ -317,8 +314,7 @@ async fn test_lsp_on_save_fetches_dependency_and_updates_lockfile() -> anyhow::R
             1,
             project_root_contents.to_string(),
         ),
-    })
-    ;
+    });
 
     // Consume a diagnostics notification triggered by opening the document
     tokio::time::timeout(WAIT_TIMEOUT, diagnostics_stream.try_next())
@@ -360,8 +356,7 @@ async fn test_lsp_on_save_fetches_dependency_and_updates_lockfile() -> anyhow::R
     lsp.notify::<notification::DidSaveTextDocument>(lsp_types::DidSaveTextDocumentParams {
         text_document: TextDocumentIdentifier::new(Url::from_file_path(&project_root).unwrap()),
         text: None,
-    })
-    ;
+    });
 
     // Wait for the server to publish diagnostics after saving. This is
     // the most reliable indicator currently that the server finished
@@ -540,8 +535,7 @@ async fn test_lsp_on_save_only_adds_new_dependencies_in_lockfile() -> anyhow::Re
             1,
             project_root_contents.to_string(),
         ),
-    })
-    ;
+    });
 
     // Consume a diagnostics notification triggered by opening the document
     tokio::time::timeout(WAIT_TIMEOUT, diagnostics_stream.try_next())
@@ -553,8 +547,7 @@ async fn test_lsp_on_save_only_adds_new_dependencies_in_lockfile() -> anyhow::Re
     lsp.notify::<notification::DidSaveTextDocument>(lsp_types::DidSaveTextDocumentParams {
         text_document: TextDocumentIdentifier::new(Url::from_file_path(&project_root).unwrap()),
         text: None,
-    })
-    ;
+    });
 
     // Wait for the server to publish diagnostics after saving. This is
     // the most reliable indicator currently that the LSP finished with saving

--- a/crates/brioche-core/tests/lsp_on_save.rs
+++ b/crates/brioche-core/tests/lsp_on_save.rs
@@ -56,7 +56,7 @@ async fn test_lsp_on_save_respects_existing_lock() -> anyhow::Result<()> {
             project_root_contents.to_string(),
         ),
     })
-    .await;
+    ;
 
     let completion_response = lsp
         .request::<request::Completion>(lsp_types::CompletionParams {
@@ -154,7 +154,7 @@ async fn test_lsp_on_save_fetches_locked_dependency() -> anyhow::Result<()> {
             project_root_contents.to_string(),
         ),
     })
-    .await;
+    ;
 
     // Consume a diagnostics notification triggered by opening the document
     tokio::time::timeout(WAIT_TIMEOUT, diagnostics_stream.try_next())
@@ -197,7 +197,7 @@ async fn test_lsp_on_save_fetches_locked_dependency() -> anyhow::Result<()> {
         text_document: TextDocumentIdentifier::new(Url::from_file_path(&project_root).unwrap()),
         text: None,
     })
-    .await;
+    ;
 
     // Wait for the server to publish diagnostics after saving. This is
     // the most reliable indicator currently that the server finished
@@ -318,7 +318,7 @@ async fn test_lsp_on_save_fetches_dependency_and_updates_lockfile() -> anyhow::R
             project_root_contents.to_string(),
         ),
     })
-    .await;
+    ;
 
     // Consume a diagnostics notification triggered by opening the document
     tokio::time::timeout(WAIT_TIMEOUT, diagnostics_stream.try_next())
@@ -361,7 +361,7 @@ async fn test_lsp_on_save_fetches_dependency_and_updates_lockfile() -> anyhow::R
         text_document: TextDocumentIdentifier::new(Url::from_file_path(&project_root).unwrap()),
         text: None,
     })
-    .await;
+    ;
 
     // Wait for the server to publish diagnostics after saving. This is
     // the most reliable indicator currently that the server finished
@@ -541,7 +541,7 @@ async fn test_lsp_on_save_only_adds_new_dependencies_in_lockfile() -> anyhow::Re
             project_root_contents.to_string(),
         ),
     })
-    .await;
+    ;
 
     // Consume a diagnostics notification triggered by opening the document
     tokio::time::timeout(WAIT_TIMEOUT, diagnostics_stream.try_next())
@@ -554,7 +554,7 @@ async fn test_lsp_on_save_only_adds_new_dependencies_in_lockfile() -> anyhow::Re
         text_document: TextDocumentIdentifier::new(Url::from_file_path(&project_root).unwrap()),
         text: None,
     })
-    .await;
+    ;
 
     // Wait for the server to publish diagnostics after saving. This is
     // the most reliable indicator currently that the LSP finished with saving

--- a/crates/brioche-core/tests/process_events.rs
+++ b/crates/brioche-core/tests/process_events.rs
@@ -411,7 +411,7 @@ fn test_process_event_create_output_events() {
     let event_lengths = create_process_output_events(
         Duration::ZERO,
         ProcessStream::Stdout,
-        &[0; ProcessOutputEvent::MAX_CONTENT_LENGTH],
+        &vec![0; ProcessOutputEvent::MAX_CONTENT_LENGTH],
     )
     .map(|event| event.content().len())
     .collect::<Vec<_>>();
@@ -420,7 +420,7 @@ fn test_process_event_create_output_events() {
     let event_lengths = create_process_output_events(
         Duration::ZERO,
         ProcessStream::Stdout,
-        &[0; ProcessOutputEvent::MAX_CONTENT_LENGTH + 1],
+        &vec![0; ProcessOutputEvent::MAX_CONTENT_LENGTH + 1],
     )
     .map(|event| event.content().len())
     .collect::<Vec<_>>();
@@ -429,7 +429,7 @@ fn test_process_event_create_output_events() {
     let event_lengths = create_process_output_events(
         Duration::ZERO,
         ProcessStream::Stdout,
-        &[0; (ProcessOutputEvent::MAX_CONTENT_LENGTH * 2) + 5],
+        &vec![0; (ProcessOutputEvent::MAX_CONTENT_LENGTH * 2) + 5],
     )
     .map(|event| event.content().len())
     .collect::<Vec<_>>();

--- a/crates/brioche-core/tests/script_ops.rs
+++ b/crates/brioche-core/tests/script_ops.rs
@@ -132,9 +132,8 @@ async fn test_script_osp_stack_frames_from_exception() -> anyhow::Result<()> {
         .value;
     let artifact = brioche_test_support::bake_without_meta(&brioche, recipe).await?;
 
-    let file = match artifact {
-        brioche_core::recipe::Artifact::File(file) => file,
-        _ => panic!("expected file artifact"),
+    let brioche_core::recipe::Artifact::File(file) = artifact else {
+        panic!("expected file artifact");
     };
     let blob_path = brioche_core::blob::local_blob_path(&brioche, file.content_blob);
     let content = tokio::fs::read_to_string(&blob_path).await?;

--- a/crates/brioche-core/tests/script_specifiers.rs
+++ b/crates/brioche-core/tests/script_specifiers.rs
@@ -6,7 +6,7 @@ use brioche_core::{
     },
 };
 
-async fn resolve(
+fn resolve(
     projects: &Projects,
     specifier: &str,
     referrer: &BriocheModuleSpecifier,
@@ -87,19 +87,19 @@ async fn test_specifier_resolve_relative() -> anyhow::Result<()> {
     let (projects, _) = brioche_test_support::load_project(&brioche, &project_dir).await?;
     let referrer = BriocheModuleSpecifier::from_path(&foo_hello_path);
 
-    let sibling_specifier = resolve(&projects, "./test.txt", &referrer).await?;
+    let sibling_specifier = resolve(&projects, "./test.txt", &referrer)?;
     assert_eq!(
         sibling_specifier,
         BriocheModuleSpecifier::from_path(&foo_test_path),
     );
 
-    let inner_specifier = resolve(&projects, "./inner/test.txt", &referrer).await?;
+    let inner_specifier = resolve(&projects, "./inner/test.txt", &referrer)?;
     assert_eq!(
         inner_specifier,
         BriocheModuleSpecifier::from_path(&foo_inner_test_path),
     );
 
-    let outer_specifier = resolve(&projects, "../test.txt", &referrer).await?;
+    let outer_specifier = resolve(&projects, "../test.txt", &referrer)?;
     assert_eq!(
         outer_specifier,
         BriocheModuleSpecifier::from_path(&test_path),
@@ -135,19 +135,19 @@ async fn test_specifier_resolve_project_relative() -> anyhow::Result<()> {
     let (projects, _) = brioche_test_support::load_project(&brioche, &project_dir).await?;
     let referrer = BriocheModuleSpecifier::from_path(&foo_hello_path);
 
-    let root_specifier = resolve(&projects, "/test.txt", &referrer).await?;
+    let root_specifier = resolve(&projects, "/test.txt", &referrer)?;
     assert_eq!(
         root_specifier,
         BriocheModuleSpecifier::from_path(&test_path),
     );
 
-    let foo_specifier = resolve(&projects, "/foo/test.txt", &referrer).await?;
+    let foo_specifier = resolve(&projects, "/foo/test.txt", &referrer)?;
     assert_eq!(
         foo_specifier,
         BriocheModuleSpecifier::from_path(&foo_test_path),
     );
 
-    let inner_specifier = resolve(&projects, "/foo/inner/test.txt", &referrer).await?;
+    let inner_specifier = resolve(&projects, "/foo/inner/test.txt", &referrer)?;
     assert_eq!(
         inner_specifier,
         BriocheModuleSpecifier::from_path(&foo_inner_test_path),
@@ -180,31 +180,31 @@ async fn test_specifier_resolve_relative_dir() -> anyhow::Result<()> {
     let (projects, _) = brioche_test_support::load_project(&brioche, &project_dir).await?;
     let referrer = BriocheModuleSpecifier::from_path(&foo_hello_path);
 
-    let sibling_specifier = resolve(&projects, "./", &referrer).await?;
+    let sibling_specifier = resolve(&projects, "./", &referrer)?;
     assert_eq!(
         sibling_specifier,
         BriocheModuleSpecifier::from_path(&foo_main_path),
     );
 
-    let sibling_bare_specifier = resolve(&projects, ".", &referrer).await?;
+    let sibling_bare_specifier = resolve(&projects, ".", &referrer)?;
     assert_eq!(
         sibling_bare_specifier,
         BriocheModuleSpecifier::from_path(&foo_main_path),
     );
 
-    let inner_specifier = resolve(&projects, "./inner", &referrer).await?;
+    let inner_specifier = resolve(&projects, "./inner", &referrer)?;
     assert_eq!(
         inner_specifier,
         BriocheModuleSpecifier::from_path(&foo_inner_main_path),
     );
 
-    let outer_specifier = resolve(&projects, "../", &referrer).await?;
+    let outer_specifier = resolve(&projects, "../", &referrer)?;
     assert_eq!(
         outer_specifier,
         BriocheModuleSpecifier::from_path(&main_path),
     );
 
-    let outer_bare_specifier = resolve(&projects, "..", &referrer).await?;
+    let outer_bare_specifier = resolve(&projects, "..", &referrer)?;
     assert_eq!(
         outer_bare_specifier,
         BriocheModuleSpecifier::from_path(&main_path),
@@ -237,25 +237,25 @@ async fn test_specifier_resolve_project_relative_dir() -> anyhow::Result<()> {
     let (projects, _) = brioche_test_support::load_project(&brioche, &project_dir).await?;
     let referrer = BriocheModuleSpecifier::from_path(&foo_hello_path);
 
-    let root_specifier = resolve(&projects, "/", &referrer).await?;
+    let root_specifier = resolve(&projects, "/", &referrer)?;
     assert_eq!(
         root_specifier,
         BriocheModuleSpecifier::from_path(&main_path),
     );
 
-    let foo_specifier = resolve(&projects, "/foo/", &referrer).await?;
+    let foo_specifier = resolve(&projects, "/foo/", &referrer)?;
     assert_eq!(
         foo_specifier,
         BriocheModuleSpecifier::from_path(&foo_main_path),
     );
 
-    let foo_bare_specifier = resolve(&projects, "/foo", &referrer).await?;
+    let foo_bare_specifier = resolve(&projects, "/foo", &referrer)?;
     assert_eq!(
         foo_bare_specifier,
         BriocheModuleSpecifier::from_path(&foo_main_path),
     );
 
-    let inner_specifier = resolve(&projects, "/foo/inner", &referrer).await?;
+    let inner_specifier = resolve(&projects, "/foo/inner", &referrer)?;
     assert_eq!(
         inner_specifier,
         BriocheModuleSpecifier::from_path(&foo_inner_main_path),
@@ -353,7 +353,7 @@ async fn test_specifier_resolve_subproject() -> anyhow::Result<()> {
     let (projects, _) = brioche_test_support::load_project(&brioche, &root_project_dir).await?;
     let referrer = BriocheModuleSpecifier::from_path(&bar_file_path);
 
-    let baz_specifier = resolve(&projects, "baz", &referrer).await?;
+    let baz_specifier = resolve(&projects, "baz", &referrer)?;
     assert_eq!(
         baz_specifier,
         BriocheModuleSpecifier::from_path(&baz_main_path),
@@ -361,10 +361,10 @@ async fn test_specifier_resolve_subproject() -> anyhow::Result<()> {
 
     // Resolving paths under a dependency is not allowed
 
-    let baz_file_specifier = resolve(&projects, "baz/file.txt", &referrer).await;
+    let baz_file_specifier = resolve(&projects, "baz/file.txt", &referrer);
     assert_matches!(baz_file_specifier, Err(_));
 
-    let baz_inner_specifier = resolve(&projects, "baz/inner/file.txt", &referrer).await;
+    let baz_inner_specifier = resolve(&projects, "baz/inner/file.txt", &referrer);
     assert_matches!(baz_inner_specifier, Err(_));
 
     Ok(())

--- a/crates/brioche-test-support/src/lib.rs
+++ b/crates/brioche-test-support/src/lib.rs
@@ -113,7 +113,7 @@ pub async fn load_rootfs_recipes(brioche: &Brioche, platform: brioche_core::plat
                 recipes.push_back(recipe.value);
             }
             Recipe::Merge { directories } => {
-                recipes.extend(directories.into_iter().map(|recipe| recipe.value))
+                recipes.extend(directories.into_iter().map(|recipe| recipe.value));
             }
             Recipe::Peel {
                 directory,
@@ -915,8 +915,7 @@ pub async fn brioche_lsp_test_with(
                     projects,
                     client,
                     Arc::new(remote_brioche_builder),
-                )
-                .await?;
+                )?;
                 anyhow::Ok(lsp_server)
             })
             .expect("failed to build LSP")
@@ -1079,8 +1078,7 @@ pub async fn brioche_lsp_test_with(
         .request::<request::Initialize>(lsp_types::InitializeParams::default())
         .await;
 
-    lsp.notify::<notification::Initialized>(lsp_types::InitializedParams {})
-        .await;
+    lsp.notify::<notification::Initialized>(lsp_types::InitializedParams {});
 
     (brioche, context, lsp)
 }
@@ -1144,7 +1142,7 @@ impl LspContext {
         result
     }
 
-    pub async fn notify<T>(&self, params: T::Params)
+    pub fn notify<T>(&self, params: T::Params)
     where
         T: notification::Notification,
     {

--- a/crates/brioche/src/jobs.rs
+++ b/crates/brioche/src/jobs.rs
@@ -13,7 +13,7 @@ pub enum JobsSubcommand {
 pub fn jobs(command: JobsSubcommand) -> anyhow::Result<ExitCode> {
     match command {
         JobsSubcommand::Logs(args) => {
-            logs::logs(args)?;
+            logs::logs(&args)?;
 
             Ok(ExitCode::SUCCESS)
         }

--- a/crates/brioche/src/jobs/logs.rs
+++ b/crates/brioche/src/jobs/logs.rs
@@ -34,7 +34,7 @@ const ZSTD_SKIPPABLE_FRAME_MAGIC: &[u8] = &[0x2A, 0x4D, 0x18];
 trait ReadSeek: std::io::Read + std::io::Seek {}
 impl<T: std::io::Read + std::io::Seek> ReadSeek for T {}
 
-pub fn logs(args: LogsArgs) -> anyhow::Result<()> {
+pub fn logs(args: &LogsArgs) -> anyhow::Result<()> {
     let input: Box<dyn ReadSeek> = if args.path.to_str() == Some("-") {
         anyhow::ensure!(
             !args.follow,
@@ -94,7 +94,7 @@ pub fn logs(args: LogsArgs) -> anyhow::Result<()> {
 
     display_events(
         &mut reader,
-        DisplayEventsOptions {
+        &DisplayEventsOptions {
             limit: args.limit,
             reverse: args.reverse,
             follow_events,

--- a/crates/brioche/src/lsp.rs
+++ b/crates/brioche/src/lsp.rs
@@ -41,8 +41,7 @@ pub async fn lsp(_args: LspArgs) -> anyhow::Result<()> {
                 projects,
                 client,
                 Arc::new(remote_brioche_builder),
-            )
-            .await?;
+            )?;
             anyhow::Ok(lsp_server)
         })
         .expect("failed to build LSP")

--- a/crates/brioche/src/main.rs
+++ b/crates/brioche/src/main.rs
@@ -176,7 +176,7 @@ fn main() -> anyhow::Result<ExitCode> {
             Ok(ExitCode::SUCCESS)
         }
         Args::RunSandbox(args) => {
-            let exit_code = run_sandbox::run_sandbox(args);
+            let exit_code = run_sandbox::run_sandbox(&args);
 
             Ok(exit_code)
         }
@@ -246,7 +246,7 @@ async fn export_project(args: ExportProjectArgs) -> anyhow::Result<()> {
 
     guard.shutdown_console().await;
 
-    println!("{}", serialized);
+    println!("{serialized}");
     Ok(())
 }
 
@@ -319,7 +319,7 @@ fn consolidate_result(
     match result {
         Err(err) => {
             reporter.emit(superconsole::Lines::from_multiline_string(
-                &format!("Error occurred with {project_name}: {err}", err = err),
+                &format!("Error occurred with {project_name}: {err}"),
                 superconsole::style::ContentStyle {
                     foreground_color: Some(superconsole::style::Color::Red),
                     ..superconsole::style::ContentStyle::default()

--- a/crates/brioche/src/migrate_registry_to_cache.rs
+++ b/crates/brioche/src/migrate_registry_to_cache.rs
@@ -77,12 +77,9 @@ pub async fn migrate_registry_to_cache(args: MigrateRegistryToCacheArgs) -> anyh
         for row in recipes_reader.deserialize() {
             let row: RecipeRecord = row?;
             let recipe = serde_json::from_str::<Recipe>(&row.recipe_json);
-            let recipe = match recipe {
-                Ok(recipe) => recipe,
-                Err(_) => {
-                    num_invalid_recipes += 1;
-                    continue;
-                }
+            let Ok(recipe) = recipe else {
+                num_invalid_recipes += 1;
+                continue;
             };
 
             let Ok(artifact) = Artifact::try_from(recipe) else {
@@ -105,12 +102,9 @@ pub async fn migrate_registry_to_cache(args: MigrateRegistryToCacheArgs) -> anyh
         for row in projects_reader.deserialize() {
             let row: ProjectRecord = row?;
             let project = serde_json::from_str::<Project>(&row.project_json);
-            let project = match project {
-                Ok(project) => project,
-                Err(_) => {
-                    num_invalid_projects += 1;
-                    continue;
-                }
+            let Ok(project) = project else {
+                num_invalid_projects += 1;
+                continue;
             };
 
             let hash_matches = row.project_hash.validate_matches(&project).is_ok();

--- a/crates/brioche/src/publish.rs
+++ b/crates/brioche/src/publish.rs
@@ -104,7 +104,7 @@ async fn run_publish(
 
             if response.tags.is_empty() {
                 reporter.emit(superconsole::Lines::from_multiline_string(
-                    &format!("Project already up to date: {} {}", name, version),
+                    &format!("Project already up to date: {name} {version}"),
                     superconsole::style::ContentStyle::default(),
                 ));
             } else {
@@ -123,10 +123,7 @@ async fn run_publish(
                     .join("\n");
 
                 reporter.emit(superconsole::Lines::from_multiline_string(
-                    &format!(
-                        "🚀 Published project {} {}\nUpdated tags:\n{}",
-                        name, version, tags_info
-                    ),
+                    &format!("🚀 Published project {name} {version}\nUpdated tags:\n{tags_info}"),
                     superconsole::style::ContentStyle::default(),
                 ));
             }

--- a/crates/brioche/src/run_sandbox.rs
+++ b/crates/brioche/src/run_sandbox.rs
@@ -14,7 +14,7 @@ pub struct RunSandboxArgs {
 }
 
 #[expect(clippy::print_stderr)]
-pub fn run_sandbox(args: RunSandboxArgs) -> ExitCode {
+pub fn run_sandbox(args: &RunSandboxArgs) -> ExitCode {
     let backend = match serde_json::from_str::<SandboxBackend>(&args.backend) {
         Ok(backend) => backend,
         Err(error) => {

--- a/crates/brioche/src/self_update.rs
+++ b/crates/brioche/src/self_update.rs
@@ -33,7 +33,7 @@ pub async fn self_update(args: SelfUpdateArgs) -> anyhow::Result<bool> {
     let update_manifest = get_update_platform_manifest(&client, platform).await?;
 
     let Some(update_manifest) = update_manifest else {
-        println!("No updates available for {}", CURRENT_VERSION);
+        println!("No updates available for {CURRENT_VERSION}");
         return Ok(false);
     };
 
@@ -75,10 +75,10 @@ pub async fn self_update(args: SelfUpdateArgs) -> anyhow::Result<bool> {
     let actual_hash = sha2::Sha256::digest(&new_update);
     let actual_hash_string = hex::encode(actual_hash);
 
-    if actual_hash_string.to_lowercase() != update_manifest.sha256.to_lowercase() {
+    if !actual_hash_string.eq_ignore_ascii_case(&update_manifest.sha256) {
         println!("Downloaded update does not match expected hash");
         println!("  Expected: {}", update_manifest.sha256);
-        println!("  Actual:   {}", actual_hash_string);
+        println!("  Actual:   {actual_hash_string}");
         anyhow::bail!("hash mismatch");
     }
 


### PR DESCRIPTION
This PR adds a bunch of Clippy lints-- mostly pedantic ones I found that I thought sounded good. I originally considered wholly enabling pedantic, but (1) there are a lot of pedantic lints I don't like, and (2) I don't like the idea of new Rust versions failing CI due to new pedantic lints being flagged by default.

The most valuable (IMO) new lint is the `dbg_macro` lint, which lints for usage of `dbg!()`. As mentioned in #185, printing to stdout/stderr causes issues today with the LSP, and `dbg!()` is another place where this can happen.