### PR TITLE
Treat custom cache config as an overlay instead of replacing default cache

### DIFF
--- a/crates/brioche-core/src/config.rs
+++ b/crates/brioche-core/src/config.rs
@@ -77,10 +77,17 @@ pub struct CacheConfig {
     #[serde(default = "default_cache_max_concurrent_operations")]
     pub max_concurrent_operations: usize,
 
+    #[serde(default = "default_use_default_cache")]
+    pub use_default_cache: bool,
+
     #[serde(default)]
     pub read_only: bool,
 
     pub allow_http: Option<bool>,
+}
+
+const fn default_use_default_cache() -> bool {
+    true
 }
 
 const fn default_cache_max_concurrent_operations() -> usize {


### PR DESCRIPTION
#179 introduced the new cache mechanism. That PR included support for configuring a custom cache using either the `cache.url` field in the Brioche config file, or the `$BRIOCHE_CACHE_URL` env var. Either way, using a custom cache would **replace** the default cache.

This made it difficult to actually use a custom cache: starting from a new cache, every recipe would need to be built from scratch. Additionally, pulling projects from the registry would always fail since the cache is also used to retrieve project sources.

With this PR, configuring a custom cache now acts as an **overlay** on top of the default cache. Every cache access first checks the custom cache, then falls back to the default cache if not found. You can still completely opt-out of the default cache by setting `config.use_default_cache = false` in the config, or setting the env var `$BRIOCHE_CACHE_USE_DEFAULT_CACHE` to `false`.

I kept this change as minimal as possible since I felt that it'd be worth getting this in prior to the next release. So, it leaves the door open for other future caching improvements (2+ custom caches, pull-through caching, strategies like round-robin between caches, etc). I'm also not super happy with the implementation, so I think it would be worth revisiting how caching works soon (in particular, I'm starting to wonder if `object_store` is the right tool for our use-case)