### PR TITLE
Update `check` subcommand to check all projects in one pass

### DIFF
--- a/crates/brioche-core/src/project.rs
+++ b/crates/brioche-core/src/project.rs
@@ -224,6 +224,18 @@ impl Projects {
         Ok(module_specifiers.collect())
     }
 
+    pub fn project_module_specifiers_for_projects(
+        &self,
+        project_hashes: &HashSet<ProjectHash>,
+    ) -> anyhow::Result<HashSet<super::script::specifier::BriocheModuleSpecifier>> {
+        let projects = self
+            .inner
+            .read()
+            .map_err(|_| anyhow::anyhow!("failed to acquire 'projects' lock"))?;
+        let module_specifiers = projects.project_module_specifiers_for_projects(project_hashes)?;
+        Ok(module_specifiers)
+    }
+
     pub fn find_containing_project(&self, path: &Path) -> anyhow::Result<Option<ProjectHash>> {
         let projects = self
             .inner
@@ -557,6 +569,19 @@ impl ProjectsInner {
             path
         });
         Ok(paths)
+    }
+
+    pub fn project_module_specifiers_for_projects(
+        &self,
+        project_hashes: &HashSet<ProjectHash>,
+    ) -> anyhow::Result<HashSet<super::script::specifier::BriocheModuleSpecifier>> {
+        let mut module_specifiers = HashSet::new();
+        for project_hash in project_hashes {
+            let module_paths = self.project_module_specifiers(*project_hash)?;
+            module_specifiers.extend(module_paths);
+        }
+
+        Ok(module_specifiers)
     }
 
     pub fn project_module_specifiers(

--- a/crates/brioche-core/tests/script_check.rs
+++ b/crates/brioche-core/tests/script_check.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::{collections::HashSet, path::PathBuf};
 
 use assert_matches::assert_matches;
 use brioche_core::script::check::{CheckResult, DiagnosticLevel};
@@ -53,7 +53,7 @@ async fn test_check_basic_valid() -> anyhow::Result<()> {
         &brioche,
         brioche_core::script::initialize_js_platform(),
         &projects,
-        project_hash,
+        &HashSet::from_iter([project_hash]),
     )
     .await?;
 
@@ -92,7 +92,7 @@ async fn test_check_basic_invalid() -> anyhow::Result<()> {
         &brioche,
         brioche_core::script::initialize_js_platform(),
         &projects,
-        project_hash,
+        &HashSet::from_iter([project_hash]),
     )
     .await?;
 
@@ -156,7 +156,7 @@ async fn test_check_import_valid() -> anyhow::Result<()> {
         &brioche,
         brioche_core::script::initialize_js_platform(),
         &projects,
-        project_hash,
+        &HashSet::from_iter([project_hash]),
     )
     .await?;
 
@@ -196,7 +196,7 @@ async fn test_check_import_nonexistent() -> anyhow::Result<()> {
         &brioche,
         brioche_core::script::initialize_js_platform(),
         &projects,
-        project_hash,
+        &HashSet::from_iter([project_hash]),
     )
     .await?;
 
@@ -235,7 +235,7 @@ async fn test_check_invalid_unused_var() -> anyhow::Result<()> {
         &brioche,
         brioche_core::script::initialize_js_platform(),
         &projects,
-        project_hash,
+        &HashSet::from_iter([project_hash]),
     )
     .await?;
 
@@ -281,7 +281,7 @@ async fn test_check_invalid_missing_await() -> anyhow::Result<()> {
         &brioche,
         brioche_core::script::initialize_js_platform(),
         &projects,
-        project_hash,
+        &HashSet::from_iter([project_hash]),
     )
     .await?;
 

--- a/crates/brioche/src/build.rs
+++ b/crates/brioche/src/build.rs
@@ -1,4 +1,4 @@
-use std::{path::PathBuf, process::ExitCode};
+use std::{collections::HashSet, path::PathBuf, process::ExitCode};
 
 use anyhow::Context as _;
 use brioche_core::{fs_utils, project::ProjectLocking, utils::DisplayDuration};
@@ -87,9 +87,13 @@ pub async fn build(
         }
 
         if args.check {
-            let checked =
-                brioche_core::script::check::check(&brioche, js_platform, &projects, project_hash)
-                    .await?;
+            let checked = brioche_core::script::check::check(
+                &brioche,
+                js_platform,
+                &projects,
+                &HashSet::from_iter([project_hash]),
+            )
+            .await?;
 
             let result = checked.ensure_ok(brioche_core::script::check::DiagnosticLevel::Error);
 

--- a/crates/brioche/src/check.rs
+++ b/crates/brioche/src/check.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::path::PathBuf;
 use std::process::ExitCode;
 
@@ -159,7 +160,13 @@ async fn run_check(
             }
         }
 
-        brioche_core::script::check::check(brioche, js_platform, projects, project_hash).await
+        brioche_core::script::check::check(
+            brioche,
+            js_platform,
+            projects,
+            &HashSet::from_iter([project_hash]),
+        )
+        .await
     }
     .instrument(tracing::info_span!("check"))
     .await?

--- a/crates/brioche/src/check.rs
+++ b/crates/brioche/src/check.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::collections::HashSet;
 use std::path::PathBuf;
 use std::process::ExitCode;
@@ -53,75 +54,91 @@ pub async fn check(
     let mut error_result = Option::None;
 
     // Handle the case where no projects and no registries are specified
-    let projects_path =
+    let project_paths =
         if args.project.project.is_empty() && args.project.registry_project.is_empty() {
             vec![PathBuf::from(".")]
         } else {
             args.project.project
         };
 
-    // Loop over the projects
-    for project_path in projects_path {
-        let project_name = format!("project '{name}'", name = project_path.display());
+    let mut project_names = HashMap::new();
+    let mut projects_to_check = HashSet::new();
 
-        match projects
+    // Load each path project
+    for project_path in project_paths {
+        let project_name = format!("project '{name}'", name = project_path.display());
+        let project_hash = projects
             .load(
                 &brioche,
                 &project_path,
                 ProjectValidation::Standard,
                 locking,
             )
-            .await
-        {
-            Ok(project_hash) => {
-                let result = run_check(
+            .await;
+
+        let project_hash = match project_hash {
+            Ok(project_hash) => project_hash,
+            Err(error) => {
+                consolidate_result(
                     &reporter,
-                    &brioche,
-                    js_platform,
-                    &projects,
-                    project_hash,
-                    &project_name,
-                    &check_options,
-                )
-                .await;
-                consolidate_result(&reporter, &project_name, result, &mut error_result);
+                    Some(&project_name),
+                    Err(error),
+                    &mut error_result,
+                );
+                continue;
             }
-            Err(e) => {
-                consolidate_result(&reporter, &project_name, Err(e), &mut error_result);
-            }
-        }
+        };
+
+        project_names.entry(project_hash).or_insert(project_name);
+        projects_to_check.insert(project_hash);
     }
 
-    // Loop over the registry projects
+    // Load each registry project
     for registry_project in args.project.registry_project {
         let project_name = format!("registry project '{registry_project}'");
-
-        match projects
+        let project_hash = projects
             .load_from_registry(
                 &brioche,
                 &registry_project,
                 &brioche_core::project::Version::Any,
             )
-            .await
-        {
-            Ok(project_hash) => {
-                let result = run_check(
+            .await;
+
+        let project_hash = match project_hash {
+            Ok(project_hash) => project_hash,
+            Err(error) => {
+                consolidate_result(
                     &reporter,
-                    &brioche,
-                    js_platform,
-                    &projects,
-                    project_hash,
-                    &project_name,
-                    &check_options,
-                )
-                .await;
-                consolidate_result(&reporter, &project_name, result, &mut error_result);
+                    Some(&project_name),
+                    Err(error),
+                    &mut error_result,
+                );
+                continue;
             }
-            Err(e) => {
-                consolidate_result(&reporter, &project_name, Err(e), &mut error_result);
-            }
-        }
+        };
+
+        project_names.entry(project_hash).or_insert(project_name);
+        projects_to_check.insert(project_hash);
     }
+
+    let project_name = if project_names.len() == 1 {
+        Some(project_names.values().next().unwrap())
+    } else {
+        None
+    };
+    let project_name = project_name.as_ref().map(|name| name.as_str());
+
+    let result = run_check(
+        &reporter,
+        &brioche,
+        js_platform,
+        &projects,
+        &projects_to_check,
+        project_name,
+        &check_options,
+    )
+    .await;
+    consolidate_result(&reporter, project_name, result, &mut error_result);
 
     guard.shutdown_console().await;
     brioche.wait_for_tasks().await;
@@ -144,8 +161,8 @@ async fn run_check(
     brioche: &Brioche,
     js_platform: brioche_core::script::JsPlatform,
     projects: &Projects,
-    project_hash: ProjectHash,
-    project_name: &String,
+    project_hashes: &HashSet<ProjectHash>,
+    project_name: Option<&str>,
     options: &CheckOptions,
 ) -> Result<bool, anyhow::Error> {
     let result = async {
@@ -160,13 +177,7 @@ async fn run_check(
             }
         }
 
-        brioche_core::script::check::check(
-            brioche,
-            js_platform,
-            projects,
-            &HashSet::from_iter([project_hash]),
-        )
-        .await
+        brioche_core::script::check::check(brioche, js_platform, projects, project_hashes).await
     }
     .instrument(tracing::info_span!("check"))
     .await?
@@ -174,10 +185,17 @@ async fn run_check(
 
     match result {
         Ok(()) => {
-            reporter.emit(superconsole::Lines::from_multiline_string(
-                &format!("No errors found in {project_name} 🎉",),
-                superconsole::style::ContentStyle::default(),
-            ));
+            if let Some(project_name) = project_name {
+                reporter.emit(superconsole::Lines::from_multiline_string(
+                    &format!("No errors found in {project_name} 🎉",),
+                    superconsole::style::ContentStyle::default(),
+                ));
+            } else {
+                reporter.emit(superconsole::Lines::from_multiline_string(
+                    "No errors found in projects 🎉",
+                    superconsole::style::ContentStyle::default(),
+                ));
+            }
 
             Ok(true)
         }

--- a/crates/brioche/src/format.rs
+++ b/crates/brioche/src/format.rs
@@ -60,10 +60,10 @@ pub async fn format(args: FormatArgs) -> anyhow::Result<ExitCode> {
                     args.check,
                 )
                 .await;
-                consolidate_result(&reporter, &project_name, result, &mut error_result);
+                consolidate_result(&reporter, Some(&project_name), result, &mut error_result);
             }
             Err(e) => {
-                consolidate_result(&reporter, &project_name, Err(e), &mut error_result);
+                consolidate_result(&reporter, Some(&project_name), Err(e), &mut error_result);
             }
         }
     }

--- a/crates/brioche/src/install.rs
+++ b/crates/brioche/src/install.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::path::PathBuf;
 use std::process::ExitCode;
 
@@ -178,9 +179,13 @@ async fn run_install(
         }
 
         if options.check {
-            let checked =
-                brioche_core::script::check::check(brioche, js_platform, projects, project_hash)
-                    .await?;
+            let checked = brioche_core::script::check::check(
+                brioche,
+                js_platform,
+                projects,
+                &HashSet::from_iter([project_hash]),
+            )
+            .await?;
 
             let result = checked.ensure_ok(brioche_core::script::check::DiagnosticLevel::Error);
 

--- a/crates/brioche/src/install.rs
+++ b/crates/brioche/src/install.rs
@@ -97,10 +97,10 @@ pub async fn install(
                 )
                 .await;
 
-                consolidate_result(&reporter, &project_name, result, &mut error_result);
+                consolidate_result(&reporter, Some(&project_name), result, &mut error_result);
             }
             Err(e) => {
-                consolidate_result(&reporter, &project_name, Err(e), &mut error_result);
+                consolidate_result(&reporter, Some(&project_name), Err(e), &mut error_result);
             }
         }
     }
@@ -130,10 +130,10 @@ pub async fn install(
                 )
                 .await;
 
-                consolidate_result(&reporter, &project_name, result, &mut error_result);
+                consolidate_result(&reporter, Some(&project_name), result, &mut error_result);
             }
             Err(e) => {
-                consolidate_result(&reporter, &project_name, Err(e), &mut error_result);
+                consolidate_result(&reporter, Some(&project_name), Err(e), &mut error_result);
             }
         }
     }

--- a/crates/brioche/src/live_update.rs
+++ b/crates/brioche/src/live_update.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use anyhow::Context as _;
 use brioche_core::{project::ProjectLocking, utils::DisplayDuration};
 use bstr::ByteSlice as _;
@@ -69,9 +71,13 @@ pub async fn live_update(
 
     let build_future = async {
         if args.check {
-            let checked =
-                brioche_core::script::check::check(&brioche, js_platform, &projects, project_hash)
-                    .await?;
+            let checked = brioche_core::script::check::check(
+                &brioche,
+                js_platform,
+                &projects,
+                &HashSet::from_iter([project_hash]),
+            )
+            .await?;
 
             let result = checked.ensure_ok(brioche_core::script::check::DiagnosticLevel::Error);
 

--- a/crates/brioche/src/main.rs
+++ b/crates/brioche/src/main.rs
@@ -333,19 +333,29 @@ async fn load_project(
 
 fn consolidate_result(
     reporter: &brioche_core::reporter::Reporter,
-    project_name: &String,
+    project_name: Option<&str>,
     result: Result<bool, anyhow::Error>,
     error_result: &mut Option<()>,
 ) {
     match result {
         Err(err) => {
-            reporter.emit(superconsole::Lines::from_multiline_string(
-                &format!("Error occurred with {project_name}: {err}"),
-                superconsole::style::ContentStyle {
-                    foreground_color: Some(superconsole::style::Color::Red),
-                    ..superconsole::style::ContentStyle::default()
-                },
-            ));
+            if let Some(project_name) = project_name {
+                reporter.emit(superconsole::Lines::from_multiline_string(
+                    &format!("Error occurred with {project_name}: {err}"),
+                    superconsole::style::ContentStyle {
+                        foreground_color: Some(superconsole::style::Color::Red),
+                        ..superconsole::style::ContentStyle::default()
+                    },
+                ));
+            } else {
+                reporter.emit(superconsole::Lines::from_multiline_string(
+                    &format!("Error occurred in project: {err}"),
+                    superconsole::style::ContentStyle {
+                        foreground_color: Some(superconsole::style::Color::Red),
+                        ..superconsole::style::ContentStyle::default()
+                    },
+                ));
+            }
 
             *error_result = Some(());
         }

--- a/crates/brioche/src/publish.rs
+++ b/crates/brioche/src/publish.rs
@@ -1,4 +1,4 @@
-use std::{path::PathBuf, process::ExitCode};
+use std::{collections::HashSet, path::PathBuf, process::ExitCode};
 
 use brioche_core::{
     Brioche,
@@ -98,9 +98,14 @@ async fn run_publish(
 
     projects.validate_no_dirty_lockfiles()?;
 
-    let result = brioche_core::script::check::check(brioche, js_platform, projects, project_hash)
-        .await?
-        .ensure_ok(brioche_core::script::check::DiagnosticLevel::Warning);
+    let result = brioche_core::script::check::check(
+        brioche,
+        js_platform,
+        projects,
+        &HashSet::from_iter([project_hash]),
+    )
+    .await?
+    .ensure_ok(brioche_core::script::check::DiagnosticLevel::Warning);
 
     match result {
         Ok(()) => {

--- a/crates/brioche/src/publish.rs
+++ b/crates/brioche/src/publish.rs
@@ -60,10 +60,10 @@ pub async fn publish(
                     &project_name,
                 )
                 .await;
-                consolidate_result(&reporter, &project_name, result, &mut error_result);
+                consolidate_result(&reporter, Some(&project_name), result, &mut error_result);
             }
             Err(e) => {
-                consolidate_result(&reporter, &project_name, Err(e), &mut error_result);
+                consolidate_result(&reporter, Some(&project_name), Err(e), &mut error_result);
             }
         }
     }

--- a/crates/brioche/src/run.rs
+++ b/crates/brioche/src/run.rs
@@ -1,4 +1,4 @@
-use std::process::ExitCode;
+use std::{collections::HashSet, process::ExitCode};
 
 use anyhow::Context as _;
 use brioche_core::{project::ProjectLocking, utils::DisplayDuration};
@@ -85,9 +85,13 @@ pub async fn run(
         }
 
         if args.check {
-            let checked =
-                brioche_core::script::check::check(&brioche, js_platform, &projects, project_hash)
-                    .await?;
+            let checked = brioche_core::script::check::check(
+                &brioche,
+                js_platform,
+                &projects,
+                &HashSet::from_iter([project_hash]),
+            )
+            .await?;
 
             let result = checked.ensure_ok(brioche_core::script::check::DiagnosticLevel::Error);
 


### PR DESCRIPTION
This PR updates how the `brioche check` subcommand handles multiple projects. Rather than building a new `Projects` instance, loading each project, then checking each one in isolation, it instead checks all the modules from all the projects in one pass.

This should save a ton of time when checking the `brioche-packages` repo. Since every* package depends on `std`, the modules in `std` effectively get typechecked and linted every time. Early on, this wasn't a big problem-- but with ~150 packages, the CI time spent just checking is definitely noticeable!

Testing locally, here's a bash one-liner to check every package:

```sh
echo ./packages/* | xargs printf -- '-p %s\n' | xargs brioche check
```

- Before this change, this took **6m 1s**
- After this change, this took **7.5s**