### PR TITLE
Add `currentDir` option to process recipes

### DIFF
--- a/crates/brioche-core/src/references.rs
+++ b/crates/brioche-core/src/references.rs
@@ -160,6 +160,7 @@ pub fn referenced_recipes(recipe: &Recipe) -> Vec<RecipeHash> {
                 command,
                 args,
                 env,
+                current_dir,
                 dependencies,
                 work_dir,
                 output_scaffold,
@@ -168,7 +169,10 @@ pub fn referenced_recipes(recipe: &Recipe) -> Vec<RecipeHash> {
                 networking: _,
             } = process;
 
-            let templates = std::iter::once(command).chain(args).chain(env.values());
+            let templates = [command, current_dir]
+                .into_iter()
+                .chain(args)
+                .chain(env.values());
 
             templates
                 .flat_map(|template| &template.components)
@@ -200,6 +204,7 @@ pub fn referenced_recipes(recipe: &Recipe) -> Vec<RecipeHash> {
                 command,
                 args,
                 env,
+                current_dir,
                 work_dir,
                 output_scaffold,
                 platform: _,
@@ -212,7 +217,10 @@ pub fn referenced_recipes(recipe: &Recipe) -> Vec<RecipeHash> {
                 .as_ref()
                 .map(|artifact| Recipe::from((**artifact).clone()));
 
-            let templates = std::iter::once(command).chain(args).chain(env.values());
+            let templates = [command, current_dir]
+                .into_iter()
+                .chain(args)
+                .chain(env.values());
 
             templates
                 .flat_map(|template| &template.components)

--- a/crates/brioche-core/src/sandbox.rs
+++ b/crates/brioche-core/src/sandbox.rs
@@ -24,7 +24,7 @@ pub struct SandboxExecutionConfig {
     pub args: Vec<SandboxTemplate>,
     #[serde_as(as = "HashMap<TickEncoded, _>")]
     pub env: HashMap<bstr::BString, SandboxTemplate>,
-    pub current_dir: SandboxPath,
+    pub current_dir: SandboxTemplate,
     pub networking: bool,
     pub uid_hint: u32,
     pub gid_hint: u32,

--- a/crates/brioche-core/src/sandbox/linux_namespace.rs
+++ b/crates/brioche-core/src/sandbox/linux_namespace.rs
@@ -42,12 +42,7 @@ pub fn run_sandbox(
         })
         .collect::<anyhow::Result<HashMap<_, _>>>()?;
 
-    let current_dir = build_template(
-        &SandboxTemplate {
-            components: vec![SandboxTemplateComponent::Path(exec.current_dir.clone())],
-        },
-        &mut host_paths,
-    )?;
+    let current_dir = build_template(&exec.current_dir, &mut host_paths)?;
 
     let mut unshare_namespaces = vec![unshare::Namespace::User];
 

--- a/crates/brioche-core/src/sandbox/unsandboxed.rs
+++ b/crates/brioche-core/src/sandbox/unsandboxed.rs
@@ -28,10 +28,7 @@ pub fn run_sandbox(exec: &super::SandboxExecutionConfig) -> anyhow::Result<super
             anyhow::Ok((key, value))
         })
         .collect::<anyhow::Result<HashMap<_, _>>>()?;
-
-    let current_dir = build_template(&SandboxTemplate {
-        components: vec![SandboxTemplateComponent::Path(exec.current_dir.clone())],
-    })?;
+    let current_dir = build_template(&exec.current_dir)?;
 
     let program_path = std::path::Path::new(&program);
     anyhow::ensure!(

--- a/crates/brioche-core/tests/bake_process.rs
+++ b/crates/brioche-core/tests/bake_process.rs
@@ -285,11 +285,11 @@ fn test_bake_process_with_readonly_contents() -> anyhow::Result<()> {
                 tpl("sh"),
                 tpl("-c"),
                 tpl(r#"
-                mkdir -p output/foo/bar &&
-                echo 'hello' > output/foo/bar/baz.txt &&
-                cp -r output "$BRIOCHE_OUTPUT" &&
-                chmod -R a-w output "$BRIOCHE_OUTPUT"
-            "#),
+                    mkdir -p output/foo/bar &&
+                    echo 'hello' > output/foo/bar/baz.txt &&
+                    cp -r output "$BRIOCHE_OUTPUT" &&
+                    chmod -R a-w output "$BRIOCHE_OUTPUT"
+                "#),
             ],
             env: BTreeMap::from_iter([
                 ("BRIOCHE_OUTPUT".into(), output_path()),
@@ -568,21 +568,21 @@ fn test_bake_process_custom_env_vars() -> anyhow::Result<()> {
                 tpl("sh"),
                 tpl("-c"),
                 tpl(r#"
-                set -euo pipefail
-                test -n "$custom_output"
-                test -d "$custom_home"
-                test -d "$custom_resources"
-                test -d "$custom_work_dir"
-                test -d "$custom_temp_dir"
+                    set -euo pipefail
+                    test -n "$custom_output"
+                    test -d "$custom_home"
+                    test -d "$custom_resources"
+                    test -d "$custom_work_dir"
+                    test -d "$custom_temp_dir"
 
-                test "$(pwd)" == "$custom_work_dir"
+                    test "$(pwd)" == "$custom_work_dir"
 
-                touch "$custom_home/file.txt"
-                touch "$custom_resources/file2.txt"
-                touch "$custom_work_dir/file3.txt"
-                touch "$custom_temp_dir/file3.txt"
-                touch "$custom_output"
-            "#),
+                    touch "$custom_home/file.txt"
+                    touch "$custom_resources/file2.txt"
+                    touch "$custom_work_dir/file3.txt"
+                    touch "$custom_temp_dir/file3.txt"
+                    touch "$custom_output"
+                "#),
             ],
             env: BTreeMap::from_iter([
                 ("custom_output".into(), output_path()),
@@ -613,15 +613,15 @@ fn test_bake_process_no_default_env_vars() -> anyhow::Result<()> {
                 tpl("sh"),
                 tpl("-c"),
                 tpl(r#"
-                set -eo pipefail
+                    set -eo pipefail
 
-                test -z "$BRIOCHE_OUTPUT"
-                test -z "$HOME"
-                test -z "$BRIOCHE_RESOURCE_DIR"
-                test -z "$TMPDIR"
+                    test -z "$BRIOCHE_OUTPUT"
+                    test -z "$HOME"
+                    test -z "$BRIOCHE_RESOURCE_DIR"
+                    test -z "$TMPDIR"
 
-                touch "$custom_output"
-            "#),
+                    touch "$custom_output"
+                "#),
             ],
             env: BTreeMap::from_iter([
                 ("custom_output".into(), output_path()),
@@ -647,9 +647,9 @@ fn test_bake_process_no_default_path() -> anyhow::Result<()> {
             args: vec![
                 tpl("-c"),
                 tpl(r#"
-                set -eo pipefail
-                touch "$BRIOCHE_OUTPUT"
-            "#),
+                    set -eo pipefail
+                    touch "$BRIOCHE_OUTPUT"
+                "#),
             ],
             env: BTreeMap::from_iter([
                 ("BRIOCHE_OUTPUT".into(), output_path()),
@@ -677,9 +677,9 @@ fn test_bake_process_command_ambiguous_error() -> anyhow::Result<()> {
             args: vec![
                 tpl("-c"),
                 tpl(r#"
-                set -eo pipefail
-                touch "$BRIOCHE_OUTPUT"
-            "#),
+                    set -eo pipefail
+                    touch "$BRIOCHE_OUTPUT"
+                "#),
             ],
             env: BTreeMap::from_iter([
                 ("BRIOCHE_OUTPUT".into(), output_path()),
@@ -708,9 +708,9 @@ fn test_bake_process_command_uses_path() -> anyhow::Result<()> {
             args: vec![
                 tpl("-c"),
                 tpl(r#"
-                set -eo pipefail
-                touch "$BRIOCHE_OUTPUT"
-            "#),
+                    set -eo pipefail
+                    touch "$BRIOCHE_OUTPUT"
+                "#),
             ],
             env: BTreeMap::from_iter([
                 (
@@ -736,9 +736,9 @@ fn test_bake_process_command_uses_dependencies() -> anyhow::Result<()> {
             args: vec![
                 tpl("-c"),
                 tpl(r#"
-                set -eo pipefail
-                touch "$BRIOCHE_OUTPUT"
-            "#),
+                    set -eo pipefail
+                    touch "$BRIOCHE_OUTPUT"
+                "#),
             ],
             env: BTreeMap::from_iter([("BRIOCHE_OUTPUT".into(), output_path())]),
             dependencies: vec![WithMeta::without_meta(utils())],
@@ -762,10 +762,10 @@ fn test_bake_process_starts_with_work_dir_contents() -> anyhow::Result<()> {
                 tpl("sh"),
                 tpl("-c"),
                 tpl(r#"
-                set -euo pipefail
-                test "$(cat file.txt)" == "hello"
-                touch "$BRIOCHE_OUTPUT"
-            "#),
+                    set -euo pipefail
+                    test "$(cat file.txt)" == "hello"
+                    touch "$BRIOCHE_OUTPUT"
+                "#),
             ],
             env: BTreeMap::from_iter([
                 ("BRIOCHE_OUTPUT".into(), output_path()),
@@ -801,11 +801,11 @@ fn test_bake_process_edit_work_dir_contents() -> anyhow::Result<()> {
                 tpl("sh"),
                 tpl("-c"),
                 tpl(r#"
-                set -euo pipefail
-                echo -n new > file.txt
-                echo -n new2 > dir/other.txt
-                touch "$BRIOCHE_OUTPUT"
-            "#),
+                    set -euo pipefail
+                    echo -n new > file.txt
+                    echo -n new2 > dir/other.txt
+                    touch "$BRIOCHE_OUTPUT"
+                "#),
             ],
             env: BTreeMap::from_iter([
                 ("BRIOCHE_OUTPUT".into(), output_path()),
@@ -848,10 +848,10 @@ fn test_bake_process_has_resource_dir() -> anyhow::Result<()> {
                 tpl("sh"),
                 tpl("-c"),
                 tpl(r#"
-                set -euo pipefail
-                test -d "$BRIOCHE_RESOURCE_DIR"
-                touch "$BRIOCHE_OUTPUT"
-            "#),
+                    set -euo pipefail
+                    test -d "$BRIOCHE_RESOURCE_DIR"
+                    touch "$BRIOCHE_OUTPUT"
+                "#),
             ],
             env: BTreeMap::from_iter([
                 ("BRIOCHE_OUTPUT".into(), output_path()),
@@ -918,26 +918,26 @@ fn test_bake_process_contains_all_resources() -> anyhow::Result<()> {
                 tpl("sh"),
                 tpl("-c"),
                 tpl(r#"
-                set -euo pipefail
-                test "$(cat "$fizz/file.txt")" = "foo"
-                test "$(cat "$buzz")" = "bar"
-                bar=""
-                baz=""
-                oldifs="$IFS"
-                IFS=":"
-                for dir in $BRIOCHE_INPUT_RESOURCE_DIRS; do
-                    if [ -e "$dir/foo/bar.txt" ]; then
-                        bar="$(cat "$dir/foo/bar.txt")"
-                    fi
-                    if [ -e "$dir/foo/baz.txt" ]; then
-                        baz="$(cat "$dir/foo/baz.txt")"
-                    fi
-                done
-                IFS="$oldifs"
-                test "$bar" = "resource a"
-                test "$baz" = "resource b"
-                touch "$BRIOCHE_OUTPUT"
-            "#),
+                    set -euo pipefail
+                    test "$(cat "$fizz/file.txt")" = "foo"
+                    test "$(cat "$buzz")" = "bar"
+                    bar=""
+                    baz=""
+                    oldifs="$IFS"
+                    IFS=":"
+                    for dir in $BRIOCHE_INPUT_RESOURCE_DIRS; do
+                        if [ -e "$dir/foo/bar.txt" ]; then
+                            bar="$(cat "$dir/foo/bar.txt")"
+                        fi
+                        if [ -e "$dir/foo/baz.txt" ]; then
+                            baz="$(cat "$dir/foo/baz.txt")"
+                        fi
+                    done
+                    IFS="$oldifs"
+                    test "$bar" = "resource a"
+                    test "$baz" = "resource b"
+                    touch "$BRIOCHE_OUTPUT"
+                "#),
             ],
             env: BTreeMap::from_iter([
                 ("BRIOCHE_OUTPUT".into(), output_path()),
@@ -985,14 +985,14 @@ fn test_bake_process_output_with_resources() -> anyhow::Result<()> {
                 tpl("sh"),
                 tpl("-c"),
                 tpl(r#"
-                set -euo pipefail
-                mkdir -p "$BRIOCHE_OUTPUT/bin"
-                echo -n "dummy_packed" > packed
-                echo -n "dummy_program" > "$BRIOCHE_RESOURCE_DIR/program"
-                echo -n "dummy_ld_linux" > "$BRIOCHE_RESOURCE_DIR/ld-linux.so"
+                    set -euo pipefail
+                    mkdir -p "$BRIOCHE_OUTPUT/bin"
+                    echo -n "dummy_packed" > packed
+                    echo -n "dummy_program" > "$BRIOCHE_RESOURCE_DIR/program"
+                    echo -n "dummy_ld_linux" > "$BRIOCHE_RESOURCE_DIR/ld-linux.so"
 
-                cp "$dummy_packed" "$BRIOCHE_OUTPUT/bin/program"
-            "#),
+                    cp "$dummy_packed" "$BRIOCHE_OUTPUT/bin/program"
+                "#),
             ],
             env: BTreeMap::from_iter([
                 ("BRIOCHE_OUTPUT".into(), output_path()),
@@ -1098,25 +1098,25 @@ fn test_bake_process_output_with_shared_resources() -> anyhow::Result<()> {
                 tpl("sh"),
                 tpl("-c"),
                 tpl(r#"
-                set -euo pipefail
-                mkdir -p "$BRIOCHE_OUTPUT/bin"
+                    set -euo pipefail
+                    mkdir -p "$BRIOCHE_OUTPUT/bin"
 
-                echo -n "resource_1_target" > "$BRIOCHE_RESOURCE_DIR/resource_1_target"
-                echo -n "resource_2_target" > "$BRIOCHE_RESOURCE_DIR/resource_2_target"
+                    echo -n "resource_1_target" > "$BRIOCHE_RESOURCE_DIR/resource_1_target"
+                    echo -n "resource_2_target" > "$BRIOCHE_RESOURCE_DIR/resource_2_target"
 
-                echo -n "dummy_foo" > "$BRIOCHE_RESOURCE_DIR/foo"
-                echo -n "dummy_bar_target" > "$BRIOCHE_RESOURCE_DIR/bar_target"
-                echo -n "dummy_baz_target" > "$BRIOCHE_RESOURCE_DIR/baz_target"
+                    echo -n "dummy_foo" > "$BRIOCHE_RESOURCE_DIR/foo"
+                    echo -n "dummy_bar_target" > "$BRIOCHE_RESOURCE_DIR/bar_target"
+                    echo -n "dummy_baz_target" > "$BRIOCHE_RESOURCE_DIR/baz_target"
 
-                ln -s "resource_1_target" "$BRIOCHE_RESOURCE_DIR/resource_1"
-                ln -s "resource_2_target" "$BRIOCHE_RESOURCE_DIR/resource_2"
+                    ln -s "resource_1_target" "$BRIOCHE_RESOURCE_DIR/resource_1"
+                    ln -s "resource_2_target" "$BRIOCHE_RESOURCE_DIR/resource_2"
 
-                ln -s "bar_target" "$BRIOCHE_RESOURCE_DIR/bar"
-                ln -s "baz_target" "$BRIOCHE_RESOURCE_DIR/baz"
+                    ln -s "bar_target" "$BRIOCHE_RESOURCE_DIR/bar"
+                    ln -s "baz_target" "$BRIOCHE_RESOURCE_DIR/baz"
 
-                cp "$dummy_packed_1" "$BRIOCHE_OUTPUT/bin/program_1"
-                cp "$dummy_packed_2" "$BRIOCHE_OUTPUT/bin/program_2"
-            "#),
+                    cp "$dummy_packed_1" "$BRIOCHE_OUTPUT/bin/program_1"
+                    cp "$dummy_packed_2" "$BRIOCHE_OUTPUT/bin/program_2"
+                "#),
             ],
             env: BTreeMap::from_iter([
                 ("BRIOCHE_OUTPUT".into(), output_path()),
@@ -1277,15 +1277,15 @@ fn test_bake_process_output_with_nested_symlink_resource_error() -> anyhow::Resu
                 tpl("sh"),
                 tpl("-c"),
                 tpl(r#"
-                set -euo pipefail
-                mkdir -p "$BRIOCHE_OUTPUT/bin"
+                    set -euo pipefail
+                    mkdir -p "$BRIOCHE_OUTPUT/bin"
 
-                echo -n "dummy_foo_target_target" > "$BRIOCHE_RESOURCE_DIR/foo_target_target"
-                ln -s "foo_target_target" "$BRIOCHE_RESOURCE_DIR/foo_target"
-                ln -s "foo_target" "$BRIOCHE_RESOURCE_DIR/foo"
+                    echo -n "dummy_foo_target_target" > "$BRIOCHE_RESOURCE_DIR/foo_target_target"
+                    ln -s "foo_target_target" "$BRIOCHE_RESOURCE_DIR/foo_target"
+                    ln -s "foo_target" "$BRIOCHE_RESOURCE_DIR/foo"
 
-                cp "$dummy_packed" "$BRIOCHE_OUTPUT/bin/program"
-            "#),
+                    cp "$dummy_packed" "$BRIOCHE_OUTPUT/bin/program"
+                "#),
             ],
             env: BTreeMap::from_iter([
                 ("BRIOCHE_OUTPUT".into(), output_path()),
@@ -1333,16 +1333,16 @@ fn test_bake_process_output_with_symlink_traversal_resource_error() -> anyhow::R
                 tpl("sh"),
                 tpl("-c"),
                 tpl(r#"
-                set -euo pipefail
-                mkdir -p "$BRIOCHE_OUTPUT/bin"
+                    set -euo pipefail
+                    mkdir -p "$BRIOCHE_OUTPUT/bin"
 
-                mkdir -p "$BRIOCHE_RESOURCE_DIR/fizz_target"
-                echo -n "dummy_fizzbuzz" > "$BRIOCHE_RESOURCE_DIR/fizz_target/buzz"
-                ln -s "fizz_target" "$BRIOCHE_RESOURCE_DIR/fizz"
-                ln -s "fizz/buzz" "$BRIOCHE_RESOURCE_DIR/foo"
+                    mkdir -p "$BRIOCHE_RESOURCE_DIR/fizz_target"
+                    echo -n "dummy_fizzbuzz" > "$BRIOCHE_RESOURCE_DIR/fizz_target/buzz"
+                    ln -s "fizz_target" "$BRIOCHE_RESOURCE_DIR/fizz"
+                    ln -s "fizz/buzz" "$BRIOCHE_RESOURCE_DIR/foo"
 
-                cp "$dummy_packed" "$BRIOCHE_OUTPUT/bin/program"
-            "#),
+                    cp "$dummy_packed" "$BRIOCHE_OUTPUT/bin/program"
+                "#),
             ],
             env: BTreeMap::from_iter([
                 ("BRIOCHE_OUTPUT".into(), output_path()),
@@ -1434,12 +1434,12 @@ fn test_bake_process_networking_disabled() -> anyhow::Result<()> {
                 tpl("sh"),
                 tpl("-c"),
                 tpl(r#"
-                wget \
-                    --timeout=1 \
-                    -O "$BRIOCHE_OUTPUT" \
-                    "$URL/file.txt" \
-                    > /dev/null 2> /dev/null
-            "#),
+                    wget \
+                        --timeout=1 \
+                        -O "$BRIOCHE_OUTPUT" \
+                        "$URL/file.txt" \
+                        > /dev/null 2> /dev/null
+                "#),
             ],
             env: BTreeMap::from_iter([
                 ("BRIOCHE_OUTPUT".into(), output_path()),
@@ -1478,12 +1478,12 @@ fn test_bake_process_networking_enabled() -> anyhow::Result<()> {
                 tpl("sh"),
                 tpl("-c"),
                 tpl(r#"
-                wget \
-                    --timeout=1 \
-                    -O "$BRIOCHE_OUTPUT" \
-                    "$URL/file.txt" \
-                    > /dev/null 2> /dev/null
-            "#),
+                    wget \
+                        --timeout=1 \
+                        -O "$BRIOCHE_OUTPUT" \
+                        "$URL/file.txt" \
+                        > /dev/null 2> /dev/null
+                "#),
             ],
             env: BTreeMap::from_iter([
                 ("BRIOCHE_OUTPUT".into(), output_path()),
@@ -1518,12 +1518,12 @@ fn test_bake_process_networking_enabled_dns() -> anyhow::Result<()> {
                 tpl("sh"),
                 tpl("-c"),
                 tpl(r#"
-                wget \
-                    --timeout=1 \
-                    -O "$BRIOCHE_OUTPUT" \
-                    "https://gist.githubusercontent.com/kylewlacy/c0f1a43e2641686f377178880fcce6ae/raw/f48155695445aa218e558fba824b61cf718d5e55/lorem-ipsum.txt" \
-                    > /dev/null 2> /dev/null
-            "#),
+                    wget \
+                        --timeout=1 \
+                        -O "$BRIOCHE_OUTPUT" \
+                        "https://gist.githubusercontent.com/kylewlacy/c0f1a43e2641686f377178880fcce6ae/raw/f48155695445aa218e558fba824b61cf718d5e55/lorem-ipsum.txt" \
+                        > /dev/null 2> /dev/null
+                "#),
             ],
             env: BTreeMap::from_iter([
                 ("BRIOCHE_OUTPUT".into(), output_path()),
@@ -1709,22 +1709,22 @@ fn test_bake_process_dependencies() -> anyhow::Result<()> {
                 tpl("sh"),
                 tpl("-c"),
                 tpl(r#"
-                set -euo pipefail
+                    set -euo pipefail
 
-                test "$PATH" = "$EXPECTED_PATH"
-                test "$DEP1" = "$EXPECTED_DEP1"
-                test "$DEP2" = "$EXPECTED_DEP2"
-                test "$DEP1_SYMLINK" = "$EXPECTED_DEP1_SYMLINK"
-                test "$DEP1_FILE" = "$EXPECTED_DEP1_FILE"
-                test "$DEP2_SYMLINK" = "$EXPECTED_DEP2_SYMLINK"
-                test "$DEP2_FILE" = "$EXPECTED_DEP2_FILE"
-                test "$FALLBACK_1" = "$EXPECTED_FALLBACK_1"
-                test "$FALLBACK_2" = "$EXPECTED_FALLBACK_2"
-                test "$FALLBACK_3" = "$EXPECTED_FALLBACK_3"
-                test "$FALLBACK_4" = "$EXPECTED_FALLBACK_4"
+                    test "$PATH" = "$EXPECTED_PATH"
+                    test "$DEP1" = "$EXPECTED_DEP1"
+                    test "$DEP2" = "$EXPECTED_DEP2"
+                    test "$DEP1_SYMLINK" = "$EXPECTED_DEP1_SYMLINK"
+                    test "$DEP1_FILE" = "$EXPECTED_DEP1_FILE"
+                    test "$DEP2_SYMLINK" = "$EXPECTED_DEP2_SYMLINK"
+                    test "$DEP2_FILE" = "$EXPECTED_DEP2_FILE"
+                    test "$FALLBACK_1" = "$EXPECTED_FALLBACK_1"
+                    test "$FALLBACK_2" = "$EXPECTED_FALLBACK_2"
+                    test "$FALLBACK_3" = "$EXPECTED_FALLBACK_3"
+                    test "$FALLBACK_4" = "$EXPECTED_FALLBACK_4"
 
-                touch "$BRIOCHE_OUTPUT"
-            "#),
+                    touch "$BRIOCHE_OUTPUT"
+                "#),
             ],
             env: BTreeMap::from_iter([
                 ("BRIOCHE_OUTPUT".into(), output_path()),

--- a/crates/brioche-core/tests/process_events.rs
+++ b/crates/brioche-core/tests/process_events.rs
@@ -10,7 +10,7 @@ use brioche_core::{
     },
     recipe::{CompleteProcessRecipe, CompleteProcessTemplate, Meta},
     reporter::job::ProcessStream,
-    sandbox::{ExitStatus, SandboxExecutionConfig, SandboxPath, SandboxPathOptions},
+    sandbox::{ExitStatus, SandboxExecutionConfig},
 };
 
 pub fn example_complete_process() -> CompleteProcessRecipe {
@@ -19,6 +19,7 @@ pub fn example_complete_process() -> CompleteProcessRecipe {
         args: vec![],
         env: Default::default(),
         work_dir: Default::default(),
+        current_dir: CompleteProcessTemplate::default_current_dir(),
         output_scaffold: None,
         platform: brioche_core::platform::Platform::X86_64Linux,
         is_unsafe: false,
@@ -36,13 +37,7 @@ fn example_process_event_description() -> ProcessEventDescription {
             command: Default::default(),
             args: Default::default(),
             env: Default::default(),
-            current_dir: SandboxPath {
-                host_path: Default::default(),
-                options: SandboxPathOptions {
-                    mode: brioche_core::sandbox::HostPathMode::Read,
-                    guest_path_hint: Default::default(),
-                },
-            },
+            current_dir: Default::default(),
             gid_hint: 0,
             uid_hint: 0,
             networking: false,

--- a/crates/brioche-core/tests/recipe_hash_stable.rs
+++ b/crates/brioche-core/tests/recipe_hash_stable.rs
@@ -286,6 +286,7 @@ async fn test_recipe_hash_stable_process() -> anyhow::Result<()> {
             command: ProcessTemplate { components: vec![] },
             args: vec![],
             env: BTreeMap::default(),
+            current_dir: ProcessTemplate::default_current_dir(),
             dependencies: vec![],
             work_dir: Box::new(brioche_test_support::without_meta(
                 brioche_test_support::lazy_dir_empty(),
@@ -309,6 +310,7 @@ async fn test_recipe_hash_stable_process() -> anyhow::Result<()> {
             },
             args: vec![],
             env: BTreeMap::default(),
+            current_dir: ProcessTemplate::default_current_dir(),
             dependencies: vec![],
             work_dir: Box::new(brioche_test_support::without_meta(
                 brioche_test_support::lazy_dir_empty(),
@@ -334,6 +336,7 @@ async fn test_recipe_hash_stable_process() -> anyhow::Result<()> {
                 components: vec![ProcessTemplateComponent::Literal { value: "sh".into() }],
             }],
             env: BTreeMap::default(),
+            current_dir: ProcessTemplate::default_current_dir(),
             dependencies: vec![],
             work_dir: Box::new(brioche_test_support::without_meta(
                 brioche_test_support::lazy_dir_empty(),
@@ -366,6 +369,7 @@ async fn test_recipe_hash_stable_process() -> anyhow::Result<()> {
                     }],
                 },
             )]),
+            current_dir: ProcessTemplate::default_current_dir(),
             dependencies: vec![],
             work_dir: Box::new(brioche_test_support::without_meta(
                 brioche_test_support::lazy_dir_empty(),
@@ -405,6 +409,7 @@ async fn test_recipe_hash_stable_process() -> anyhow::Result<()> {
                     ],
                 },
             )]),
+            current_dir: ProcessTemplate::default_current_dir(),
             dependencies: vec![],
             work_dir: Box::new(brioche_test_support::without_meta(
                 brioche_test_support::lazy_dir_empty(),
@@ -444,6 +449,7 @@ async fn test_recipe_hash_stable_process() -> anyhow::Result<()> {
                     ],
                 },
             )]),
+            current_dir: ProcessTemplate::default_current_dir(),
             dependencies: vec![],
             work_dir: Box::new(brioche_test_support::without_meta(
                 brioche_test_support::lazy_dir_empty(),
@@ -483,6 +489,7 @@ async fn test_recipe_hash_stable_process() -> anyhow::Result<()> {
                     ],
                 },
             )]),
+            current_dir: ProcessTemplate::default_current_dir(),
             dependencies: vec![],
             work_dir: Box::new(brioche_test_support::without_meta(
                 brioche_test_support::lazy_dir_empty(),
@@ -495,6 +502,90 @@ async fn test_recipe_hash_stable_process() -> anyhow::Result<()> {
         .hash()
         .to_string(),
         "5d14c32fce7134257ede8918680a83d9b33a292879192ac99461202851ab82e5",
+    ));
+
+    asserts.push((
+        Recipe::Process(ProcessRecipe {
+            command: ProcessTemplate {
+                components: vec![ProcessTemplateComponent::Literal {
+                    value: "/usr/bin/env".into(),
+                }],
+            },
+            args: vec![ProcessTemplate {
+                components: vec![ProcessTemplateComponent::Literal { value: "sh".into() }],
+            }],
+            env: BTreeMap::from_iter([(
+                "PATH".into(),
+                ProcessTemplate {
+                    components: vec![
+                        ProcessTemplateComponent::Input {
+                            recipe: brioche_test_support::without_meta(
+                                brioche_test_support::lazy_dir_empty(),
+                            ),
+                        },
+                        ProcessTemplateComponent::Literal {
+                            value: "/bin".into(),
+                        },
+                    ],
+                },
+            )]),
+            current_dir: ProcessTemplate {
+                components: vec![ProcessTemplateComponent::WorkDir],
+            },
+            dependencies: vec![],
+            work_dir: Box::new(brioche_test_support::without_meta(
+                brioche_test_support::lazy_dir_empty(),
+            )),
+            output_scaffold: None,
+            platform: Platform::X86_64Linux,
+            is_unsafe: true,
+            networking: true,
+        })
+        .hash()
+        .to_string(),
+        "5d14c32fce7134257ede8918680a83d9b33a292879192ac99461202851ab82e5",
+    ));
+
+    asserts.push((
+        Recipe::Process(ProcessRecipe {
+            command: ProcessTemplate {
+                components: vec![ProcessTemplateComponent::Literal {
+                    value: "/usr/bin/env".into(),
+                }],
+            },
+            args: vec![ProcessTemplate {
+                components: vec![ProcessTemplateComponent::Literal { value: "sh".into() }],
+            }],
+            env: BTreeMap::from_iter([(
+                "PATH".into(),
+                ProcessTemplate {
+                    components: vec![
+                        ProcessTemplateComponent::Input {
+                            recipe: brioche_test_support::without_meta(
+                                brioche_test_support::lazy_dir_empty(),
+                            ),
+                        },
+                        ProcessTemplateComponent::Literal {
+                            value: "/bin".into(),
+                        },
+                    ],
+                },
+            )]),
+            current_dir: ProcessTemplate {
+                components: vec![ProcessTemplateComponent::OutputPath],
+            },
+            dependencies: vec![],
+            work_dir: Box::new(brioche_test_support::without_meta(
+                brioche_test_support::lazy_dir_empty(),
+            )),
+            output_scaffold: None,
+            platform: Platform::X86_64Linux,
+            is_unsafe: true,
+            networking: true,
+        })
+        .hash()
+        .to_string(),
+        "7f78c082d7b4ef77863fe2aa32c90c5a5c764610fba91e5419d0cd406d351cd2",
     ));
 
     let left: Vec<_> = asserts.iter().map(|(left, _)| left).collect();

--- a/crates/brioche-test-support/src/lib.rs
+++ b/crates/brioche-test-support/src/lib.rs
@@ -474,6 +474,7 @@ pub fn default_process_x86_64_linux() -> ProcessRecipe {
         command: ProcessTemplate { components: vec![] },
         args: vec![],
         env: BTreeMap::new(),
+        current_dir: ProcessTemplate::default_current_dir(),
         dependencies: vec![],
         work_dir: Box::new(WithMeta::without_meta(Recipe::Directory(
             Directory::default(),
@@ -490,6 +491,7 @@ pub fn default_process() -> ProcessRecipe {
         command: ProcessTemplate { components: vec![] },
         args: vec![],
         env: BTreeMap::new(),
+        current_dir: ProcessTemplate::default_current_dir(),
         dependencies: vec![],
         work_dir: Box::new(WithMeta::without_meta(Recipe::Directory(
             Directory::default(),


### PR DESCRIPTION
This PR updates the `process` (and `complete_process`) recipe types with a new optional field: `currentDir`. When set to a process template value, the spawned process will change to a different directory before running, rather than the default `$HOME/work` directory (a.k.a `std.workDir`). Also, setting `currentDir` to `std.workDir` is treated exactly equivalent to omitting `currentDir`, which is important for preserving stable recipe hashes before and after this PR.

Here's a minimal example (note: will need a change in the `std` package as well)

```typescript
// Returns a recipe containing `hello.txt`
export default function() {
  return std.runBash`
    echo hi > hello.txt
  `
    .outputScaffold(std.directory())
    .currentDir(std.outputPath)
    .toDirectory();
}
```

Here, `.currentDir(std.outputPath)` is used as an alternative to doing `cd "$BRIOCHE_OUTPUT"` within the Bash script. This should help simplify a few packages today (there are quite a few places where we `cd` manually today; [GitHub search](https://github.com/search?q=repo%3Abrioche-dev%2Fbrioche-packages%20%22cd%20%5C%22%24BRIOCHE_OUTPUT%5C%22%22&type=code)).

I'm hoping this can be used for more interesting abstractions in the future. I have some potential ideas, but nothing concrete today...

---

As for the name, the main choices I condered work `currentDir`, `changeDir`, and `workingDir`.

- `workingDir` is the most descriptive name, but it would be too easy to confuse with `workDir` (which can even be used alongside `currentDir`).
- `changeDir` looks the closest to POSIX terminology-- the `chdir()` C function and `cd` for "change directory"-- but I don't like the verb "change" here. It's not really _changing_ anything, it feels more accurate to say that it's setting the _initial_ working directory for the recipe.

So that left `currentDir`. Rust also uses the term `current_dir` for the `std::process::Command` API, so that sold it for me.