### PR TITLE
Add new command to start a debug shell within a job

### DIFF
--- a/crates/brioche-core/src/bake.rs
+++ b/crates/brioche-core/src/bake.rs
@@ -23,7 +23,7 @@ pub use process::{ProcessRootfsRecipes, process_rootfs_recipes};
 mod attach_resources;
 mod collect_references;
 mod download;
-mod process;
+pub mod process;
 mod unarchive;
 
 #[derive(Debug, Default)]

--- a/crates/brioche-core/src/bake/process.rs
+++ b/crates/brioche-core/src/bake/process.rs
@@ -1240,7 +1240,7 @@ async fn append_dependency_envs(
     Ok(())
 }
 
-async fn sandbox_backend(
+pub async fn sandbox_backend(
     brioche: &Brioche,
     platform: crate::platform::Platform,
 ) -> anyhow::Result<SandboxBackend> {

--- a/crates/brioche/src/jobs.rs
+++ b/crates/brioche/src/jobs.rs
@@ -1,5 +1,6 @@
-use std::process::ExitCode;
+use std::{path::Path, process::ExitCode};
 
+use brioche_core::{process_events::PROCESS_EVENT_MAGIC, utils::io::NotSeekable};
 use clap::Subcommand;
 
 mod logs;
@@ -18,4 +19,76 @@ pub fn jobs(command: JobsSubcommand) -> anyhow::Result<ExitCode> {
             Ok(ExitCode::SUCCESS)
         }
     }
+}
+
+const ZSTD_FRAME_MAGIC: &[u8] = &[0x28, 0xB5, 0x2F, 0xFD];
+const ZSTD_SKIPPABLE_FRAME_MAGIC: &[u8] = &[0x2A, 0x4D, 0x18];
+
+trait ReadSeek: std::io::Read + std::io::Seek {}
+impl<T: std::io::Read + std::io::Seek> ReadSeek for T {}
+
+fn log_file_reader_from_stdin() -> anyhow::Result<Box<dyn ReadSeek>> {
+    let mut stdin = std::io::stdin().lock();
+    let format = detect_log_file_format(&mut stdin)?;
+
+    match format {
+        LogFileFormat::Zstd => {
+            let decoder = zstd_framed::ZstdReader::builder_buffered(stdin).build()?;
+            Ok(Box::new(NotSeekable(decoder)))
+        }
+        LogFileFormat::Bin => Ok(Box::new(NotSeekable(stdin))),
+    }
+}
+
+fn log_file_reader_from_path(path: &Path) -> anyhow::Result<Box<dyn ReadSeek>> {
+    let file = std::fs::File::open(path)?;
+    let mut buf_reader = std::io::BufReader::new(file);
+    let format = detect_log_file_format(&mut buf_reader)?;
+
+    match format {
+        LogFileFormat::Zstd => {
+            let seek_table = zstd_framed::table::read_seek_table(&mut buf_reader)
+                .ok()
+                .flatten();
+            let mut decoder = zstd_framed::ZstdReader::builder(buf_reader);
+            if let Some(seek_table) = seek_table {
+                decoder = decoder.with_seek_table(seek_table);
+            }
+            let decoder = decoder.build()?;
+            Ok(Box::new(decoder))
+        }
+        LogFileFormat::Bin => Ok(Box::new(buf_reader)),
+    }
+}
+
+fn detect_log_file_format(reader: &mut impl std::io::BufRead) -> anyhow::Result<LogFileFormat> {
+    let buf = reader.fill_buf()?;
+
+    let process_event_magic = PROCESS_EVENT_MAGIC.as_bytes();
+    let process_event_magic_partial_len = process_event_magic.len().min(buf.len());
+    let process_event_magic_partial = &process_event_magic[0..process_event_magic_partial_len];
+    if buf.starts_with(process_event_magic_partial) {
+        return Ok(LogFileFormat::Bin);
+    }
+
+    let zstd_frame_magic_partial_len = ZSTD_FRAME_MAGIC.len().min(buf.len());
+    let zstd_frame_magic_partial = &ZSTD_FRAME_MAGIC[0..zstd_frame_magic_partial_len];
+    if buf.starts_with(zstd_frame_magic_partial) {
+        return Ok(LogFileFormat::Zstd);
+    }
+
+    let zstd_skippable_frame_magic_partial_len = ZSTD_SKIPPABLE_FRAME_MAGIC.len().min(buf.len());
+    let zstd_skippable_frame_magic_partial =
+        &ZSTD_SKIPPABLE_FRAME_MAGIC[0..zstd_skippable_frame_magic_partial_len];
+    if buf.starts_with(zstd_skippable_frame_magic_partial) {
+        return Ok(LogFileFormat::Zstd);
+    }
+
+    anyhow::bail!("could not detect log file format");
+}
+
+#[derive(Debug, Clone, Copy)]
+enum LogFileFormat {
+    Zstd,
+    Bin,
 }

--- a/crates/brioche/src/jobs/debug_shell.rs
+++ b/crates/brioche/src/jobs/debug_shell.rs
@@ -1,0 +1,89 @@
+use std::path::PathBuf;
+
+use brioche_core::{
+    process_events::{ProcessEvent, ProcessEventDescription, reader::ProcessEventReader},
+    sandbox::{SandboxTemplate, SandboxTemplateComponent},
+};
+use clap::Parser;
+
+use super::{log_file_reader_from_path, log_file_reader_from_stdin};
+
+#[derive(Debug, Parser)]
+pub struct DebugShellArgs {
+    /// The path to the event file from the job
+    path: PathBuf,
+}
+
+pub async fn debug_shell(args: &DebugShellArgs) -> anyhow::Result<()> {
+    let job_description = tokio::task::spawn_blocking({
+        let path = args.path.clone();
+        move || {
+            let input = if path.to_str() == Some("-") {
+                log_file_reader_from_stdin()?
+            } else {
+                log_file_reader_from_path(&path)?
+            };
+
+            let mut reader = ProcessEventReader::new(input)?;
+            let job_description = read_job_description_event(&mut reader)?;
+            anyhow::Ok(job_description)
+        }
+    })
+    .await??;
+
+    let backend = {
+        let (reporter, _guard) = brioche_core::reporter::console::start_console_reporter(
+            brioche_core::reporter::console::ConsoleReporterKind::Plain,
+        )?;
+
+        let brioche = brioche_core::BriocheBuilder::new(reporter.clone())
+            .build()
+            .await?;
+        crate::start_shutdown_handler(brioche.clone());
+
+        brioche_core::bake::process::sandbox_backend(&brioche, job_description.recipe.platform)
+            .await?
+    };
+
+    let sandbox_config = brioche_core::sandbox::SandboxExecutionConfig {
+        command: SandboxTemplate {
+            components: vec![SandboxTemplateComponent::Literal {
+                value: b"/bin/sh".into(),
+            }],
+        },
+        args: vec![SandboxTemplate {
+            components: vec![SandboxTemplateComponent::Literal {
+                value: b"-i".into(),
+            }],
+        }],
+        ..job_description.sandbox_config.clone()
+    };
+
+    let exit_status = tokio::task::spawn_blocking(move || {
+        brioche_core::sandbox::run_sandbox(backend, sandbox_config)
+    })
+    .await??;
+    if !exit_status.success() {
+        anyhow::bail!("sandbox execution failed: {exit_status:?}");
+    }
+
+    Ok(())
+}
+
+fn read_job_description_event(
+    reader: &mut ProcessEventReader<impl std::io::Read>,
+) -> anyhow::Result<ProcessEventDescription> {
+    for _ in 0..2 {
+        let event = reader.read_next_event()?;
+
+        let Some(event) = event else {
+            break;
+        };
+
+        if let ProcessEvent::Description(description) = event {
+            return Ok(description);
+        }
+    }
+
+    anyhow::bail!("failed to read `Description` event from event file");
+}

--- a/crates/brioche/src/jobs/logs.rs
+++ b/crates/brioche/src/jobs/logs.rs
@@ -1,14 +1,12 @@
 use std::path::PathBuf;
 
-use brioche_core::{
-    process_events::{
-        PROCESS_EVENT_MAGIC,
-        display::{DisplayEventsOptions, display_events},
-    },
-    utils::io::NotSeekable,
-};
+use brioche_core::process_events::display::{DisplayEventsOptions, display_events};
 use clap::Parser;
 use notify::Watcher as _;
+
+use crate::jobs::log_file_reader_from_stdin;
+
+use super::log_file_reader_from_path;
 
 #[derive(Debug, Parser)]
 pub struct LogsArgs {
@@ -28,48 +26,16 @@ pub struct LogsArgs {
     follow: bool,
 }
 
-const ZSTD_FRAME_MAGIC: &[u8] = &[0x28, 0xB5, 0x2F, 0xFD];
-const ZSTD_SKIPPABLE_FRAME_MAGIC: &[u8] = &[0x2A, 0x4D, 0x18];
-
-trait ReadSeek: std::io::Read + std::io::Seek {}
-impl<T: std::io::Read + std::io::Seek> ReadSeek for T {}
-
 pub fn logs(args: &LogsArgs) -> anyhow::Result<()> {
-    let input: Box<dyn ReadSeek> = if args.path.to_str() == Some("-") {
+    let input = if args.path.to_str() == Some("-") {
         anyhow::ensure!(
             !args.follow,
             "cannot specify --follow when reading from stdin"
         );
 
-        let mut stdin = std::io::stdin().lock();
-        let format = detect_format(&mut stdin)?;
-
-        match format {
-            LogFileFormat::Zstd => {
-                let decoder = zstd_framed::ZstdReader::builder_buffered(stdin).build()?;
-                Box::new(NotSeekable(decoder))
-            }
-            LogFileFormat::Bin => Box::new(NotSeekable(stdin)),
-        }
+        log_file_reader_from_stdin()?
     } else {
-        let file = std::fs::File::open(&args.path)?;
-        let mut buf_reader = std::io::BufReader::new(file);
-        let format = detect_format(&mut buf_reader)?;
-
-        match format {
-            LogFileFormat::Zstd => {
-                let seek_table = zstd_framed::table::read_seek_table(&mut buf_reader)
-                    .ok()
-                    .flatten();
-                let mut decoder = zstd_framed::ZstdReader::builder(buf_reader);
-                if let Some(seek_table) = seek_table {
-                    decoder = decoder.with_seek_table(seek_table);
-                }
-                let decoder = decoder.build()?;
-                Box::new(decoder)
-            }
-            LogFileFormat::Bin => Box::new(buf_reader),
-        }
+        log_file_reader_from_path(&args.path)?
     };
 
     let mut reader = brioche_core::process_events::reader::ProcessEventReader::new(input)?;
@@ -102,36 +68,4 @@ pub fn logs(args: &LogsArgs) -> anyhow::Result<()> {
     )?;
 
     Ok(())
-}
-
-fn detect_format(reader: &mut impl std::io::BufRead) -> anyhow::Result<LogFileFormat> {
-    let buf = reader.fill_buf()?;
-
-    let process_event_magic = PROCESS_EVENT_MAGIC.as_bytes();
-    let process_event_magic_partial_len = process_event_magic.len().min(buf.len());
-    let process_event_magic_partial = &process_event_magic[0..process_event_magic_partial_len];
-    if buf.starts_with(process_event_magic_partial) {
-        return Ok(LogFileFormat::Bin);
-    }
-
-    let zstd_frame_magic_partial_len = ZSTD_FRAME_MAGIC.len().min(buf.len());
-    let zstd_frame_magic_partial = &ZSTD_FRAME_MAGIC[0..zstd_frame_magic_partial_len];
-    if buf.starts_with(zstd_frame_magic_partial) {
-        return Ok(LogFileFormat::Zstd);
-    }
-
-    let zstd_skippable_frame_magic_partial_len = ZSTD_SKIPPABLE_FRAME_MAGIC.len().min(buf.len());
-    let zstd_skippable_frame_magic_partial =
-        &ZSTD_SKIPPABLE_FRAME_MAGIC[0..zstd_skippable_frame_magic_partial_len];
-    if buf.starts_with(zstd_skippable_frame_magic_partial) {
-        return Ok(LogFileFormat::Zstd);
-    }
-
-    anyhow::bail!("could not detect log file format");
-}
-
-#[derive(Debug, Clone, Copy)]
-enum LogFileFormat {
-    Zstd,
-    Bin,
 }

--- a/crates/brioche/src/jobs/logs.rs
+++ b/crates/brioche/src/jobs/logs.rs
@@ -4,9 +4,7 @@ use brioche_core::process_events::display::{DisplayEventsOptions, display_events
 use clap::Parser;
 use notify::Watcher as _;
 
-use crate::jobs::log_file_reader_from_stdin;
-
-use super::log_file_reader_from_path;
+use super::{log_file_reader_from_path, log_file_reader_from_stdin};
 
 #[derive(Debug, Parser)]
 pub struct LogsArgs {


### PR DESCRIPTION
This PR adds a new `brioche jobs debug-shell` command. It takes a path to an `events.bin.zst` file (just like `brioche jobs logs`), then launches an interactive shell within the context of the job.

When the `events.bin.zst` format was added for process jobs in #138, one of the events that was added was the [`ProcessEventDescription`](https://github.com/brioche-dev/brioche/blob/469d224be6c36dafdad1607b5e7ff45c704dda04/crates/brioche-core/src/process_events.rs#L102) event, which includes a lot of context about how the process was run. It includes a full serialized version of the `SandboxExecutionConfig` used when we ran the process! So, launching a debug shell is fairly easy: this PR reads the `SandboxExecutionConfig` value from `events.bin.zst`, modifies it so it runs `/bin/sh -i` instead of the original command, then calls `brioche_core::sandbox::run_sandbox()`

From a security perspective, this command feels a little scary at first since we're trusting the raw sandbox config from the `events.bin.zst` file, meaning a "malicious" events file could include arbitrary host paths when starting the sandbox. I felt that, in practice, users wouldn't be likely to try using `brioche jobs debug-shell` with arbitrarily-downloaded event files. Plus, I added a little note to the help text to call out it should only be used with files from a trusted source. (And even then, the risk should be about the same as, say, using an untrusted `docker-compose.yml` file, which could similarly mount arbitrary paths from the host)

Currently, it doesn't allow any customization when run. In the future, I'd like to enhance this command to support more options: tweaking the sandboxing rules like enabling/disabling networking, allowing extra tools to be injected in the sandbox like `strace`, or running a "fresh" copy of the sandbox (setting up a new sandbox root instead of inheriting the old one, meaning there'd be no intermittent build files)

I've had the idea to add this command for a while, but finally bit the bullet because I've been working on getting LLVM to build, which is both very slow (about 90 minutes on my machine currently to get to the point that I'm working on debugging) and takes a huge amount of space (over 160 GB!)

