### PR TITLE
Update `live-update` subcommand to use `liveUpdate` export

### DIFF
--- a/crates/brioche/src/live_update.rs
+++ b/crates/brioche/src/live_update.rs
@@ -96,7 +96,7 @@ pub async fn live_update(
             js_platform,
             &projects,
             project_hash,
-            "autoUpdate",
+            "liveUpdate",
         )
         .await?;
 
@@ -105,7 +105,7 @@ pub async fn live_update(
             recipe,
             &brioche_core::bake::BakeScope::Project {
                 project_hash,
-                export: "autoUpdate".to_string(),
+                export: "liveUpdate".to_string(),
             },
         )
         .instrument(tracing::info_span!("bake"))


### PR DESCRIPTION
- Follow-up to #234
- Companion PR to https://github.com/brioche-dev/brioche-packages/pull/385

This PR updates the `brioche live-update` subcommand introduced in #234 to use the export named `liveUpdate` instead of `autoUpdate`. Now that https://github.com/brioche-dev/brioche-packages/pull/385 is ready to merge, we should get this change in on the Brioche side before merging the change on the Brioche Packages side.