### PR TITLE
Implement `unsandboxed` sandbox backend

### DIFF
--- a/crates/brioche-core/src/bake/process.rs
+++ b/crates/brioche-core/src/bake/process.rs
@@ -1355,6 +1355,9 @@ async fn select_sandbox_backend(
                 crate::sandbox::linux_namespace::LinuxNamespaceSandbox { mount_style },
             ))
         }
+        crate::config::SandboxConfig::Unsandboxed => {
+            Ok(crate::sandbox::SandboxBackend::Unsandboxed)
+        }
     }
 }
 

--- a/crates/brioche-core/src/config.rs
+++ b/crates/brioche-core/src/config.rs
@@ -42,6 +42,7 @@ pub enum SandboxConfig {
     #[default]
     Auto,
     LinuxNamespace(SandboxLinuxNamespaceConfig),
+    Unsandboxed,
 }
 
 #[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize)]

--- a/crates/brioche-core/src/sandbox.rs
+++ b/crates/brioche-core/src/sandbox.rs
@@ -3,11 +3,13 @@ use std::{collections::HashMap, path::PathBuf};
 use crate::encoding::{AsPath, TickEncoded};
 
 pub mod linux_namespace;
+pub mod unsandboxed;
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum SandboxBackend {
     LinuxNamespace(linux_namespace::LinuxNamespaceSandbox),
+    Unsandboxed,
 }
 
 #[serde_with::serde_as]
@@ -129,5 +131,6 @@ pub fn run_sandbox(
                 }
             }
         }
+        SandboxBackend::Unsandboxed => unsandboxed::run_sandbox(&exec),
     }
 }

--- a/crates/brioche-core/src/sandbox/unsandboxed.rs
+++ b/crates/brioche-core/src/sandbox/unsandboxed.rs
@@ -1,0 +1,75 @@
+use std::path::PathBuf;
+use std::{collections::HashMap, ffi::OsString};
+
+use anyhow::Context as _;
+use bstr::ByteSlice as _;
+
+use super::{SandboxPath, SandboxTemplate, SandboxTemplateComponent};
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum MountStyle {
+    Namespace,
+    PRoot { proot_path: PathBuf },
+}
+
+pub fn run_sandbox(exec: &super::SandboxExecutionConfig) -> anyhow::Result<super::ExitStatus> {
+    let program = build_template(&exec.command)?;
+    let args = exec
+        .args
+        .iter()
+        .map(build_template)
+        .collect::<anyhow::Result<Vec<_>>>()?;
+    let env = exec
+        .env
+        .iter()
+        .map(|(key, value)| {
+            let key = key.to_os_str()?.to_owned();
+            let value = build_template(value)?;
+            anyhow::Ok((key, value))
+        })
+        .collect::<anyhow::Result<HashMap<_, _>>>()?;
+
+    let current_dir = build_template(&SandboxTemplate {
+        components: vec![SandboxTemplateComponent::Path(exec.current_dir.clone())],
+    })?;
+
+    let program_path = std::path::Path::new(&program);
+    anyhow::ensure!(
+        program_path.is_absolute(),
+        "expected command to resolve to an absolute path: {}",
+        program.to_string_lossy()
+    );
+
+    let mut command = std::process::Command::new(program_path);
+    command.args(args);
+    command.env_clear();
+    command.envs(env);
+    command.current_dir(current_dir);
+
+    let mut child = command
+        .spawn()
+        .map_err(|error| anyhow::anyhow!("failed to spawn unsandboxed process: {error}"))?;
+
+    let exit_status = child.wait()?;
+
+    Ok(exit_status.into())
+}
+
+fn build_template(template: &SandboxTemplate) -> anyhow::Result<OsString> {
+    let mut result = OsString::new();
+    for component in &template.components {
+        match component {
+            SandboxTemplateComponent::Literal { value } => {
+                let value = value
+                    .to_os_str()
+                    .context("failed to convert string to OsString")?;
+                result.push(value);
+            }
+            SandboxTemplateComponent::Path(SandboxPath { host_path, .. }) => {
+                result.push(host_path);
+            }
+        }
+    }
+
+    Ok(result)
+}


### PR DESCRIPTION
Closes #220

This PR adds a new sandbox backend called `unsandboxed`. As the name implies, this effectively disables sandboxing, allowing build steps to run directly on the host system.

When used, builds can trivially break the rules of hermeticity, as they can perform any kind of operations on the host system. For example, the `.unsafe({ networking })` setting has no effect when using the unsandboxed backend, as the underlying process always has standard network access.

So, this backend should only be used as a last resort, such as when user namespaces are blocked and when PRoot isn't a suitable choice (because the `ptrace` syscall is blocked, because a PRoot binary isn't available, or when the performance hit from PRoot is too high). On the other hand, this sandbox only uses functionality from Rust's standard library, so this backend could be a good choice when starting work on a new platform.