### PR TITLE
Update to Rust v1.88

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace.package]
 edition = "2024"
-rust-version = "1.87" # To align with the rust-toolchain.toml
+rust-version = "1.88" # To align with the rust-toolchain.toml
 
 [workspace]
 members = [

--- a/brioche.lock
+++ b/brioche.lock
@@ -1,12 +1,12 @@
 {
   "dependencies": {
-    "ca_certificates": "948f481d85b46452696b4787edbb2f076ae2274239b4e1cf109a582b33dc61ea",
-    "curl": "a39cc98eb5b152d6211a96d8eef2d197f6f89ab878f3238ce1eb07250ca42ca3",
-    "git": "d63a69a593a7012b7c1bd34847ca6414f1d7872f3e08e8b374c821e728af5020",
-    "nodejs": "8ea8d2dfb9601e0b6dc62aa9db3c2afadc31dd0802feb9bfdbb675558d8ff86c",
-    "openssl": "6077e914f17db2f1a6292dfc0f37715adb34ce11f46ab1ceda38622b303c1a0b",
-    "rust": "d8edbc1ab8011944c9f3ff47a0e351c8a0b4df903a27633e5421176fcc0b6512",
-    "std": "c1c3718fc8098d7083f01d193876757803a35cf09dfe73e3c03e4103c1b8862c"
+    "ca_certificates": "f17d6ab733ede66647958856e6b0267bbcec03a466eddd845b7da66f4d5d3b51",
+    "curl": "f4c8ab8f0975708c205b4b16beff45a1036ed50dc6355649f0b28c84c795f187",
+    "git": "f951eecbbe96c1eb70f216d4ee4dd5a281586e4fc0e3ec5dcfb5748b285d9ad4",
+    "nodejs": "152eb0cfe5b74ee0ac45eeb630480f866316781542901e497febe222849610a6",
+    "openssl": "9ee9d4164f1da5bf90d03d979397ddbbb59d058d7176157e1d7aed1e46bc0d3e",
+    "rust": "c2ac9fb4e37fd0e79d910a2b3b830ee5e2deee527211cbe264e7002600b9bff4",
+    "std": "53610fd1f61ed4d70e167eaf9033f25fa9c3d5ff77caeefe85bd64f6d98a1628"
   },
   "git_refs": {
     "https://github.com/launchbadge/sqlx.git": {

--- a/brioche.lock
+++ b/brioche.lock
@@ -2,15 +2,9 @@
   "dependencies": {
     "ca_certificates": "f17d6ab733ede66647958856e6b0267bbcec03a466eddd845b7da66f4d5d3b51",
     "curl": "f4c8ab8f0975708c205b4b16beff45a1036ed50dc6355649f0b28c84c795f187",
-    "git": "f951eecbbe96c1eb70f216d4ee4dd5a281586e4fc0e3ec5dcfb5748b285d9ad4",
     "nodejs": "152eb0cfe5b74ee0ac45eeb630480f866316781542901e497febe222849610a6",
-    "openssl": "9ee9d4164f1da5bf90d03d979397ddbbb59d058d7176157e1d7aed1e46bc0d3e",
     "rust": "c2ac9fb4e37fd0e79d910a2b3b830ee5e2deee527211cbe264e7002600b9bff4",
+    "sqlx_cli": "6571f73a190520f71f6df966f5849336f6e9bc288890ebe8e74af95a9e25c902",
     "std": "53610fd1f61ed4d70e167eaf9033f25fa9c3d5ff77caeefe85bd64f6d98a1628"
-  },
-  "git_refs": {
-    "https://github.com/launchbadge/sqlx.git": {
-      "v0.7.4": "635dba5b2682033101a1271e9fb4bf2516c0b840"
-    }
   }
 }

--- a/crates/brioche-core/src/download.rs
+++ b/crates/brioche-core/src/download.rs
@@ -41,7 +41,7 @@ pub async fn download(
         }
     });
 
-    let mut download_stream = response
+    let download_stream = response
         .bytes_stream()
         .map_err(futures::io::Error::other)
         .into_async_read()

--- a/project.bri
+++ b/project.bri
@@ -33,8 +33,7 @@ export default function (): std.Recipe<std.Directory> {
     // Makefiles for miscellaneous tasks
     "**/Makefile",
   );
-  source = validateRuntime(source);
-  source = validateSqlxMetadata(source);
+  source = std.merge(validateRuntime(source), validateSqlxMetadata(source));
 
   return cargoBuild({
     source,

--- a/project.bri
+++ b/project.bri
@@ -3,8 +3,7 @@ import rust, { cargoBuild, vendorCrate } from "rust";
 import curl from "curl";
 import caCertificates from "ca_certificates";
 import nodejs, { npmInstall } from "nodejs";
-import { gitCheckout } from "git";
-import openssl from "openssl";
+import sqlxCli from "sqlx_cli";
 
 /**
  * Returns a recipe to build Brioche itself. This results in a packed build,
@@ -131,22 +130,6 @@ export function runtime(): std.Recipe<std.Directory> {
     .dependencies(nodejs())
     .workDir(npmPackage)
     .toDirectory();
-}
-
-export function sqlxCli() {
-  const source = gitCheckout(
-    Brioche.gitRef({
-      repository: "https://github.com/launchbadge/sqlx.git",
-      ref: "v0.7.4",
-    }),
-  );
-
-  return cargoBuild({
-    source,
-    path: "sqlx-cli",
-    dependencies: [openssl()],
-    runnable: "bin/sqlx",
-  });
 }
 
 interface ValidateOptions {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.87"
+channel = "1.88"
 profile = "default"
 targets = ["x86_64-unknown-linux-musl"]


### PR DESCRIPTION
This PR updates the Rust version in `rust-toolchain.toml`, `Cargo.toml`, and `project.bri` to use Rust v1.88.0.

There was a new warning that appeared that I fixed. I also made a few miscellaneous tweaks to the Brioche-in-Brioche build:

- Replace custom `sqlx-cli` build with upstream `sqlx_cli` package (https://github.com/brioche-dev/brioche-packages/pull/719)
- Update "validation" steps to run in parallel