### PR TITLE
Add JS op to get current platform

### DIFF
--- a/crates/brioche-core/src/script/js.rs
+++ b/crates/brioche-core/src/script/js.rs
@@ -7,6 +7,7 @@ deno_core::extension!(
     brioche_js,
     ops = [
         op_brioche_version,
+        op_brioche_current_platform,
         op_brioche_console,
         op_brioche_stack_frames_from_exception,
         op_brioche_utf8_encode,
@@ -30,6 +31,12 @@ pub enum ConsoleLevel {
 #[string]
 fn op_brioche_version() -> String {
     crate::VERSION.to_string()
+}
+
+#[deno_core::op2]
+#[string]
+fn op_brioche_current_platform() -> String {
+    crate::platform::current_platform().to_string()
 }
 
 #[deno_core::op2]


### PR DESCRIPTION
This PR adds a new op to get the current host platform, accessible from the runtime as `Deno.core.ops.op_brioche_current_platform`.

This is a bit of a departure from the [May 2025 Project Update](https://brioche.dev/blog/project-update-2025-05/). I still think "proper" cross-compilation support will be a feature for Brioche >=v0.2.0, but adding this op would let us get aarch64 support out really quickly, and would enable us to start getting some aarch64 packages set up ASAP. This would both let folks start using aarch64 sooner rather than later, and would help uncover any aarch64-specific build issues, which should overall make the changes for Brioche v0.2.0 less risky.