### PR TITLE
Add `brioche live-update` command to live-update/auto-update projects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1216,6 +1216,7 @@ version = "0.1.5"
 dependencies = [
  "anyhow",
  "brioche-core",
+ "bstr",
  "cfg-if 1.0.0",
  "clap",
  "csv",

--- a/crates/brioche-core/src/project.rs
+++ b/crates/brioche-core/src/project.rs
@@ -12,6 +12,7 @@ use super::{Brioche, vfs::FileId};
 
 pub mod analyze;
 pub mod artifact;
+pub mod edit;
 mod load;
 
 #[derive(Debug, Clone, Copy)]

--- a/crates/brioche-core/src/project/analyze.rs
+++ b/crates/brioche-core/src/project/analyze.rs
@@ -635,7 +635,7 @@ where
         .filter_map(|result| result.transpose())
 }
 
-fn expression_to_json(
+pub fn expression_to_json(
     expr: &biome_js_syntax::AnyJsExpression,
     env: &HashMap<String, serde_json::Value>,
 ) -> anyhow::Result<serde_json::Value> {

--- a/crates/brioche-core/src/project/edit.rs
+++ b/crates/brioche-core/src/project/edit.rs
@@ -1,0 +1,154 @@
+use std::path::Path;
+
+use anyhow::Context as _;
+use biome_rowan::{AstNode as _, AstNodeExt as _, AstNodeList as _, AstSeparatedList as _};
+
+use crate::vfs::Vfs;
+
+#[derive(Debug, Default, Clone)]
+pub struct ProjectChanges {
+    pub project_definition: Option<serde_json::Value>,
+}
+
+pub async fn edit_project(
+    vfs: &Vfs,
+    project_path: &Path,
+    changes: ProjectChanges,
+) -> anyhow::Result<bool> {
+    let root_module_path = project_path.join("project.bri");
+    let file = root_module_path.display();
+    let (_, contents) = vfs
+        .load(&root_module_path)
+        .await
+        .with_context(|| format!("{file}: failed to read root module file"))?;
+    let contents =
+        std::str::from_utf8(&contents).with_context(|| format!("{file}: invalid UTF-8"))?;
+    let parsed = biome_js_parser::parse(
+        contents,
+        biome_js_syntax::JsFileSource::ts().with_module_kind(biome_js_syntax::ModuleKind::Module),
+        biome_js_parser::JsParserOptions::default(),
+    )
+    .cast::<biome_js_syntax::JsModule>()
+    .expect("failed to cast module");
+
+    let mut module = parsed
+        .try_tree()
+        .with_context(|| format!("{file}: failed to parse module"))?;
+    let mut did_update = false;
+
+    let project_export = module.items().iter().find_map(|item| {
+        let export = item.as_js_export()?;
+
+        let export_clause = export.export_clause().ok()?;
+        let declaration = export_clause.as_any_js_declaration_clause()?;
+        let var_declaration = declaration.as_js_variable_declaration_clause()?;
+        let var_declaration = var_declaration.declaration().ok()?;
+
+        var_declaration.declarators().iter().find_map(|declarator| {
+            let declarator = declarator.ok()?;
+            let id = declarator.id().ok()?;
+            let id = id.as_any_js_binding()?.as_js_identifier_binding()?;
+            let id_name = id.name_token().ok()?;
+
+            if id_name.text_trimmed() == "project" {
+                Some(declarator)
+            } else {
+                None
+            }
+        })
+    });
+
+    if let Some(new_project_definition) = &changes.project_definition {
+        let Some(project_export) = project_export else {
+            anyhow::bail!("project does not have a project definition");
+        };
+
+        let line = contents[..project_export.syntax().text_range().start().into()]
+            .lines()
+            .count();
+        let file_line = format!("{file}:{line}");
+        let project_export_expr = project_export
+            .initializer()
+            .map(|init| {
+                let expr = init.expression().with_context(|| {
+                    format!("{file_line}: invalid project export: failed to parse expression")
+                })?;
+                anyhow::Ok(expr)
+            })
+            .with_context(|| format!("{file_line}: invalid project export: expected assignment like `export const project = {{ ... }}`"))??;
+        let current_project_export_json =
+            super::analyze::expression_to_json(&project_export_expr, &Default::default())
+                .with_context(|| format!("{file_line}: invalid project export"))?;
+
+        if current_project_export_json != *new_project_definition {
+            let new_project_export_expr = json_to_expression(new_project_definition);
+
+            module = module
+                .replace_node(project_export_expr, new_project_export_expr)
+                .expect("failed to update JS AST node");
+            did_update = true;
+        }
+    };
+
+    if did_update {
+        let new_contents = crate::script::format::format_code(&module.text())?;
+
+        tokio::fs::write(&root_module_path, &new_contents[..]).await?;
+        vfs.unload(&root_module_path)?;
+        vfs.load(&root_module_path).await?;
+    }
+
+    Ok(did_update)
+}
+
+fn json_to_expression(value: &serde_json::Value) -> biome_js_syntax::AnyJsExpression {
+    // Generate a dummy JavaScript module with the JSON value embedded.
+    // biome_js_parser / biome_syntax don't seem to offer a way to construct
+    // AST nodes publicly, so generating valid JS source and parsing it
+    // seems like the best option
+    let json = serde_json::to_string_pretty(value).expect("failed to serialize JSON");
+    let script = format!("export const project = {json};");
+
+    // Parse the module
+    let parsed = biome_js_parser::parse(
+        &script,
+        biome_js_syntax::JsFileSource::ts().with_module_kind(biome_js_syntax::ModuleKind::Module),
+        biome_js_parser::JsParserOptions::default(),
+    )
+    .cast::<biome_js_syntax::JsModule>()
+    .expect("failed to cast module");
+
+    // Extract the expression
+    let module = parsed.try_tree().expect("failed to parse module");
+    let project_export = module
+        .items()
+        .iter()
+        .find_map(|item| {
+            let export = item.as_js_export()?;
+
+            let export_clause = export.export_clause().ok()?;
+            let declaration = export_clause.as_any_js_declaration_clause()?;
+            let var_declaration = declaration.as_js_variable_declaration_clause()?;
+            let var_declaration = var_declaration.declaration().ok()?;
+
+            var_declaration.declarators().iter().find_map(|declarator| {
+                let declarator = declarator.ok()?;
+                let id = declarator.id().ok()?;
+                let id = id.as_any_js_binding()?.as_js_identifier_binding()?;
+                let id_name = id.name_token().ok()?;
+
+                if id_name.text_trimmed() == "project" {
+                    Some(declarator)
+                } else {
+                    None
+                }
+            })
+        })
+        .expect("failed to find project export");
+    let project_export_initializer = project_export
+        .initializer()
+        .expect("failed to get project export initializer");
+    project_export_initializer
+        .expression()
+        .expect("failed to parse project export expression")
+}

--- a/crates/brioche-core/tests/project_edit.rs
+++ b/crates/brioche-core/tests/project_edit.rs
@@ -1,0 +1,175 @@
+use brioche_core::project::edit::edit_project;
+use pretty_assertions::assert_eq;
+
+#[tokio::test]
+async fn test_project_edit_empty() -> anyhow::Result<()> {
+    let (brioche, context) = brioche_test_support::brioche_test().await;
+
+    let foo_dir = context.mkdir("foo").await;
+    let foo_module = indoc::indoc! {r#"
+        export const project = {
+          name: "foo",
+          version: "0.1.0",
+        };
+    "#};
+    let foo_module_path = context.write_file("foo/project.bri", foo_module).await;
+
+    let (_, foo_hash_initial) = brioche_test_support::load_project(&brioche, &foo_dir).await?;
+
+    let did_change = edit_project(
+        &brioche.vfs,
+        &foo_dir,
+        brioche_core::project::edit::ProjectChanges::default(),
+    )
+    .await?;
+
+    let (_, foo_hash_final) = brioche_test_support::load_project(&brioche, &foo_dir).await?;
+
+    assert!(!did_change);
+    assert_eq!(
+        tokio::fs::read_to_string(&foo_module_path).await?,
+        foo_module
+    );
+    assert_eq!(foo_hash_initial, foo_hash_final);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_project_edit_identical() -> anyhow::Result<()> {
+    let (brioche, context) = brioche_test_support::brioche_test().await;
+
+    let foo_dir = context.mkdir("foo").await;
+    let foo_module = indoc::indoc! {r#"
+        export const project = {
+          name: "foo",
+          version: "0.1.0",
+        };
+    "#};
+    let foo_module_path = context.write_file("foo/project.bri", foo_module).await;
+
+    let (_, foo_hash_initial) = brioche_test_support::load_project(&brioche, &foo_dir).await?;
+
+    let did_change = edit_project(
+        &brioche.vfs,
+        &foo_dir,
+        brioche_core::project::edit::ProjectChanges {
+            project_definition: Some(serde_json::json!({
+                "name": "foo",
+                "version": "0.1.0",
+            })),
+        },
+    )
+    .await?;
+
+    let (_, foo_hash_final) = brioche_test_support::load_project(&brioche, &foo_dir).await?;
+
+    assert!(!did_change);
+    assert_eq!(
+        tokio::fs::read_to_string(&foo_module_path).await?,
+        foo_module
+    );
+    assert_eq!(foo_hash_initial, foo_hash_final);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_project_edit_edited() -> anyhow::Result<()> {
+    let (brioche, context) = brioche_test_support::brioche_test().await;
+
+    let foo_dir = context.mkdir("foo").await;
+    let foo_module = indoc::indoc! {r#"
+        export const project = {
+          name: "foo",
+          version: "0.1.0",
+        };
+    "#};
+    let foo_module_path = context.write_file("foo/project.bri", foo_module).await;
+
+    let (_, foo_hash_initial) = brioche_test_support::load_project(&brioche, &foo_dir).await?;
+
+    let did_change = edit_project(
+        &brioche.vfs,
+        &foo_dir,
+        brioche_core::project::edit::ProjectChanges {
+            project_definition: Some(serde_json::json!({
+                "name": "foo",
+                "version": "0.2.0",
+            })),
+        },
+    )
+    .await?;
+
+    let (_, foo_hash_final) = brioche_test_support::load_project(&brioche, &foo_dir).await?;
+
+    let foo_module_updated = indoc::indoc! {r#"
+        export const project = {
+          name: "foo",
+          version: "0.2.0",
+        };
+    "#};
+    assert!(did_change);
+    assert_eq!(
+        tokio::fs::read_to_string(&foo_module_path).await?,
+        foo_module_updated
+    );
+    assert_ne!(foo_hash_initial, foo_hash_final);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_project_edit_preserves_order_and_extra_values() -> anyhow::Result<()> {
+    let (brioche, context) = brioche_test_support::brioche_test().await;
+
+    let foo_dir = context.mkdir("foo").await;
+    let foo_module = indoc::indoc! {r#"
+        export const project = {
+          name: "foo",
+          version: "0.1.0",
+        };
+    "#};
+    let foo_module_path = context.write_file("foo/project.bri", foo_module).await;
+
+    let (_, foo_hash_initial) = brioche_test_support::load_project(&brioche, &foo_dir).await?;
+
+    let did_change = edit_project(
+        &brioche.vfs,
+        &foo_dir,
+        brioche_core::project::edit::ProjectChanges {
+            project_definition: Some(serde_json::json!({
+                "version": "0.2.0",
+                "name": "foo",
+                "extra": {
+                    "a": [1, 2],
+                    "c": null,
+                    "b": {},
+                },
+            })),
+        },
+    )
+    .await?;
+
+    let (_, foo_hash_final) = brioche_test_support::load_project(&brioche, &foo_dir).await?;
+
+    let foo_module_updated = indoc::indoc! {r#"
+        export const project = {
+          version: "0.2.0",
+          name: "foo",
+          extra: {
+            a: [1, 2],
+            c: null,
+            b: {},
+          },
+        };
+    "#};
+    assert!(did_change);
+    assert_eq!(
+        tokio::fs::read_to_string(&foo_module_path).await?,
+        foo_module_updated
+    );
+    assert_ne!(foo_hash_initial, foo_hash_final);
+
+    Ok(())
+}

--- a/crates/brioche/Cargo.toml
+++ b/crates/brioche/Cargo.toml
@@ -12,6 +12,7 @@ self-update = []
 [dependencies]
 anyhow = { version = "1.0.98", features = ["backtrace"] }
 brioche-core = { path = "../brioche-core" }
+bstr = "1.12.0"
 cfg-if = "1.0.0"
 clap = { version = "4.5.37", features = ["derive"] }
 csv = "1.3.1"

--- a/crates/brioche/src/live_update.rs
+++ b/crates/brioche/src/live_update.rs
@@ -1,0 +1,207 @@
+use anyhow::Context as _;
+use brioche_core::{project::ProjectLocking, utils::DisplayDuration};
+use clap::Parser;
+use tracing::Instrument as _;
+
+#[derive(Debug, Parser)]
+pub struct LiveUpdateArgs {
+    #[command(flatten)]
+    project: super::ProjectArgs,
+
+    /// Check the project before building
+    #[arg(long)]
+    check: bool,
+
+    /// Validate that the lockfile is up-to-date before applying updates
+    #[arg(long)]
+    locked: bool,
+
+    /// Keep temporary build files. Useful for debugging build failures
+    #[arg(long)]
+    keep_temps: bool,
+
+    /// The output display format.
+    #[arg(long, value_enum, default_value_t)]
+    display: super::DisplayMode,
+}
+
+#[expect(clippy::print_stderr)]
+pub async fn live_update(
+    js_platform: brioche_core::script::JsPlatform,
+    args: LiveUpdateArgs,
+) -> anyhow::Result<()> {
+    anyhow::ensure!(
+        args.project.registry.is_none(),
+        "cannot edit a registry project"
+    );
+
+    let (reporter, mut guard) = brioche_core::reporter::console::start_console_reporter(
+        args.display.to_console_reporter_kind(),
+    )?;
+
+    let brioche = brioche_core::BriocheBuilder::new(reporter.clone())
+        .keep_temps(args.keep_temps)
+        .build()
+        .await?;
+    crate::start_shutdown_handler(brioche.clone());
+
+    let projects = brioche_core::project::Projects::default();
+
+    let locking = if args.locked {
+        ProjectLocking::Locked
+    } else {
+        ProjectLocking::Unlocked
+    };
+
+    let project_hash = super::load_project(&brioche, &projects, &args.project, locking).await?;
+
+    // If the `--locked` flag is used, validate that all lockfiles are
+    // up-to-date. Otherwise, write any out-of-date lockfiles
+    if args.locked {
+        projects.validate_no_dirty_lockfiles()?;
+    } else {
+        let num_lockfiles_updated = projects.commit_dirty_lockfiles().await?;
+        if num_lockfiles_updated > 0 {
+            tracing::info!(num_lockfiles_updated, "updated lockfiles");
+        }
+    }
+
+    let build_future = async {
+        if args.check {
+            let checked =
+                brioche_core::script::check::check(&brioche, js_platform, &projects, project_hash)
+                    .await?;
+
+            let result = checked.ensure_ok(brioche_core::script::check::DiagnosticLevel::Error);
+
+            match result {
+                Ok(()) => reporter.emit(superconsole::Lines::from_multiline_string(
+                    "No errors found",
+                    superconsole::style::ContentStyle {
+                        foreground_color: Some(superconsole::style::Color::Green),
+                        ..superconsole::style::ContentStyle::default()
+                    },
+                )),
+                Err(diagnostics) => {
+                    guard.shutdown_console().await;
+
+                    diagnostics.write(&brioche.vfs, &mut std::io::stdout())?;
+                    anyhow::bail!("checks failed");
+                }
+            }
+        }
+
+        let recipe = brioche_core::script::evaluate::evaluate(
+            &brioche,
+            js_platform,
+            &projects,
+            project_hash,
+            "autoUpdate",
+        )
+        .await?;
+
+        let artifact = brioche_core::bake::bake(
+            &brioche,
+            recipe,
+            &brioche_core::bake::BakeScope::Project {
+                project_hash,
+                export: "autoUpdate".to_string(),
+            },
+        )
+        .instrument(tracing::info_span!("bake"))
+        .await?;
+
+        guard.shutdown_console().await;
+
+        let elapsed = DisplayDuration(reporter.elapsed());
+        let num_jobs = reporter.num_jobs();
+        let jobs_message = match num_jobs {
+            0 => "(no new jobs)".to_string(),
+            1 => "1 job".to_string(),
+            n => format!("{n} jobs"),
+        };
+        eprintln!("Build finished, completed {jobs_message} in {elapsed}");
+
+        // Validate that the artifact is a directory that contains the
+        // command to run before returning
+        let command_artifact = match &artifact.value {
+            brioche_core::recipe::Artifact::File(_) => {
+                anyhow::bail!("artifact returned a file, expected a directory");
+            }
+            brioche_core::recipe::Artifact::Symlink { .. } => {
+                anyhow::bail!("artifact returned a symlink, expected a directory");
+            }
+            brioche_core::recipe::Artifact::Directory(dir) => dir
+                .get(&brioche, b"brioche-run")
+                .await
+                .with_context(|| "failed to retrieve \"brioche-run\" from returned artifact")?,
+        };
+        anyhow::ensure!(
+            command_artifact.is_some(),
+            "\"brioche-run\" not found in returned artifact",
+        );
+
+        let output = brioche_core::output::create_local_output(&brioche, &artifact.value).await?;
+
+        brioche.wait_for_tasks().await;
+
+        Ok(output)
+    };
+
+    let output = build_future
+        .instrument(tracing::info_span!("run_build"))
+        .await?;
+
+    let command_path = output.path.join("brioche-run");
+
+    eprintln!("Executing brioche-run");
+
+    let mut command = tokio::process::Command::new(command_path);
+
+    if let Some(resource_dir) = output.resource_dir {
+        command.env("BRIOCHE_RESOURCE_DIR", resource_dir);
+    }
+
+    command.stderr(std::process::Stdio::inherit());
+
+    let output = command.output().await.context("failed to run process")?;
+
+    if !output.status.success() {
+        anyhow::bail!("process failed: {}", output.status);
+    }
+
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout).with_context(|| {
+        format!(
+            "failed to parse JSON response: {:?}",
+            bstr::BStr::new(&output.stdout)
+        )
+    })?;
+    let project_paths = projects.local_paths(project_hash)?;
+
+    anyhow::ensure!(project_paths.len() == 1, "could not determine project path");
+    let project_path = project_paths.iter().next().unwrap();
+
+    let did_update = brioche_core::project::edit::edit_project(
+        &brioche.vfs,
+        project_path,
+        brioche_core::project::edit::ProjectChanges {
+            project_definition: Some(value),
+        },
+    )
+    .await?;
+
+    if did_update {
+        // Reload the project from scratch
+        let projects = brioche_core::project::Projects::default();
+        super::load_project(&brioche, &projects, &args.project, ProjectLocking::Unlocked).await?;
+
+        // Update lockfiles
+        projects.commit_dirty_lockfiles().await?;
+
+        eprintln!("Updated project");
+    } else {
+        eprintln!("Project is already up-to-date");
+    }
+
+    Ok(())
+}

--- a/crates/brioche/src/main.rs
+++ b/crates/brioche/src/main.rs
@@ -11,6 +11,7 @@ mod check;
 mod format;
 mod install;
 mod jobs;
+mod live_update;
 mod lsp;
 mod migrate_registry_to_cache;
 mod publish;
@@ -43,6 +44,10 @@ enum Args {
 
     /// Publish a project to a registry
     Publish(publish::PublishArgs),
+
+    /// Update a Brioche project based on the current version of
+    /// the upstream project
+    LiveUpdate(live_update::LiveUpdateArgs),
 
     /// Start the Language Server Protocol server
     Lsp(lsp::LspArgs),
@@ -129,6 +134,16 @@ fn main() -> anyhow::Result<ExitCode> {
             let exit_code = rt.block_on(publish::publish(js_platform, args))?;
 
             Ok(exit_code)
+        }
+        Args::LiveUpdate(args) => {
+            let js_platform = brioche_core::script::initialize_js_platform();
+            let rt = tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()?;
+
+            rt.block_on(live_update::live_update(js_platform, args))?;
+
+            Ok(ExitCode::SUCCESS)
         }
         Args::Lsp(args) => {
             let js_platform = brioche_core::script::initialize_js_platform();


### PR DESCRIPTION
Closes #165 

This PR implements the new command `brioche live-update`. It either updates the current project or takes a project path to update (`-p`), as well as a fairly standard assortment of flags like `--check`, `--locked`, etc.

When called, it builds and runs the `autoUpdate` export (as if running `brioche run -e autoUpdate`). Then, it captures the process's stdout and parses it as JSON. This value is treated as the new project export (`export const project = {...}`), so it updates the file `project.bri`, reformats it, then reloads the project and updates the lockfile.

So, this lets the `autoUpdate` function make changes to `project.bri` based on arbitrary external sources. Here's an example [from the `ripgrep` package](https://github.com/brioche-dev/brioche-packages/blob/642eca1f635db35c63e7496d34486926e41a8c29/packages/ripgrep/project.bri#L46-L64):

```typescript
export async function autoUpdate() {
  const src = std.file(std.indoc`
    let version = http get https://api.github.com/repos/BurntSushi/ripgrep/releases/latest
      | get tag_name
      | str replace --regex '^v' ''

    $env.project
      | from json
      | update version $version
      | to json
  `);

  return std.withRunnable(std.directory(), {
    command: "nu",
    args: [src],
    env: { project: JSON.stringify(project) },
    dependencies: [nushell()],
  });
}
```

Implementation-wise, there are a few things that I think are not ideal:

- If the project doesn't contain an `autoUpdate` function, then this command will fail. I want to change this in the future (probably with a flag like `--if-defined`) but it would take some refactoring
- I don't think Biome exposes a way to create new AST nodes, so the process to update the JS using the JSON value is very silly:
  - 1. Generate a fake JS module like this: `export const project = {json};`
  - 2. Parse the script from (a) and extract the value as an AST node
  - 3. Replacethe original AST node in `project.bri` with (b)
  - 4. Convert the AST to text
  - 5. Reformat the text from (d) and overwrite `project.bri`
- Dealing with the `Vfs` and `Projects` types feels very fiddly here. I'm not convinced the code there is solid, and I've had the sense that both types will need to change
- I'd like to run the result of `autoUpdate` in a sandbox, but I don't think there's an easy way to do this today.

## Naming

I called the command `brioche live-update`, and I prefer the term "live update" over "auto update" (I feel auto-update could be confused with `brioche self-update`). It's also closer to the terminology used by Homebrew: [livecheck](https://docs.brew.sh/Brew-Livecheck)

To start with, I opted to still use the `autoUpdate` export that a lot of packages in `brioche-packages` already use. I wanted to get this change in first to validate it, but as a quick follow-up, I'd like to rename the exports to `liveUpdate` then update the Brioche side