### PR TITLE
Speed up debug compilation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,3 +63,19 @@ used_underscore_items = "warn"
 
 [profile.dev]
 debug = "limited"
+
+# Optimize some dependencies in dev mode to speed up tests
+[profile.dev.package.swc_ecma_ast]
+opt-level = 2
+[profile.dev.package.swc_ecma_visit]
+opt-level = 2
+[profile.dev.package.swc_ecma_transforms_base]
+opt-level = 2
+[profile.dev.package.swc_ecma_lexer]
+opt-level = 2
+[profile.dev.package.swc_ecma_parser]
+opt-level = 2
+[profile.dev.package.swc_ecma_codegen]
+opt-level = 2
+[profile.dev.package.swc_common]
+opt-level = 2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,23 +62,4 @@ used_underscore_binding = "warn"
 used_underscore_items = "warn"
 
 [profile.dev]
-# Enable optimizations for debug builds because the JS runs slow without it.
-# Also, we end up overflowing the stack without optimizations when parsing JS
-opt-level = 2
-
-[profile.profiling]
-inherits = "release"
-debug = true
-
-[profile.release-tiny]
-inherits = "release"
-opt-level = "z"
-lto = true
-codegen-units = 1
-strip = "symbols"
-panic = "abort"
-
-# Like `release-tiny`, but with debug info needed for `cargo bloat`
-[profile.release-tiny-bloat]
-inherits = "release-tiny"
-strip = "debuginfo"
+debug = "limited"


### PR DESCRIPTION
This PR speeds up builds for the `dev` profile by a decent amount. I made a small logging change within `brioche-core`, and the time it took to rebuild just the change files when running a test (`cargo test --test project_edit`) went from around 18 seconds to around 7 seconds on my machine.

I've been frustrated for a while with how long it was taking tests to run, even for very minor changes. Before I went down this rabbit hole, it was taking around 2 minutes or so to re-run tests, which just killed my momentum for larger features! Like I mentioned, the changes from this PR cut the time down from around 18 seconds down to 7-- I also made some changes to my local dev environment that accounted for the rest of the speedup. I'll outline the changes in this PR, the change I made locally, and one idea that's currently blocked (not in chronological order).

Before I dive in, I want to call out this article from fasterthanlime, which was the number one most valuable resource for getting these changes in: https://fasterthanli.me/articles/why-is-my-rust-build-so-slow

## PR change: switch to lower opt-level

There was a comment in the code about using `opt-level = 2` for debug builds to make scripts run faster. After some testing, scripts don't run _that_ much faster when going from opt-level 0 to opt-level 2. This also makes sense, since V8 is doing the heavy lifting and `deno_core` links against a pre-built V8 library by default, so opt-level doesn't really have much of an impact overall.

## PR change: optimize some dependencies

On the other hand, the `lsp_on_save` tests were hitting a timeout that they didn't hit at higher opt-levels. I did some profiling against the dev build of the test binaries using [samply](https://github.com/mstange/samply) and found that a majority of the extra time was being spent in various `swc` crates, which `deno_ast` uses for transpiling TypeScript to JavaScript. I tweaked the `dev` profile a little more to re-enable optimizations for a handful of `swc` libraries, which I found to help drastically without spending too much extra time compiling dependencies.

## PR change: reduce debug info

This doesn't have a big impact on compile time, but it helps a decent amount on disk space usage in the `target` dir (from 30 GiB to ~20 GiB when running `cargo test`). Obviously the extra debug info can be useful, but I personally don't use gdb/lldb very often so I felt it would be better to get the disk space back instead of writing debug info I don't use on a regular basis. It might make sense to change this again in the future.

## Local change: switch from gold to lld

Surprisingly, this had the biggest impact for me locally! I underestimated how much faster lld was over gold, and I've gone as far to changing my default Rust linker system-wide by putting this in `~/.cargo/config.toml`:

```toml
[target.x86_64-unknown-linux-gnu]
rustflags = ["-C", "link-arg=-fuse-ld=lld"]
```

(I haven't tried mold yet, but I'll probably give it a shot in the future)

## Abandoned (for now): dynamic linking

I did some experimentation around dynamic linking various components to speed up link times and to decrease disk usage (see [this article](https://robert.kra.hn/posts/2022-09-09-speeding-up-incremental-rust-compilation-with-dylibs/) for context). The most promising option I found was to mark `lib.crate-type = ["dylib"]` within `brioche-test-support/Cargo.toml`, which forces each test binary to dynamically link against `brioche-core`. This _did_ help a decent amount-- namely, it shaved several GB off of the `target` dir, and did somewhat help with link times (not a ton though).

But, because of https://github.com/denoland/rusty_v8/issues/1706, we can't do this easily today without downgrading `deno_core`. Dynamically linking against `rusty_v8` (a.k.a the `v8` crate) causes linker errors, even as a transitive dependency. I investigated that issue in depth, and TL;DR this would require `rusty_v8` to patch their V8 build and adjust their build params.

Since this idea would be blocked by an upstream dependency _and_ didn't seem to lead to a big win anyway, I chose not to go any more in depth on this. But, if https://github.com/denoland/rusty_v8/issues/1706 is resolved in the future, it might be worth revisiting this idea again.