### PR TITLE
Update console output to show download / archive sizes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1275,6 +1275,7 @@ dependencies = [
  "brioche-pack",
  "brioche-test-support",
  "bstr",
+ "bytesize 2.0.1",
  "cfg-if 1.0.0",
  "console-subscriber",
  "debug-ignore",
@@ -1429,6 +1430,12 @@ name = "bytesize"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d2c12f985c78475a6b8d629afd0c360260ef34cfef52efccdcfd31972f81c2e"
+
+[[package]]
+name = "bytesize"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3c8f83209414aacf0eeae3cf730b18d6981697fba62f200fcfb92b9f082acba"
 
 [[package]]
 name = "bzip2"
@@ -3006,7 +3013,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "729b7e708352a35b2b37ab39cbc7a2b9d22f8386808a10b6ea7dd4cd1cf817cd"
 dependencies = [
  "bytes",
- "bytesize",
+ "bytesize 1.3.2",
  "crc32fast",
  "crossbeam-channel",
  "flate2",
@@ -5584,7 +5591,7 @@ version = "29.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ee7ce24c980b976607e2d6ae4aae92827994d23fed71659c3ede3f92528b58b"
 dependencies = [
- "bytesize",
+ "bytesize 1.3.2",
  "human_format",
  "log",
  "parking_lot 0.12.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1306,6 +1306,7 @@ dependencies = [
  "opentelemetry_sdk",
  "pathdiff",
  "petgraph",
+ "pin-project-lite",
  "pretty_assertions",
  "regex",
  "relative-path",

--- a/crates/brioche-core/Cargo.toml
+++ b/crates/brioche-core/Cargo.toml
@@ -75,6 +75,7 @@ opentelemetry-semantic-conventions = "0.29.0"
 opentelemetry_sdk = { version = "0.29.0", features = ["rt-tokio"] }
 pathdiff = "0.2.3"
 petgraph = "0.8.1"
+pin-project-lite = "0.2.16"
 regex = "1.11.1"
 relative-path = { version = "1.9.3", features = ["serde"] }
 reqwest = { version = "0.12.15", default-features = false, features = [

--- a/crates/brioche-core/Cargo.toml
+++ b/crates/brioche-core/Cargo.toml
@@ -42,6 +42,7 @@ biome_unicode_table = "=0.5.7"
 blake3 = "1.8.1"
 brioche-pack = { path = "../brioche-pack" }
 bstr = { version = "1.12.0", features = ["serde"] }
+bytesize = "2.0.1"
 cfg-if = "1.0.0"
 console-subscriber = "0.4.1"
 debug-ignore = "1.0.5"

--- a/crates/brioche-core/src/cache/archive.rs
+++ b/crates/brioche-core/src/cache/archive.rs
@@ -352,8 +352,8 @@ pub async fn read_artifact_archive(
 ) -> anyhow::Result<Artifact> {
     let job_id = brioche.reporter.add_job(NewJob::CacheFetch {
         kind: fetch_kind,
-        downloaded_data: None,
-        total_data: None,
+        downloaded_bytes: None,
+        total_bytes: None,
         downloaded_blobs: None,
         total_blobs: None,
         started_at: std::time::Instant::now(),
@@ -577,8 +577,8 @@ pub async fn read_artifact_archive(
     brioche.reporter.update_job(
         job_id,
         UpdateJob::CacheFetchUpdate {
-            downloaded_data: None,
-            total_data: Some(total_needed_bytes),
+            downloaded_bytes: None,
+            total_bytes: Some(total_needed_bytes),
             downloaded_blobs: None,
             total_blobs: Some(total_needed_blobs),
         },
@@ -636,7 +636,7 @@ pub async fn read_artifact_archive(
                 brioche.reporter.update_job(
                     job_id,
                     UpdateJob::CacheFetchAdd {
-                        downloaded_data: Some(length),
+                        downloaded_bytes: Some(length),
                         downloaded_blobs: Some(1),
                     },
                 );
@@ -738,8 +738,8 @@ pub async fn read_artifact_archive(
     brioche.reporter.update_job(
         job_id,
         UpdateJob::CacheFetchUpdate {
-            downloaded_data: Some(total_needed_bytes),
-            total_data: Some(total_needed_bytes),
+            downloaded_bytes: Some(total_needed_bytes),
+            total_bytes: Some(total_needed_bytes),
             downloaded_blobs: Some(total_needed_blobs),
             total_blobs: Some(total_needed_blobs),
         },
@@ -807,7 +807,7 @@ async fn fetch_blobs_from_chunks(
                 brioche.reporter.update_job(
                     job_id,
                     UpdateJob::CacheFetchAdd {
-                        downloaded_data: Some(length),
+                        downloaded_bytes: Some(length),
                         downloaded_blobs: Some(1),
                     },
                 );
@@ -860,7 +860,7 @@ async fn fetch_blobs_from_chunks(
                         reporter.update_job(
                             job_id,
                             UpdateJob::CacheFetchAdd {
-                                downloaded_data: Some(length),
+                                downloaded_bytes: Some(length),
                                 downloaded_blobs: None,
                             },
                         );
@@ -889,7 +889,7 @@ async fn fetch_blobs_from_chunks(
             brioche.reporter.update_job(
                 job_id,
                 UpdateJob::CacheFetchAdd {
-                    downloaded_data: None,
+                    downloaded_bytes: None,
                     downloaded_blobs: Some(1),
                 },
             );

--- a/crates/brioche-core/src/cache/archive.rs
+++ b/crates/brioche-core/src/cache/archive.rs
@@ -354,8 +354,6 @@ pub async fn read_artifact_archive(
         kind: fetch_kind,
         downloaded_bytes: None,
         total_bytes: None,
-        downloaded_blobs: None,
-        total_blobs: None,
         started_at: std::time::Instant::now(),
     });
 
@@ -573,14 +571,11 @@ pub async fn read_artifact_archive(
         .iter()
         .map(|(_, range)| range.end.saturating_sub(range.start))
         .sum::<u64>();
-    let total_needed_blobs: u64 = needed_blobs.len().try_into()?;
     brioche.reporter.update_job(
         job_id,
         UpdateJob::CacheFetchUpdate {
             downloaded_bytes: None,
             total_bytes: Some(total_needed_bytes),
-            downloaded_blobs: None,
-            total_blobs: Some(total_needed_blobs),
         },
     );
 
@@ -637,7 +632,6 @@ pub async fn read_artifact_archive(
                     job_id,
                     UpdateJob::CacheFetchAdd {
                         downloaded_bytes: Some(length),
-                        downloaded_blobs: Some(1),
                     },
                 );
 
@@ -740,8 +734,6 @@ pub async fn read_artifact_archive(
         UpdateJob::CacheFetchUpdate {
             downloaded_bytes: Some(total_needed_bytes),
             total_bytes: Some(total_needed_bytes),
-            downloaded_blobs: Some(total_needed_blobs),
-            total_blobs: Some(total_needed_blobs),
         },
     );
 
@@ -808,7 +800,6 @@ async fn fetch_blobs_from_chunks(
                     job_id,
                     UpdateJob::CacheFetchAdd {
                         downloaded_bytes: Some(length),
-                        downloaded_blobs: Some(1),
                     },
                 );
 
@@ -861,7 +852,6 @@ async fn fetch_blobs_from_chunks(
                             job_id,
                             UpdateJob::CacheFetchAdd {
                                 downloaded_bytes: Some(length),
-                                downloaded_blobs: None,
                             },
                         );
                     }
@@ -890,7 +880,6 @@ async fn fetch_blobs_from_chunks(
                 job_id,
                 UpdateJob::CacheFetchAdd {
                     downloaded_bytes: None,
-                    downloaded_blobs: Some(1),
                 },
             );
 

--- a/crates/brioche-core/src/process_events/reader.rs
+++ b/crates/brioche-core/src/process_events/reader.rs
@@ -39,8 +39,10 @@ where
         Ok(Self { reader })
     }
 
-    pub const fn pos(&self) -> u64 {
-        self.reader.cursor
+    pub fn pos(&self) -> u64 {
+        self.reader
+            .cursor
+            .load(std::sync::atomic::Ordering::Relaxed)
     }
 
     pub fn seek_to_pos(&mut self, pos: u64) -> Result<(), ProcessEventReadError>

--- a/crates/brioche-core/src/reporter/console.rs
+++ b/crates/brioche-core/src/reporter/console.rs
@@ -732,10 +732,25 @@ impl superconsole::Component for JobComponent<'_> {
                     .saturating_sub(1)
                     .saturating_sub(line.len());
 
-                let truncated_url = string_with_width(url.as_str(), remaining_width, "…");
+                let downloaded_size = bytesize::ByteSize(*downloaded_bytes);
+                let total_size = total_bytes.map(bytesize::ByteSize);
+                let mut download_message = total_size.map_or_else(
+                    || downloaded_size.to_string(),
+                    |total_size| format!("{downloaded_size} / {total_size}"),
+                );
+                let truncated_url = string_with_width(
+                    url.as_str(),
+                    remaining_width
+                        .saturating_sub(download_message.len())
+                        .saturating_sub(2),
+                    "…",
+                );
+
+                download_message += "  ";
+                download_message += &truncated_url;
 
                 line.extend(progress_bar_spans(
-                    &truncated_url,
+                    &download_message,
                     remaining_width,
                     progress_fraction.unwrap_or(0.0),
                 ));

--- a/crates/brioche-core/src/reporter/console.rs
+++ b/crates/brioche-core/src/reporter/console.rs
@@ -317,16 +317,40 @@ impl ConsoleReporter {
                 };
 
                 match &update {
-                    UpdateJob::Download { finished_at, .. } => {
+                    UpdateJob::Download {
+                        finished_at,
+                        downloaded_bytes,
+                        ..
+                    } => {
+                        let Job::Download { url, .. } = job else {
+                            panic!(
+                                "tried to update non-download job {id:?} with a download update"
+                            );
+                        };
+
                         if let Some(finished_at) = finished_at {
                             let elapsed = finished_at.saturating_duration_since(job.created_at());
-                            eprintln!("Finished download in {}", DisplayDuration(elapsed));
+
+                            let downloaded_size = bytesize::ByteSize(*downloaded_bytes);
+                            let elapsed_duration = DisplayDuration(elapsed);
+
+                            eprintln!(
+                                "Finished downloading {url} ({downloaded_size}) in {elapsed_duration}"
+                            );
                         }
                     }
-                    UpdateJob::Unarchive { finished_at, .. } => {
+                    UpdateJob::Unarchive {
+                        finished_at,
+                        read_bytes,
+                        ..
+                    } => {
                         if let Some(finished_at) = finished_at {
                             let elapsed = finished_at.saturating_duration_since(job.created_at());
-                            eprintln!("Finished unarchiving in {}", DisplayDuration(elapsed));
+
+                            let read_size = bytesize::ByteSize(*read_bytes);
+                            let elapsed_duration = DisplayDuration(elapsed);
+
+                            eprintln!("Finished unarchiving {read_size} in {elapsed_duration}");
                         }
                     }
                     UpdateJob::ProcessUpdateStatus { status } => {

--- a/crates/brioche-core/src/reporter/console.rs
+++ b/crates/brioche-core/src/reporter/console.rs
@@ -262,8 +262,6 @@ impl ConsoleReporter {
                         kind: super::job::CacheFetchKind::Bake,
                         downloaded_bytes: _,
                         total_bytes: _,
-                        downloaded_blobs: _,
-                        total_blobs: _,
                         started_at: _,
                     } => {
                         eprintln!("Fetching artifact from cache");
@@ -272,8 +270,6 @@ impl ConsoleReporter {
                         kind: super::job::CacheFetchKind::Project,
                         downloaded_bytes: _,
                         total_bytes: _,
-                        downloaded_blobs: _,
-                        total_blobs: _,
                         started_at: _,
                     } => {
                         eprintln!("Fetching project from cache");
@@ -852,8 +848,6 @@ impl superconsole::Component for JobComponent<'_> {
                 kind,
                 downloaded_bytes,
                 total_bytes,
-                downloaded_blobs: _,
-                total_blobs: _,
                 started_at: _,
                 finished_at: _,
             } => {

--- a/crates/brioche-core/src/reporter/console.rs
+++ b/crates/brioche-core/src/reporter/console.rs
@@ -766,17 +766,27 @@ impl superconsole::Component for JobComponent<'_> {
                     indicator_span(indicator),
                     superconsole::Span::new_unstyled_lossy(" Unarchive "),
                     percentage_span,
+                    superconsole::Span::new_unstyled_lossy(" "),
                 ]);
 
-                if !job.is_complete() {
-                    let remaining_width = dimensions
-                        .width
-                        .saturating_sub(1)
-                        .saturating_sub(line.len());
+                let remaining_width = dimensions
+                    .width
+                    .saturating_sub(1)
+                    .saturating_sub(line.len());
 
-                    line.push(superconsole::Span::new_unstyled_lossy(" "));
-                    line.extend(progress_bar_spans("", remaining_width, progress_fraction));
-                }
+                let read_size = bytesize::ByteSize(*read_bytes);
+                let total_size = bytesize::ByteSize(*total_bytes);
+                let unarchive_message = if job.is_complete() {
+                    format!("Unarchive: {read_size}")
+                } else {
+                    format!("Unarchive: {read_size} / {total_size}")
+                };
+
+                line.extend(progress_bar_spans(
+                    &unarchive_message,
+                    remaining_width,
+                    progress_fraction,
+                ));
 
                 superconsole::Lines::from_iter([line])
             }

--- a/crates/brioche-core/src/reporter/console.rs
+++ b/crates/brioche-core/src/reporter/console.rs
@@ -851,8 +851,8 @@ impl superconsole::Component for JobComponent<'_> {
                 kind,
                 downloaded_bytes,
                 total_bytes,
-                downloaded_blobs,
-                total_blobs,
+                downloaded_blobs: _,
+                total_blobs: _,
                 started_at: _,
                 finished_at: _,
             } => {
@@ -882,20 +882,17 @@ impl superconsole::Component for JobComponent<'_> {
                     superconsole::Span::new_unstyled_lossy(" "),
                 ]);
 
+                let downloaded_size = bytesize::ByteSize(*downloaded_bytes);
+                let total_size = total_bytes.map(bytesize::ByteSize);
+
                 let fetch_kind = match kind {
                     super::job::CacheFetchKind::Bake => "artifact",
                     super::job::CacheFetchKind::Project => "project",
                 };
                 let fetching_message = if job.is_complete() {
-                    format!(
-                        "Fetch {fetch_kind}: {downloaded_blobs} blob{s}",
-                        s = if *downloaded_blobs == 1 { "" } else { "s" }
-                    )
-                } else if let Some(total_blobs) = total_blobs {
-                    format!(
-                        "Fetch {fetch_kind}: {downloaded_blobs} / {total_blobs} blob{s}",
-                        s = if *downloaded_blobs == 1 { "" } else { "s" }
-                    )
+                    format!("Fetch {fetch_kind}: {downloaded_size}")
+                } else if let Some(total_size) = total_size {
+                    format!("Fetch {fetch_kind}: {downloaded_size} / {total_size}")
                 } else {
                     format!("Fetch {fetch_kind}")
                 };

--- a/crates/brioche-core/src/reporter/console.rs
+++ b/crates/brioche-core/src/reporter/console.rs
@@ -260,8 +260,8 @@ impl ConsoleReporter {
                     NewJob::Process { status: _ } => {}
                     NewJob::CacheFetch {
                         kind: super::job::CacheFetchKind::Bake,
-                        downloaded_data: _,
-                        total_data: _,
+                        downloaded_bytes: _,
+                        total_bytes: _,
                         downloaded_blobs: _,
                         total_blobs: _,
                         started_at: _,
@@ -270,8 +270,8 @@ impl ConsoleReporter {
                     }
                     NewJob::CacheFetch {
                         kind: super::job::CacheFetchKind::Project,
-                        downloaded_data: _,
-                        total_data: _,
+                        downloaded_bytes: _,
+                        total_bytes: _,
                         downloaded_blobs: _,
                         total_blobs: _,
                         started_at: _,
@@ -849,17 +849,17 @@ impl superconsole::Component for JobComponent<'_> {
             }
             Job::CacheFetch {
                 kind,
-                downloaded_data,
-                total_data,
+                downloaded_bytes,
+                total_bytes,
                 downloaded_blobs,
                 total_blobs,
                 started_at: _,
                 finished_at: _,
             } => {
-                let total_progress = match total_data {
+                let total_progress = match total_bytes {
                     None => 0.0,
                     Some(0) => 1.0,
-                    Some(total_data) => *downloaded_data as f64 / *total_data as f64,
+                    Some(total_bytes) => *downloaded_bytes as f64 / *total_bytes as f64,
                 };
                 let total_percent = (total_progress * 100.0) as u64;
 

--- a/crates/brioche-core/src/reporter/console.rs
+++ b/crates/brioche-core/src/reporter/console.rs
@@ -428,7 +428,7 @@ impl ConsoleReporter {
 
                         let Job::CacheFetch {
                             kind,
-                            downloaded_blobs,
+                            downloaded_bytes,
                             ..
                         } = job
                         else {
@@ -439,10 +439,11 @@ impl ConsoleReporter {
                             crate::reporter::job::CacheFetchKind::Project => "project",
                         };
 
+                        let downloaded_size = bytesize::ByteSize(*downloaded_bytes);
+                        let elapsed_duration = DisplayDuration(elapsed);
+
                         eprintln!(
-                            "Finished fetching {fetch_kind} with {downloaded_blobs} new blob{s} from cache in {}",
-                            DisplayDuration(elapsed),
-                            s = if *downloaded_blobs == 1 { "" } else { "s" }
+                            "Fetched {downloaded_size} for {fetch_kind} from cache in {elapsed_duration}",
                         );
                     }
                 }

--- a/crates/brioche-core/src/reporter/job.rs
+++ b/crates/brioche-core/src/reporter/job.rs
@@ -16,8 +16,8 @@ pub enum NewJob {
     },
     CacheFetch {
         kind: CacheFetchKind,
-        downloaded_data: Option<u64>,
-        total_data: Option<u64>,
+        downloaded_bytes: Option<u64>,
+        total_bytes: Option<u64>,
         downloaded_blobs: Option<u64>,
         total_blobs: Option<u64>,
         started_at: std::time::Instant,
@@ -42,12 +42,12 @@ pub enum UpdateJob {
         status: ProcessStatus,
     },
     CacheFetchAdd {
-        downloaded_data: Option<u64>,
+        downloaded_bytes: Option<u64>,
         downloaded_blobs: Option<u64>,
     },
     CacheFetchUpdate {
-        downloaded_data: Option<u64>,
-        total_data: Option<u64>,
+        downloaded_bytes: Option<u64>,
+        total_bytes: Option<u64>,
         downloaded_blobs: Option<u64>,
         total_blobs: Option<u64>,
     },
@@ -75,8 +75,8 @@ pub enum Job {
     },
     CacheFetch {
         kind: CacheFetchKind,
-        downloaded_data: u64,
-        total_data: Option<u64>,
+        downloaded_bytes: u64,
+        total_bytes: Option<u64>,
         downloaded_blobs: u64,
         total_blobs: Option<u64>,
         started_at: std::time::Instant,
@@ -104,15 +104,15 @@ impl Job {
             },
             NewJob::CacheFetch {
                 kind,
-                downloaded_data,
-                total_data,
+                downloaded_bytes,
+                total_bytes,
                 downloaded_blobs,
                 total_blobs,
                 started_at,
             } => Self::CacheFetch {
                 kind,
-                downloaded_data: downloaded_data.unwrap_or(0),
-                total_data,
+                downloaded_bytes: downloaded_bytes.unwrap_or(0),
+                total_bytes,
                 downloaded_blobs: downloaded_blobs.unwrap_or(0),
                 total_blobs,
                 started_at,
@@ -180,11 +180,11 @@ impl Job {
                 *status = new_status;
             }
             UpdateJob::CacheFetchAdd {
-                downloaded_data: add_downloaded_data,
+                downloaded_bytes: add_downloaded_bytes,
                 downloaded_blobs: add_downloaded_blobs,
             } => {
                 let Self::CacheFetch {
-                    downloaded_data,
+                    downloaded_bytes,
                     downloaded_blobs,
                     ..
                 } = self
@@ -194,8 +194,8 @@ impl Job {
                     );
                 };
 
-                if let Some(add_downloaded_data) = add_downloaded_data {
-                    *downloaded_data += add_downloaded_data;
+                if let Some(add_downloaded_bytes) = add_downloaded_bytes {
+                    *downloaded_bytes += add_downloaded_bytes;
                 }
 
                 if let Some(add_downloaded_blobs) = add_downloaded_blobs {
@@ -203,15 +203,15 @@ impl Job {
                 }
             }
             UpdateJob::CacheFetchUpdate {
-                downloaded_data: new_downloaded_data,
-                total_data: new_total_data,
+                downloaded_bytes: new_downloaded_bytes,
+                total_bytes: new_total_bytes,
                 downloaded_blobs: new_downloaded_blobs,
                 total_blobs: new_total_blobs,
             } => {
                 let Self::CacheFetch {
                     kind: _,
-                    downloaded_data,
-                    total_data,
+                    downloaded_bytes,
+                    total_bytes,
                     downloaded_blobs,
                     total_blobs,
                     started_at: _,
@@ -223,11 +223,11 @@ impl Job {
                     );
                 };
 
-                if let Some(new_downloaded_data) = new_downloaded_data {
-                    *downloaded_data = new_downloaded_data;
+                if let Some(new_downloaded_bytes) = new_downloaded_bytes {
+                    *downloaded_bytes = new_downloaded_bytes;
                 }
-                if let Some(new_total_data) = new_total_data {
-                    *total_data = Some(new_total_data);
+                if let Some(new_total_bytes) = new_total_bytes {
+                    *total_bytes = Some(new_total_bytes);
                 }
                 if let Some(new_downloaded_blobs) = new_downloaded_blobs {
                     *downloaded_blobs = new_downloaded_blobs;
@@ -241,8 +241,8 @@ impl Job {
             } => {
                 let Self::CacheFetch {
                     kind: _,
-                    downloaded_data,
-                    total_data,
+                    downloaded_bytes,
+                    total_bytes,
                     downloaded_blobs,
                     total_blobs,
                     started_at: _,
@@ -254,8 +254,8 @@ impl Job {
                     );
                 };
 
-                if let Some(total_data) = total_data {
-                    *downloaded_data = *total_data;
+                if let Some(total_bytes) = total_bytes {
+                    *downloaded_bytes = *total_bytes;
                 }
 
                 if let Some(total_blobs) = total_blobs {

--- a/crates/brioche-core/src/reporter/job.rs
+++ b/crates/brioche-core/src/reporter/job.rs
@@ -18,8 +18,6 @@ pub enum NewJob {
         kind: CacheFetchKind,
         downloaded_bytes: Option<u64>,
         total_bytes: Option<u64>,
-        downloaded_blobs: Option<u64>,
-        total_blobs: Option<u64>,
         started_at: std::time::Instant,
     },
 }
@@ -43,13 +41,10 @@ pub enum UpdateJob {
     },
     CacheFetchAdd {
         downloaded_bytes: Option<u64>,
-        downloaded_blobs: Option<u64>,
     },
     CacheFetchUpdate {
         downloaded_bytes: Option<u64>,
         total_bytes: Option<u64>,
-        downloaded_blobs: Option<u64>,
-        total_blobs: Option<u64>,
     },
     CacheFetchFinish {
         finished_at: std::time::Instant,
@@ -77,8 +72,6 @@ pub enum Job {
         kind: CacheFetchKind,
         downloaded_bytes: u64,
         total_bytes: Option<u64>,
-        downloaded_blobs: u64,
-        total_blobs: Option<u64>,
         started_at: std::time::Instant,
         finished_at: Option<std::time::Instant>,
     },
@@ -106,15 +99,11 @@ impl Job {
                 kind,
                 downloaded_bytes,
                 total_bytes,
-                downloaded_blobs,
-                total_blobs,
                 started_at,
             } => Self::CacheFetch {
                 kind,
                 downloaded_bytes: downloaded_bytes.unwrap_or(0),
                 total_bytes,
-                downloaded_blobs: downloaded_blobs.unwrap_or(0),
-                total_blobs,
                 started_at,
                 finished_at: None,
             },
@@ -181,12 +170,9 @@ impl Job {
             }
             UpdateJob::CacheFetchAdd {
                 downloaded_bytes: add_downloaded_bytes,
-                downloaded_blobs: add_downloaded_blobs,
             } => {
                 let Self::CacheFetch {
-                    downloaded_bytes,
-                    downloaded_blobs,
-                    ..
+                    downloaded_bytes, ..
                 } = self
                 else {
                     anyhow::bail!(
@@ -197,23 +183,15 @@ impl Job {
                 if let Some(add_downloaded_bytes) = add_downloaded_bytes {
                     *downloaded_bytes += add_downloaded_bytes;
                 }
-
-                if let Some(add_downloaded_blobs) = add_downloaded_blobs {
-                    *downloaded_blobs += add_downloaded_blobs;
-                }
             }
             UpdateJob::CacheFetchUpdate {
                 downloaded_bytes: new_downloaded_bytes,
                 total_bytes: new_total_bytes,
-                downloaded_blobs: new_downloaded_blobs,
-                total_blobs: new_total_blobs,
             } => {
                 let Self::CacheFetch {
                     kind: _,
                     downloaded_bytes,
                     total_bytes,
-                    downloaded_blobs,
-                    total_blobs,
                     started_at: _,
                     finished_at: _,
                 } = self
@@ -229,12 +207,6 @@ impl Job {
                 if let Some(new_total_bytes) = new_total_bytes {
                     *total_bytes = Some(new_total_bytes);
                 }
-                if let Some(new_downloaded_blobs) = new_downloaded_blobs {
-                    *downloaded_blobs = new_downloaded_blobs;
-                }
-                if let Some(new_total_blobs) = new_total_blobs {
-                    *total_blobs = Some(new_total_blobs);
-                }
             }
             UpdateJob::CacheFetchFinish {
                 finished_at: new_finished_at,
@@ -243,8 +215,6 @@ impl Job {
                     kind: _,
                     downloaded_bytes,
                     total_bytes,
-                    downloaded_blobs,
-                    total_blobs,
                     started_at: _,
                     finished_at,
                 } = self
@@ -256,10 +226,6 @@ impl Job {
 
                 if let Some(total_bytes) = total_bytes {
                     *downloaded_bytes = *total_bytes;
-                }
-
-                if let Some(total_blobs) = total_blobs {
-                    *downloaded_blobs = *total_blobs;
                 }
 
                 *finished_at = Some(new_finished_at);

--- a/crates/brioche-core/src/utils/io.rs
+++ b/crates/brioche-core/src/utils/io.rs
@@ -1,11 +1,19 @@
+use std::sync::{
+    Arc,
+    atomic::{AtomicU64, Ordering},
+};
+
 pub struct ReadTracker<R> {
     pub reader: R,
-    pub cursor: u64,
+    pub cursor: Arc<AtomicU64>,
 }
 
 impl<R> ReadTracker<R> {
-    pub const fn new(reader: R) -> Self {
-        Self { reader, cursor: 0 }
+    pub fn new(reader: R) -> Self {
+        Self {
+            reader,
+            cursor: Arc::new(AtomicU64::new(0)),
+        }
     }
 }
 
@@ -16,7 +24,7 @@ where
     fn read(&mut self, buf: &mut [u8]) -> Result<usize, std::io::Error> {
         let n = self.reader.read(buf)?;
         let n_u64: u64 = n.try_into().map_err(std::io::Error::other)?;
-        self.cursor += n_u64;
+        self.cursor.fetch_add(n_u64, Ordering::Relaxed);
         Ok(n)
     }
 }
@@ -31,7 +39,7 @@ where
 
     fn consume(&mut self, amt: usize) {
         let amt_u64: u64 = amt.try_into().unwrap();
-        self.cursor += amt_u64;
+        self.cursor.fetch_add(amt_u64, Ordering::Relaxed);
         self.reader.consume(amt);
     }
 }
@@ -42,7 +50,7 @@ where
 {
     fn seek(&mut self, pos: std::io::SeekFrom) -> std::io::Result<u64> {
         let new_pos = self.reader.seek(pos)?;
-        self.cursor = new_pos;
+        self.cursor.store(new_pos, Ordering::Relaxed);
         Ok(new_pos)
     }
 }


### PR DESCRIPTION
This PR tweaks how several jobs are displayed, both for the "pretty" console display and the plaintext display.

When the "cache" and "download" jobs run, they will show the size of downloaded data out of the total size. The "unarchive" job will show the number of bytes read from the archive out of the archive's total size. Sizes are shown using the [`bytesize`](https://docs.rs/bytesize/latest/bytesize/) crate.

![Brioche screenshot showing one running and one complete job. The complete one has a full progress bar labelled "Fetch project: 248.5 KiB", and the running one has a partial progress bar labelled "Fetch artifact: 114.8 MiB / 364.3 MiB"](https://github.com/user-attachments/assets/09e80e15-a6e5-4621-af3c-bbc72bb8b0d4)
