### PR TITLE
Add support for `Brioche.gitCheckout` as a static

### DIFF
--- a/crates/brioche-core/src/project/analyze.rs
+++ b/crates/brioche-core/src/project/analyze.rs
@@ -562,7 +562,7 @@ where
                         .map(|arg| arg_to_string_literal(arg, env))
                         .map(|arg| {
                             arg.with_context(|| {
-                                format!("{location}: invalid arg to Brioche.includeDirectory")
+                                format!("{location}: invalid arg to Brioche.glob")
                             })
                         })
                         .collect::<anyhow::Result<Vec<_>>>()?;
@@ -607,7 +607,7 @@ where
                         .map(|arg| arg_to_json(arg, env))
                         .map(|arg| {
                             arg.with_context(|| {
-                                format!("{location}: invalid arg to Brioche.download")
+                                format!("{location}: invalid arg to Brioche.gitRef")
                             })
                         })
                         .collect::<anyhow::Result<Vec<_>>>()?;

--- a/crates/brioche-core/src/project/analyze.rs
+++ b/crates/brioche-core/src/project/analyze.rs
@@ -599,7 +599,7 @@ where
 
                     Ok(Some(StaticQuery::Download { url }))
                 }
-                "gitRef" => {
+                "gitRef" | "gitCheckout" => {
                     // Get the arguments
                     let args = call_expr.arguments()?.args();
                     let args = args
@@ -607,7 +607,7 @@ where
                         .map(|arg| arg_to_json(arg, env))
                         .map(|arg| {
                             arg.with_context(|| {
-                                format!("{location}: invalid arg to Brioche.gitRef")
+                                format!("{location}: invalid arg to Brioche.{callee_member_text}")
                             })
                         })
                         .collect::<anyhow::Result<Vec<_>>>()?;
@@ -617,14 +617,14 @@ where
                         [options] => options.clone(),
                         _ => {
                             anyhow::bail!(
-                                "{location}: Brioche.gitRef() must take exactly one argument",
+                                "{location}: Brioche.{callee_member_text}() must take exactly one argument",
                             );
                         }
                     };
 
                     // Parse the options
                     let options = serde_json::from_value(options).with_context(|| {
-                        format!("{location}: invalid options for Brioche.gitRef, expected an object with the keys `repository` and `ref`")
+                        format!("{location}: invalid options for Brioche.{callee_member_text}, expected an object with the keys `repository` and `ref`")
                     })?;
 
                     Ok(Some(StaticQuery::GitRef(options)))

--- a/crates/brioche-core/src/script.rs
+++ b/crates/brioche-core/src/script.rs
@@ -8,11 +8,11 @@ use std::{
 };
 
 use anyhow::Context as _;
-use bridge::RuntimeBridge;
+use bridge::{GetStaticOptions, RuntimeBridge};
 use deno_core::OpState;
 use specifier::BriocheModuleSpecifier;
 
-use crate::{bake::BakeScope, project::analyze::StaticQuery};
+use crate::bake::BakeScope;
 
 use super::{
     blob::BlobHash,
@@ -276,7 +276,7 @@ pub async fn op_brioche_read_blob(
 pub async fn op_brioche_get_static(
     state: Rc<RefCell<OpState>>,
     #[string] url: String,
-    #[serde] static_: StaticQuery,
+    #[serde] options: GetStaticOptions,
 ) -> Result<bridge::GetStaticResult, AnyError> {
     let bridge = {
         let state = state.try_borrow().map_err(AnyError::new)?;
@@ -288,7 +288,7 @@ pub async fn op_brioche_get_static(
 
     let specifier: BriocheModuleSpecifier = url.parse().map_err(AnyError::new)?;
 
-    let recipe = bridge.get_static(specifier, static_).await?;
+    let recipe = bridge.get_static(specifier, options).await?;
     Ok(recipe)
 }
 

--- a/crates/brioche-core/tests/script_eval.rs
+++ b/crates/brioche-core/tests/script_eval.rs
@@ -645,11 +645,7 @@ async fn test_eval_brioche_download() -> anyhow::Result<()> {
 async fn test_eval_brioche_git_ref() -> anyhow::Result<()> {
     let (brioche, context) = brioche_test_support::brioche_test().await;
 
-    let mut mock_repo = mockito::Server::new_with_opts_async(mockito::ServerOpts {
-        port: 1231,
-        ..Default::default()
-    })
-    .await;
+    let mut mock_repo = mockito::Server::new_async().await;
     let mock_repo_url = mock_repo.url();
 
     // Mock a git "handshake" server response for protocol version 2

--- a/crates/brioche-core/tests/script_eval.rs
+++ b/crates/brioche-core/tests/script_eval.rs
@@ -741,3 +741,258 @@ async fn test_eval_brioche_git_ref() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn test_eval_brioche_git_checkout() -> anyhow::Result<()> {
+    let (brioche, context) = brioche_test_support::brioche_test().await;
+
+    let mut mock_repo = mockito::Server::new_async().await;
+    let mock_repo_url = mock_repo.url();
+
+    // Mock a git "handshake" server response for protocol version 2
+    let mock_git_info_refs_response = b"001e# service=git-upload-pack\n0000000eversion 2\n0000";
+    let mock_git_info_refs = mock_repo
+        .mock("GET", "/info/refs?service=git-upload-pack")
+        .with_header(
+            "Content-Type",
+            "application/x-git-upload-pack-advertisement",
+        )
+        .with_header("Cache-Control", "no-cache")
+        .with_body(mock_git_info_refs_response)
+        .expect(1)
+        .create();
+
+    // Mock a git "ls-refs" response, with one branch named "main" with a
+    // commit hash of "0123456789abcdef01234567890123456789abcd"
+    let mock_git_upload_pack_response =
+        b"003d0123456789abcdef01234567890123456789abcd refs/heads/main\n0000";
+    let mock_git_upload_pack = mock_repo
+        .mock("POST", "/git-upload-pack")
+        .with_header("Content-Type", "application/x-git-upload-pack-result")
+        .with_header("Cache-Control", "no-cache")
+        .with_body(mock_git_upload_pack_response)
+        .expect(1)
+        .create();
+
+    // From Brioche's perspective, `Brioche.gitCheckout()` is treated
+    // the same as `Brioche.gitRef()`. In practice, it will actually checkout
+    // the ref, but that's implemented at the packaging layer
+    let project_dir = context.mkdir("myproject").await;
+    context
+        .write_file(
+            "myproject/project.bri",
+            r#"
+                globalThis.Brioche = {
+                    gitCheckout: async ({ repository, ref }) => {
+                        return await Deno.core.ops.op_brioche_get_static(
+                            import.meta.url,
+                            {
+                                type: "git_ref",
+                                repository,
+                                ref,
+                            },
+                        );
+                    }
+                }
+
+                export default async () => {
+                    const gitCheckout = await Brioche.gitCheckout({
+                        repository: "<REPO_URL>",
+                        ref: "main",
+                    });
+                    return {
+                        briocheSerialize: async () => {
+                            return {
+                                type: "create_file",
+                                content: JSON.stringify(gitCheckout),
+                                executable: false,
+                                resources: {
+                                    type: "directory",
+                                    entries: {},
+                                },
+                            };
+                        },
+                    };
+                };
+            "#
+            .replace("<REPO_URL>", &mock_repo_url),
+        )
+        .await;
+
+    let (projects, project_hash) =
+        brioche_test_support::load_project(&brioche, &project_dir).await?;
+
+    let resolved = evaluate(&brioche, &projects, project_hash, "default")
+        .await?
+        .value;
+
+    let brioche_core::recipe::Recipe::CreateFile { content, .. } = resolved else {
+        panic!("expected create_file recipe, got {resolved:?}");
+    };
+
+    mock_git_info_refs.assert_async().await;
+    mock_git_upload_pack.assert_async().await;
+
+    let git_ref: serde_json::Value = serde_json::from_slice(&content)?;
+    assert_eq!(
+        git_ref,
+        serde_json::json!({
+            "staticKind": "git_ref",
+            "repository": format!("{mock_repo_url}/"),
+            "commit": "0123456789abcdef01234567890123456789abcd",
+        }),
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_eval_brioche_git_ref_and_git_checkout() -> anyhow::Result<()> {
+    let (brioche, context) = brioche_test_support::brioche_test().await;
+
+    let mut mock_repo = mockito::Server::new_async().await;
+    let mock_repo_url = mock_repo.url();
+
+    // Mock a git "handshake" server response for protocol version 2
+    // TODO: Update code so each repo only gets evaluated once
+    let mock_git_info_refs_response = b"001e# service=git-upload-pack\n0000000eversion 2\n0000";
+    let mock_git_info_refs = mock_repo
+        .mock("GET", "/info/refs?service=git-upload-pack")
+        .with_header(
+            "Content-Type",
+            "application/x-git-upload-pack-advertisement",
+        )
+        .with_header("Cache-Control", "no-cache")
+        .with_body(mock_git_info_refs_response)
+        .expect_at_least(1)
+        .create();
+
+    // Mock a git "ls-refs" response, with three branches:
+    // - "main" with commit hash "0123456789abcdef01234567890123456789abcd"
+    // - "feature1" with commit hash "abcdef0123456789abcdef012345678901234567"
+    // - "feature2" with commit hash "0000000000111111111122222222223333333333"
+    let mock_git_upload_pack_response =
+        b"003d0123456789abcdef01234567890123456789abcd refs/heads/main\n0041abcdef0123456789abcdef012345678901234567 refs/heads/feature1\n00410000000000111111111122222222223333333333 refs/heads/feature2\n0000";
+    let mock_git_upload_pack = mock_repo
+        .mock("POST", "/git-upload-pack")
+        .with_header("Content-Type", "application/x-git-upload-pack-result")
+        .with_header("Cache-Control", "no-cache")
+        .with_body(mock_git_upload_pack_response)
+        .expect_at_least(1)
+        .create();
+
+    // From Brioche's perspective, `Brioche.gitCheckout()` is treated
+    // the same as `Brioche.gitRef()`. In practice, it will actually checkout
+    // the ref, but that's implemented at the packaging layer
+    let project_dir = context.mkdir("myproject").await;
+    context
+        .write_file(
+            "myproject/project.bri",
+            r#"
+                globalThis.Brioche = {
+                    gitRef: async ({ repository, ref }) => {
+                        return await Deno.core.ops.op_brioche_get_static(
+                            import.meta.url,
+                            {
+                                type: "git_ref",
+                                repository,
+                                ref,
+                            },
+                        );
+                    },
+                    gitCheckout: async ({ repository, ref }) => {
+                        return await Deno.core.ops.op_brioche_get_static(
+                            import.meta.url,
+                            {
+                                type: "git_ref",
+                                repository,
+                                ref,
+                            },
+                        );
+                    },
+                };
+
+                export default async () => {
+                    const gitRefMain = await Brioche.gitRef({
+                        repository: "<REPO_URL>",
+                        ref: "main",
+                    });
+                    const gitCheckoutFeature1 = await Brioche.gitCheckout({
+                        repository: "<REPO_URL>",
+                        ref: "feature1",
+                    });
+                    const gitRefFeature2 = await Brioche.gitRef({
+                        repository: "<REPO_URL>",
+                        ref: "feature2",
+                    });
+                    const gitCheckoutFeature2 = await Brioche.gitCheckout({
+                        repository: "<REPO_URL>",
+                        ref: "feature2",
+                    });
+                    return {
+                        briocheSerialize: async () => {
+                            return {
+                                type: "create_file",
+                                content: JSON.stringify({
+                                    gitRefMain,
+                                    gitCheckoutFeature1,
+                                    gitRefFeature2,
+                                    gitCheckoutFeature2,
+                                }),
+                                executable: false,
+                                resources: {
+                                    type: "directory",
+                                    entries: {},
+                                },
+                            };
+                        },
+                    };
+                };
+            "#
+            .replace("<REPO_URL>", &mock_repo_url),
+        )
+        .await;
+
+    let (projects, project_hash) =
+        brioche_test_support::load_project(&brioche, &project_dir).await?;
+
+    let resolved = evaluate(&brioche, &projects, project_hash, "default")
+        .await?
+        .value;
+
+    let brioche_core::recipe::Recipe::CreateFile { content, .. } = resolved else {
+        panic!("expected create_file recipe, got {resolved:?}");
+    };
+
+    mock_git_info_refs.assert_async().await;
+    mock_git_upload_pack.assert_async().await;
+
+    let git_ref: serde_json::Value = serde_json::from_slice(&content)?;
+    assert_eq!(
+        git_ref,
+        serde_json::json!({
+            "gitRefMain": {
+                "staticKind": "git_ref",
+                "repository": format!("{mock_repo_url}/"),
+                "commit": "0123456789abcdef01234567890123456789abcd",
+            },
+            "gitCheckoutFeature1": {
+                "staticKind": "git_ref",
+                "repository": format!("{mock_repo_url}/"),
+                "commit": "abcdef0123456789abcdef012345678901234567",
+            },
+            "gitRefFeature2": {
+                "staticKind": "git_ref",
+                "repository": format!("{mock_repo_url}/"),
+                "commit": "0000000000111111111122222222223333333333",
+            },
+            "gitCheckoutFeature2": {
+                "staticKind": "git_ref",
+                "repository": format!("{mock_repo_url}/"),
+                "commit": "0000000000111111111122222222223333333333",
+            },
+        }),
+    );
+
+    Ok(())
+}

--- a/crates/brioche-core/tests/script_eval.rs
+++ b/crates/brioche-core/tests/script_eval.rs
@@ -897,6 +897,7 @@ async fn test_eval_brioche_git_ref_and_git_checkout() -> anyhow::Result<()> {
                                 type: "git_ref",
                                 repository,
                                 ref,
+                                callee: "Brioche.gitRef",
                             },
                         );
                     },
@@ -907,6 +908,7 @@ async fn test_eval_brioche_git_ref_and_git_checkout() -> anyhow::Result<()> {
                                 type: "git_ref",
                                 repository,
                                 ref,
+                                callee: "Brioche.gitCheckout",
                             },
                         );
                     },


### PR DESCRIPTION
This PR updates project analysis to parse `Brioche.gitCheckout` as a static.

From an implementation perspective, `Brioche.gitCheckout` is treated identically to [`Brioche.gitRef`](https://brioche.dev/docs/core-concepts/statics/#briochegitref). The main motivation behind this new method is to update the `brioche-packages` repo to provide a different implementation for `Brioche.gitCheckout`-- specifically, the new `Brioche.gitCheckout` function is intended to be implemented by checking out the returned git commit.

To help improve errors, I also tweaked the underlying `Deno.core.ops.op_brioche_get_static` function to accept a `callee` property in its options. The implementation should pass the function name, which will allow the Rust implementation to return a more specific error message.