### PR TITLE
chore: remove resolver setting from Cargo.toml since this is the default value for Rust 1.85

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ members = [
     "crates/brioche-pack",
     "crates/brioche-test-support",
 ]
-resolver = "3"
 
 [workspace.lints.clippy]
 all = { level = "warn", priority = -1 }


### PR DESCRIPTION
See https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions