### PR TITLE
Use Brioche nightly for building packed aarch64 build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,12 +184,23 @@ jobs:
           - name: aarch64-linux
             runs_on: ubuntu-22.04-arm
             target: aarch64-unknown-linux-gnu
+            nightly: "true"
     runs-on: ${{ matrix.platform.runs_on }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Install Brioche
+        if: matrix.platform.nightly != 'true'
         uses: brioche-dev/setup-brioche@v1
+      - name: Install Brioche (nightly)
+        if: matrix.platform.nightly == 'true'
+        run: |
+          mkdir -p ~/.local/bin
+          curl -L https://development-content.brioche.dev/github.com/brioche-dev/brioche/branches/main/$PLATFORM/brioche -o ~/.local/bin/brioche
+          chmod +x ~/.local/bin/brioche
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+        env:
+          PLATFORM: ${{ matrix.platform.name }}
       - name: Build Brioche
         # HACK: Added a workaround for bug fixed by https://github.com/brioche-dev/brioche/pull/216
         # TODO: Update when Brioche >0.1.5 is released


### PR DESCRIPTION
Follow-up to #292 

The build after merging #292 still failed, but this time because the CI job was still using the `brioche-dev/setup-brioche` action, which doesn't work for aarch64 currently (since the last stable release of Brioche didn't include aarch64 support yet).

This PR works around it by using the nightly version of Brioche, just like the `brioche-packages` repo currently does: https://github.com/brioche-dev/brioche-packages/blob/811a87dcd6c420ba0d6da314cb512849637a6036/.github/workflows/_build.yml#L33-L40 (but here we still use the stable version for x86-64)