### PR TITLE
Add workaround for "file exists" bug in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,10 @@ jobs:
       - name: Install Brioche
         uses: brioche-dev/setup-brioche@v1
       - name: Check Brioche project
+        # HACK: Added a workaround for bug fixed by https://github.com/brioche-dev/brioche/pull/216
+        # TODO: Update when Brioche >0.1.5 is released
         run: |
+          brioche check || true
           brioche check
           brioche fmt --check
 
@@ -179,7 +182,11 @@ jobs:
       - name: Install Brioche
         uses: brioche-dev/setup-brioche@v1
       - name: Build Brioche
-        run: brioche build --check -o "brioche-packed-$PLATFORM"
+        # HACK: Added a workaround for bug fixed by https://github.com/brioche-dev/brioche/pull/216
+        # TODO: Update when Brioche >0.1.5 is released
+        run: |
+          brioche check || true
+          brioche build --check -o "brioche-packed-$PLATFORM"
         env:
           PLATFORM: x86_64-linux
       - name: Prepare artifact


### PR DESCRIPTION
Follow-up for #249 to fix CI build failure (i.e. [CI #638](https://github.com/brioche-dev/brioche/actions/runs/15234413454))

This was a bug that was fixed by #216, which hasn't made it into a stable release yet. The CI pipeline uses Brioche v0.1.5 currently, so I felt the best option was to just add a ~~quick-and-dirty hack~~ workaround to get CI working for now