### PR TITLE
Fix CI build for packed aarch64 artifact using x86-64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,7 +184,7 @@ jobs:
           - name: aarch64-linux
             runs_on: ubuntu-22.04-arm
             target: aarch64-unknown-linux-gnu
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.platform.runs_on }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
This PR fixes the CI build for the packed aarch64 artifact, which was always running using a runner type of `ubuntu-24.04`. Since the build itself isn't cross-compiling, this meant the final binary ended up being built for x86-64 rather than aarch64