### PR TITLE
Sign and restructure built binaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,10 +110,10 @@ jobs:
     strategy:
       matrix:
         platform:
-          - name: x86_64-linux
+          - name: x86_64-linux-gnu
             runs_on: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
-          - name: aarch64-linux
+          - name: aarch64-linux-gnu
             runs_on: ubuntu-22.04-arm
             target: aarch64-unknown-linux-gnu
           - name: x86_64-macos
@@ -126,41 +126,34 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      - name: Install dependencies
-        if: matrix.platform.install_deps
-        run: ${{ matrix.platform.install_deps }}
       - name: Install Rust targets
         run: rustup target add "$TARGET"
         env:
           TARGET: ${{ matrix.platform.target }}
       - name: Build Brioche
         run: |
-          extra_args=()
-          if [ -n "$FEATURES" ]; then
-            extra_args+=(--features "$FEATURES")
-          fi
-          cargo build \
-            --all \
-            --bin brioche \
-            --release \
-            --target="$TARGET" \
-            "${extra_args[@]}"
+          cargo build --bin brioche --release --target="$TARGET"
         env:
           TARGET: ${{ matrix.platform.target }}
-          FEATURES: ${{ matrix.platform.features }}
       - name: Prepare artifact
+        id: prepare-artifact
         run: |
-          mkdir -p "artifacts/brioche/$PLATFORM/"
-          cp \
-            "target/$TARGET/release/brioche" \
-            "artifacts/brioche/$PLATFORM/"
+          artifact_name="brioche-${GITHUB_SHA}-${PLATFORM}"
+          artifact_path="artifacts/${artifact_name}.tar.gz"
+
+          mkdir -p "artifacts/$artifact_name/bin"
+          touch "artifacts/$artifact_name/.brioche-install"
+          cp "target/$TARGET/release/brioche" "artifacts/$artifact_name/bin"
+
+          tar -czvf "$artifact_path" -C artifacts "$artifact_name"
+
+          echo "artifact-name=$artifact_name" >> "$GITHUB_OUTPUT"
+          echo "artifact-path=$artifact_path" >> "$GITHUB_OUTPUT"
+
+          ls -lhR artifacts/
 
           if command -v sha256sum &> /dev/null; then
             find artifacts/ -type f | xargs sha256sum
-          fi
-
-          if command -v tree &> /dev/null; then
-            tree --du -h artifacts/brioche
           fi
         env:
           PLATFORM: ${{ matrix.platform.name }}
@@ -168,9 +161,10 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: brioche-${{ matrix.platform.name }}
+          name: ${{ steps.prepare-artifact.outputs.artifact-name }}
+          path: ${{ steps.prepare-artifact.outputs.artifact-path }}
+          compression-level: 0
           if-no-files-found: error
-          path: artifacts/brioche
 
   build-packed:
     name: Build packed artifacts
@@ -182,33 +176,36 @@ jobs:
       - name: Install Brioche
         uses: brioche-dev/setup-brioche@v1
       - name: Build Brioche
+        id: build
         # HACK: Added a workaround for bug fixed by https://github.com/brioche-dev/brioche/pull/216
         # TODO: Update when Brioche >0.1.5 is released
         run: |
+          artifact_name="brioche-${GITHUB_SHA}-${PLATFORM}"
+          artifact_path="artifacts/${artifact_name}.tar.gz"
+
+          mkdir -p "artifacts"
           brioche check || true
-          brioche build --check -o "brioche-packed-$PLATFORM"
-        env:
-          PLATFORM: x86_64-linux
-      - name: Prepare artifact
-        run: |
-          mkdir -p "artifacts/brioche-packed/$PLATFORM"
-          tar -czf "artifacts/brioche-packed/$PLATFORM/brioche-packed-$PLATFORM.tar.gz" "brioche-packed-$PLATFORM"
+          brioche build --check -o "artifacts/$artifact_name"
+
+          tar -czvf "$artifact_path" -C artifacts "$artifact_name"
+
+          echo "artifact-name=$artifact_name" >> "$GITHUB_OUTPUT"
+          echo "artifact-path=$artifact_path" >> "$GITHUB_OUTPUT"
+
+          ls -lhR artifacts/
 
           if command -v sha256sum &> /dev/null; then
             find artifacts/ -type f | xargs sha256sum
-          fi
-
-          if command -v tree &> /dev/null; then
-            tree --du -h artifacts/brioche-packed
           fi
         env:
           PLATFORM: x86_64-linux
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: brioche-packed-x86_64-linux
+          name: ${{ steps.build.outputs.artifact-name }}
+          path: ${{ steps.build.outputs.artifact-path }}
+          compression-level: 0
           if-no-files-found: error
-          path: artifacts/brioche-packed
 
   push:
     name: Push artifacts
@@ -216,49 +213,20 @@ jobs:
     needs: [check, all-tests-passed, build, build-packed]
     runs-on: ubuntu-24.04
     steps:
-      - name: Install AWS CLI
-        uses: unfor19/install-aws-cli-action@v1
-      - name: Download artifacts (x86_64-linux)
+      - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
-          name: brioche-x86_64-linux
-          path: artifacts/brioche
-      - name: Download artifacts (aarch64-linux)
-        uses: actions/download-artifact@v4
-        with:
-          name: brioche-aarch64-linux
-          path: artifacts/brioche
-      - name: Download artifacts (x86_64-macos)
-        uses: actions/download-artifact@v4
-        with:
-          name: brioche-x86_64-macos
-          path: artifacts/brioche
-      - name: Download artifacts (aarch64-macos)
-        uses: actions/download-artifact@v4
-        with:
-          name: brioche-aarch64-macos
-          path: artifacts/brioche
-      - name: Download artifacts (x86_64-linux packed)
-        uses: actions/download-artifact@v4
-        with:
-          name: brioche-packed-x86_64-linux
-          path: artifacts/brioche-packed
+          path: artifacts
+          merge-multiple: true
       # Upload the Brioche build for the current branch
-      - name: Prepare upload
-        run: |
-          mkdir -p artifacts/uploads/branch/brioche-packed
-          cp -r artifacts/brioche/* artifacts/uploads/branch/
-          cp -r artifacts/brioche-packed/* artifacts/uploads/branch/brioche-packed/
-
-          if command -v tree &> /dev/null; then
-            tree --du -h artifacts/uploads/branch
-          fi
       - name: Upload to S3
         run: |
-          aws s3 sync \
+          ls -lhR artifacts/
+
+          echo aws s3 sync \
             --endpoint "$S3_ENDPOINT" \
             --delete \
-            artifacts/uploads/branch/ \
+            artifacts/ \
             "s3://brioche-dev-development-content/github.com/brioche-dev/brioche/branches/$GITHUB_REF_NAME/"
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.R2_S3_ACCESS_KEY_ID }}

--- a/project.bri
+++ b/project.bri
@@ -34,8 +34,9 @@ export default function (): std.Recipe<std.Directory> {
     // Makefiles for miscellaneous tasks
     "**/Makefile",
   );
-  source = validateRuntime(source);
-  source = validateSqlxMetadata(source);
+
+  // Run validations
+  source = std.merge(validateRuntime(source), validateSqlxMetadata(source));
 
   return cargoBuild({
     source,
@@ -51,7 +52,11 @@ export default function (): std.Recipe<std.Directory> {
       networking: true,
     },
     dependencies: [curl(), caCertificates()],
-  });
+  }).pipe((recipe) =>
+    // Insert an empty marker file at the root of the recipe so we can find
+    // where Brioche is installed
+    recipe.insert(".brioche-install", std.file("")),
+  );
 }
 
 /**


### PR DESCRIPTION
This PR makes some big changes to how binaries are built in CI for Brioche releases.

**To-do**: (This PR still has a lot of work left! Mostly opening it now to track the current status)

- [ ] Restructure build artifacts
- [ ] Update self-updater to support new artifact format
- [ ] Sign built binaries in CI
- [ ] Handle releases in CI automatically

## Restructure build artifacts

During Brioche v0.1.5, we had 2 build artifacts used during the release:

- `brioche-x86_64-linux `: A plain, dynamically-linked glibc build of Brioche
- `brioche-packed-x86_64-linux.tar.gz `: A tarfile containing a [packed executable](https://brioche.dev/docs/how-it-works/packed-executables/) build of Brioche (`bin/brioche` plus the resources it uses)

Here's the new structure from this PR:

- `brioche-x86_64-linux.tar.gz`: A tarfile containing a packed executable build of Brioche
- `brioche-x86_64-linux-gnu.tar.gz`: A tarfile containing a dynamically linked glibc build of Brioche
- (and equivalents for aarch64)

Importantly, everything is standardized to be a tarfile containing `bin/brioche`, which means installing / updating the build will be the same regardless of where it came from. Similarly, the new names help clarify where you'd use each: one works on any Linux distro, while the other works on any distro that follows the normal GNU conventions.

> **To-do**: I was thinking we'd also need some kind of marker file in the tarfile to help the self-updater, but I'm still not sure if we would need that

## Update self-updater to support new artifact format

Pretty self-explanatory: the self-updater needs to support the new build artifact format. Since the build artifacts are all tarfiles structured the same, this means the self-updater works for both packed and unpacked builds now!

## Sign built binaries in CI

As of Brioche v0.1.5, the Brioche install script and the self-updater validated the final Brioche binary using a checksum. Since the goal is for the installer to install nightly builds (see https://github.com/brioche-dev/brioche.dev/pull/49), we need some other way to validate that the downloaded binary is valid.

I did some research on different signing options, and ultimately landed on using SSH keys for signing. It seems much easier to understand and manage than using GPG keys, and users are pretty likely to have `ssh` preinstalled and available to validate the signatures. (I'm also interested in Cosign and/or GitHub Attestations, but I'd rather save that for a future enhancement).

TL;DR: the CI pipeline will sign builds with a private key,  and will upload the signature along with each artifact. The install script can then use the public key to validate the artifact was signed by the private key.

## Handle release in CI automatically

Ever since the initial release of Brioche, I've manually done a lot of work as part of each release. Basically, that meant manually uploading files, updating the installer script, then updating the self-update manifest.

To make future releases easier, the CI pipeline should handle each of those pieces.