### PR TITLE
Update Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,12 @@ updates:
       day: "friday"
       time: "17:00"
       timezone: "America/Los_Angeles"
+    # Update all the dependencies:
+    # - direct: explicitly defined dependencies in the Cargo.toml file
+    # - indirect: transient dependencies in the Cargo.lock file
+    allow:
+      - dependency-type: direct
+      - dependency-type: indirect
     groups:
       cargo:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,9 +21,11 @@ updates:
     allow:
       - dependency-type: direct
       - dependency-type: indirect
+    # As for now, disable the update of biome dependencies
+    # See: https://github.com/biomejs/biome/issues/5151
+    ignore:
+      - dependency-name: "biome_*"
     groups:
       cargo:
         patterns:
           - "*"
-    ignore:
-      - dependency-name: "biome_*"


### PR DESCRIPTION
Update the configuration of dependabot to ensure all the dependencies defined in Cargo.lock are weekly updated. See https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#dependency-type-allow

It can reduce the risk of having a dependency with a CVE inside, and it's ensure we are always using the most "fixed" version (a version with fewer bugs) and running with the latest performance gains.