### PR TITLE
Replace `tempdir` dependency with `tempfile`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1239,7 +1239,7 @@ dependencies = [
  "strum 0.27.1",
  "superconsole",
  "tar",
- "tempdir",
+ "tempfile",
  "thiserror 2.0.11",
  "tick-encoding",
  "tokio",
@@ -1288,7 +1288,7 @@ dependencies = [
  "reqwest-middleware",
  "serde",
  "serde_json",
- "tempdir",
+ "tempfile",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -2470,12 +2470,6 @@ dependencies = [
  "libc",
  "winapi",
 ]
-
-[[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "funty"
@@ -5680,19 +5674,6 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
@@ -5735,21 +5716,6 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
-
-[[package]]
-name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
@@ -5765,15 +5731,6 @@ checksum = "a88e0da7a2c97baa202165137c158d0a2e824ac465d13d81046727b34cb247d3"
 dependencies = [
  "getrandom 0.3.1",
  "zerocopy 0.8.18",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -5873,15 +5830,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
 ]
 
 [[package]]
@@ -7580,16 +7528,6 @@ dependencies = [
  "filetime",
  "libc",
  "xattr",
-]
-
-[[package]]
-name = "tempdir"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
-dependencies = [
- "rand 0.4.6",
- "remove_dir_all",
 ]
 
 [[package]]

--- a/crates/brioche-core/Cargo.toml
+++ b/crates/brioche-core/Cargo.toml
@@ -7,7 +7,13 @@ rust-version.workspace = true
 [dependencies]
 anyhow = { version = "1.0.96", features = ["backtrace"] }
 assert_matches = "1.5.0"
-async-compression = { version = "0.4.20", features = ["tokio", "bzip2", "gzip", "xz", "zstd"] }
+async-compression = { version = "0.4.20", features = [
+    "tokio",
+    "bzip2",
+    "gzip",
+    "xz",
+    "zstd",
+] }
 async-recursion = "1.1.1"
 async-trait = "0.1.86"
 aws-config = "1.5.17"
@@ -45,7 +51,10 @@ deno_error = "0.5.6"
 directories = "6.0.0"
 fastcdc = { version = "3.1.0", features = ["tokio"] }
 futures = "0.3.31"
-gix = { version = "0.70.0", features = ["blocking-network-client", "blocking-http-transport-reqwest"] }
+gix = { version = "0.70.0", features = [
+    "blocking-network-client",
+    "blocking-http-transport-reqwest",
+] }
 globset = "0.4.16"
 hex = "0.4.3"
 http = "1.2.0"
@@ -55,25 +64,46 @@ json-canon = "0.1.3"
 lazy_format = "2.0.3"
 nix = { version = "0.29.0", features = ["user"] }
 num_enum = "0.7.3"
-object_store = { git = "https://github.com/brioche-dev/arrow-rs.git", branch = "object-store-disable-all-compression-formats", features = ["aws", "http"] }
+object_store = { git = "https://github.com/brioche-dev/arrow-rs.git", branch = "object-store-disable-all-compression-formats", features = [
+    "aws",
+    "http",
+] }
 opentelemetry = "0.28.0"
-opentelemetry-otlp = { version = "0.28.0", default-features = false, features = ["http-proto", "reqwest-rustls"] }
+opentelemetry-otlp = { version = "0.28.0", default-features = false, features = [
+    "http-proto",
+    "reqwest-rustls",
+] }
 opentelemetry-semantic-conventions = "0.28.0"
 opentelemetry_sdk = { version = "0.28.0", features = ["rt-tokio"] }
 pathdiff = "0.2.3"
 petgraph = "0.7.1"
 regex = "1.11.1"
 relative-path = { version = "1.9.3", features = ["serde"] }
-reqwest = { version = "0.12.12", default-features = false, features = ["rustls-tls", "zstd", "json", "stream"] }
+reqwest = { version = "0.12.12", default-features = false, features = [
+    "rustls-tls",
+    "zstd",
+    "json",
+    "stream",
+] }
 reqwest-middleware = { version = "0.4.1", features = ["json"] }
 reqwest-retry = "0.7.0"
-rust-embed = { version = "8.6.0", features = ["debug-embed", "interpolate-folder-path", "include-exclude"] }
+rust-embed = { version = "8.6.0", features = [
+    "debug-embed",
+    "interpolate-folder-path",
+    "include-exclude",
+] }
 serde = { version = "1.0.218", features = ["derive"] }
 serde_json = "1.0.139"
 serde_v8 = "0.249.0"
 serde_with = { version = "3.12.0", features = ["hex"] }
 sha2 = "0.10.8"
-sqlx = { version = "0.8.3", features = ["runtime-tokio-rustls", "sqlite", "macros", "migrate", "json"] }
+sqlx = { version = "0.8.3", features = [
+    "runtime-tokio-rustls",
+    "sqlite",
+    "macros",
+    "migrate",
+    "json",
+] }
 strum = { version = "0.27.1", features = ["derive"] }
 superconsole = "0.2.0"
 tar = "0.4.44"
@@ -85,13 +115,23 @@ toml = "0.8.20"
 tower-lsp = "0.20.0"
 tracing = "0.1.41"
 tracing-opentelemetry = "0.29.0"
-tracing-subscriber = { version = "0.3.19", features = ["env-filter", "json", "tracing-log"] }
+tracing-subscriber = { version = "0.3.19", features = [
+    "env-filter",
+    "json",
+    "tracing-log",
+] }
 ulid = "1.2.0"
 url = { version = "2.5.4", features = ["serde"] }
 urlencoding = "2.1.3"
 walkdir = "2.5.0"
 wax = { version = "0.6.0", default-features = false }
-zip = { version = "2.2.3", default-features = false, features = ["bzip2", "deflate", "deflate64", "lzma", "zstd"] }
+zip = { version = "2.2.3", default-features = false, features = [
+    "bzip2",
+    "deflate",
+    "deflate64",
+    "lzma",
+    "zstd",
+] }
 zstd = "0.13.3"
 zstd-framed = { version = "0.1.1", features = ["tokio"] }
 

--- a/crates/brioche-core/Cargo.toml
+++ b/crates/brioche-core/Cargo.toml
@@ -142,7 +142,7 @@ divan = "0.1.17"
 indoc = "2.0.5"
 mockito = "1.6.1"
 pretty_assertions = "1.4.1"
-tempdir = "0.3.7"
+tempfile = "3.17.1"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libmount = "0.1.15"

--- a/crates/brioche-core/tests/object_store_utils_s3.rs
+++ b/crates/brioche-core/tests/object_store_utils_s3.rs
@@ -54,7 +54,7 @@ async fn test_object_store_utils_s3_credentials_explicit_credentials_with_sessio
 
 #[tokio::test]
 async fn test_object_store_utils_s3_credentials_from_env_files() {
-    let tempdir = tempdir::TempDir::new("brioche-test").unwrap();
+    let tempdir = tempfile::TempDir::with_prefix("brioche-test").unwrap();
     let credentials_path = tempdir.path().join("credentials");
     tokio::fs::write(
         &credentials_path,
@@ -87,7 +87,7 @@ async fn test_object_store_utils_s3_credentials_from_env_files() {
 
 #[tokio::test]
 async fn test_object_store_utils_s3_credentials_from_env_files_with_session_token() {
-    let tempdir = tempdir::TempDir::new("brioche-test").unwrap();
+    let tempdir = tempfile::TempDir::with_prefix("brioche-test").unwrap();
     let credentials_path = tempdir.path().join("credentials");
     tokio::fs::write(
         &credentials_path,
@@ -121,7 +121,7 @@ async fn test_object_store_utils_s3_credentials_from_env_files_with_session_toke
 
 #[tokio::test]
 async fn test_object_store_utils_s3_credentials_from_env_files_with_profile() {
-    let tempdir = tempdir::TempDir::new("brioche-test").unwrap();
+    let tempdir = tempfile::TempDir::with_prefix("brioche-test").unwrap();
     let credentials_path = tempdir.path().join("credentials");
     tokio::fs::write(
         &credentials_path,
@@ -205,7 +205,7 @@ async fn test_object_store_utils_s3_config_explicit_endpoint() {
 
 #[tokio::test]
 async fn test_object_store_utils_s3_config_values_from_env_files() {
-    let tempdir = tempdir::TempDir::new("brioche-test").unwrap();
+    let tempdir = tempfile::TempDir::with_prefix("brioche-test").unwrap();
     let config_path = tempdir.path().join("credentials");
     tokio::fs::write(
         &config_path,
@@ -241,7 +241,7 @@ async fn test_object_store_utils_s3_config_values_from_env_files() {
 
 #[tokio::test]
 async fn test_object_store_utils_s3_config_values_from_env_files_with_profile() {
-    let tempdir = tempdir::TempDir::new("brioche-test").unwrap();
+    let tempdir = tempfile::TempDir::with_prefix("brioche-test").unwrap();
     let config_path = tempdir.path().join("credentials");
     tokio::fs::write(
         &config_path,
@@ -281,7 +281,7 @@ async fn test_object_store_utils_s3_config_values_from_env_files_with_profile() 
 
 #[tokio::test]
 async fn test_object_store_utils_s3_config_values_from_env_files_with_service_config() {
-    let tempdir = tempdir::TempDir::new("brioche-test").unwrap();
+    let tempdir = tempfile::TempDir::with_prefix("brioche-test").unwrap();
     let config_path = tempdir.path().join("credentials");
     tokio::fs::write(
         &config_path,

--- a/crates/brioche-test-support/Cargo.toml
+++ b/crates/brioche-test-support/Cargo.toml
@@ -17,7 +17,7 @@ reqwest = "0.12.12"
 reqwest-middleware = "0.4.1"
 serde = { version = "1.0.218", features = ["derive"] }
 serde_json = "1.0.139"
-tempdir = "0.3.7"
+tempfile = "3.17.1"
 tokio = { version = "1.43.0", features = ["full", "tracing"] }
 tokio-stream = { version = "0.1.17", features = ["sync"] }
 tokio-util = { version = "0.7.13", features = ["full"] }

--- a/crates/brioche-test-support/src/lib.rs
+++ b/crates/brioche-test-support/src/lib.rs
@@ -31,7 +31,7 @@ pub async fn brioche_test() -> (Brioche, TestContext) {
 pub async fn brioche_test_with(
     f: impl FnOnce(BriocheBuilder) -> BriocheBuilder,
 ) -> (Brioche, TestContext) {
-    let temp = tempdir::TempDir::new("brioche-test").unwrap();
+    let temp = tempfile::TempDir::with_prefix("brioche-test").unwrap();
     let registry_server = mockito::Server::new_async().await;
 
     let brioche_data_dir = temp.path().join("brioche-data");
@@ -568,7 +568,7 @@ pub fn new_cache() -> Arc<dyn object_store::ObjectStore> {
 
 pub struct TestContext {
     brioche: Brioche,
-    temp: tempdir::TempDir,
+    temp: tempfile::TempDir,
     pub registry_server: mockito::ServerGuard,
     _reporter_guard: brioche_core::reporter::ReporterGuard,
 }


### PR DESCRIPTION
The [`tempdir`](https://github.com/rust-lang-deprecated/tempdir) crate had been deprecated long ago and no longer receives updates. The same functionality now exists in the `tempfile` crate.