### PR TITLE
Revert "chore: remove resolver setting from Cargo.toml since this is the default value for Rust 1.85"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "crates/brioche-pack",
     "crates/brioche-test-support",
 ]
+resolver = "3"
 
 [workspace.lints.clippy]
 all = { level = "warn", priority = -1 }


### PR DESCRIPTION
Reverts brioche-dev/brioche#206

For some reason, this change broke the `brioche build` invocation (my guess is due to `cargo-chef`? But haven't dug into it)

Also, with the change from #206, I started getting this warning by default:

```
warning: virtual workspace defaulting to `resolver = "1"` despite one or more workspace members being on edition 2024 which implies `resolver = "3"`
note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
note: to use the edition 2024 resolver, specify `workspace.resolver = "3"` in the workspace root's manifest
note: for more details see https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions
```

Together, I think it makes sense to roll back and specify the resolve even though it's strictly required