### PR TITLE
Add new `--experimental-lazy` CLI option for `brioche build`

### DIFF
--- a/crates/brioche-core/src/lazy_bake.rs
+++ b/crates/brioche-core/src/lazy_bake.rs
@@ -1,0 +1,130 @@
+use std::collections::{HashSet, VecDeque};
+
+use crate::recipe::Unarchive;
+
+use super::{Brioche, recipe::Recipe};
+
+/// Returns true if a recipe would be cheap to bake after fetching all of
+/// its inputs from a remote cache. This corresponds to the CLI option
+/// `--experimental-lazy`.
+///
+/// In some contexts, `brioche build --sync` is used to sync the build
+/// result to a remote cache, but without any need for the build result itself.
+/// For this scenario, `brioche build --sync` would still fetch the build
+/// result from the cache, only to re-validate that every expensive recipe
+/// is already in the cache-- which means fetching from the cache in this
+/// situation would do nothing but waste time and bandwidth.
+///
+/// This function answers the question: "would running `brioche build --sync`
+/// just fetch existing bakes from the remote cache without syncing any new
+/// recipes?"
+pub async fn is_cheap_to_bake_or_in_remote_cache(
+    brioche: &Brioche,
+    recipe: Recipe,
+) -> anyhow::Result<bool> {
+    let mut needed_recipes = VecDeque::from_iter([recipe]);
+    let mut visited_recipes = HashSet::new();
+
+    while let Some(recipe) = needed_recipes.pop_front() {
+        let recipe_hash = recipe.hash();
+        if !visited_recipes.insert(recipe_hash) {
+            continue;
+        }
+
+        match recipe {
+            recipe if recipe.is_expensive_to_bake() => {
+                tracing::debug!("checking {:?} {}", recipe.kind(), recipe_hash);
+                let bake_result = crate::cache::load_bake(brioche, recipe_hash).await?;
+                if bake_result.is_none() {
+                    // Expensive recipe not found in cache, so we'd need
+                    // to bake it
+                    return Ok(false);
+                }
+            }
+            Recipe::File {
+                content_blob: _,
+                executable: _,
+                resources,
+            } => {
+                needed_recipes.push_back(resources.value);
+            }
+            Recipe::Directory(_) | Recipe::Symlink { .. } => {
+                // No extra needed recipes
+            }
+            Recipe::Unarchive(Unarchive {
+                file,
+                compression: _,
+                archive: _,
+            }) => {
+                needed_recipes.push_back(file.value);
+            }
+            Recipe::Download(_)
+            | Recipe::Process(_)
+            | Recipe::CompleteProcess(_)
+            | Recipe::Sync { .. } => {
+                // These recipes all should've been caught by the
+                // `.is_expensive_to_bake()` check above!
+                panic!("reached recipe that should've been expensive to bake");
+            }
+            Recipe::CreateFile {
+                content: _,
+                executable: _,
+                resources,
+            } => {
+                needed_recipes.push_back(resources.value);
+            }
+            Recipe::CreateDirectory(directory) => {
+                needed_recipes.extend(directory.entries.into_values().map(|recipe| recipe.value));
+            }
+            Recipe::Cast { recipe, to: _ } => {
+                needed_recipes.push_back(recipe.value);
+            }
+            Recipe::Merge { directories } => {
+                needed_recipes.extend(directories.into_iter().map(|recipe| recipe.value));
+            }
+            Recipe::Peel {
+                directory,
+                depth: _,
+            } => {
+                needed_recipes.push_back(directory.value);
+            }
+            Recipe::Get { directory, path: _ } => {
+                needed_recipes.push_back(directory.value);
+            }
+            Recipe::Insert {
+                directory,
+                path: _,
+                recipe,
+            } => {
+                needed_recipes.push_back(directory.value);
+                if let Some(recipe) = recipe {
+                    needed_recipes.push_back(recipe.value);
+                }
+            }
+            Recipe::Glob {
+                directory,
+                patterns: _,
+            } => {
+                needed_recipes.push_back(directory.value);
+            }
+            Recipe::SetPermissions {
+                file,
+                executable: _,
+            } => {
+                needed_recipes.push_back(file.value);
+            }
+            Recipe::CollectReferences { recipe } => {
+                needed_recipes.push_back(recipe.value);
+            }
+            Recipe::AttachResources { recipe } => {
+                needed_recipes.push_back(recipe.value);
+            }
+            Recipe::Proxy(proxy) => {
+                let inner = proxy.inner(brioche).await?;
+                needed_recipes.push_back(inner);
+            }
+        }
+    }
+
+    Ok(true)
+}

--- a/crates/brioche-core/src/lib.rs
+++ b/crates/brioche-core/src/lib.rs
@@ -18,6 +18,7 @@ pub mod download;
 pub mod encoding;
 pub mod fs_utils;
 pub mod input;
+pub mod lazy_bake;
 pub mod object_store_utils;
 pub mod output;
 pub mod platform;

--- a/crates/brioche-core/tests/lazy_bake.rs
+++ b/crates/brioche-core/tests/lazy_bake.rs
@@ -1,0 +1,143 @@
+use std::sync::Arc;
+
+use brioche_core::{
+    Brioche,
+    cache::CacheClient,
+    recipe::{DownloadRecipe, Recipe, Unarchive},
+    registry::RegistryClient,
+};
+
+async fn is_lazy_bake_accepted(brioche: &Brioche, recipe: Recipe) -> bool {
+    brioche_core::lazy_bake::is_cheap_to_bake_or_in_remote_cache(brioche, recipe.clone())
+        .await
+        .unwrap()
+}
+
+#[tokio::test]
+async fn test_lazy_bake_always_accepts_cheap_recipes() -> anyhow::Result<()> {
+    // Cheap resources are never cached, so we shouldn't even check the
+    // cache for them. Using Mockito as the server lets us ensure that
+    // the cache isn't even checked
+    let mock_cache = mockito::Server::new_async().await;
+    let (brioche, _context) = brioche_test_with_http_cache(&mock_cache.url()).await;
+
+    // A literal file without any resources is cheap
+    let hello_blob = brioche_test_support::blob(&brioche, "hello world").await;
+    let hello_file = brioche_test_support::file(hello_blob, false);
+    assert!(is_lazy_bake_accepted(&brioche, hello_file.clone().into()).await);
+
+    // Unarchiving a file should be accepted if the archived file is accepted
+    let unarchive_hello_file = Recipe::Unarchive(Unarchive {
+        file: Box::new(brioche_test_support::without_meta(
+            hello_file.clone().into(),
+        )),
+        archive: brioche_core::recipe::ArchiveFormat::Tar,
+        compression: brioche_core::recipe::CompressionFormat::None,
+    });
+    assert!(is_lazy_bake_accepted(&brioche, unarchive_hello_file).await);
+
+    // Directories are never baked and are always cheap
+    let dir_with_hello = brioche_test_support::dir(&brioche, [("hello.txt", hello_file)]).await;
+    assert!(is_lazy_bake_accepted(&brioche, dir_with_hello.clone().into()).await);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_lazy_bake_accepts_uncached_expensive_recipes_when_cached() -> anyhow::Result<()> {
+    let cache = brioche_test_support::new_cache();
+    let (brioche, _context) = brioche_test_with_cache(cache.clone(), true).await;
+
+    let hello_blob = brioche_test_support::blob(&brioche, "hello world").await;
+    let hello_file = brioche_test_support::file(hello_blob, false);
+
+    // Process, download, and sync recipes are expensive, so they should
+    // only be accepted when cached
+    let process = Recipe::Process(brioche_test_support::default_process_x86_64_linux());
+    let download = Recipe::Download(DownloadRecipe {
+        url: "https://example.com".parse().unwrap(),
+        hash: brioche_core::Hash::Sha256 { value: vec![0; 32] },
+    });
+    let sync_hello_file = Recipe::Sync {
+        recipe: Box::new(brioche_test_support::without_meta(
+            hello_file.clone().into(),
+        )),
+    };
+
+    // A lazy dir should only be accepted if all of its entries are accepted
+    let lazy_dir_with_expensive_recipes = brioche_test_support::lazy_dir([
+        ("foo", process.clone()),
+        ("bar", download.clone()),
+        ("baz", sync_hello_file.clone()),
+    ]);
+
+    // With an empty cache, none of these recipes should be accepted
+    assert!(!is_lazy_bake_accepted(&brioche, process.clone()).await);
+    assert!(!is_lazy_bake_accepted(&brioche, download.clone()).await);
+    assert!(!is_lazy_bake_accepted(&brioche, sync_hello_file.clone()).await);
+    assert!(!is_lazy_bake_accepted(&brioche, lazy_dir_with_expensive_recipes.clone()).await);
+
+    // Cache the result of the process recipe
+    brioche_core::cache::save_bake(&brioche, process.hash(), hello_file.hash())
+        .await
+        .unwrap();
+
+    // Just the process recipe should be accepted now
+    assert!(is_lazy_bake_accepted(&brioche, process.clone()).await);
+    assert!(!is_lazy_bake_accepted(&brioche, download.clone()).await);
+    assert!(!is_lazy_bake_accepted(&brioche, sync_hello_file.clone()).await);
+    assert!(!is_lazy_bake_accepted(&brioche, lazy_dir_with_expensive_recipes.clone()).await);
+
+    // Save the download recipe
+    brioche_core::cache::save_bake(&brioche, download.hash(), hello_file.hash())
+        .await
+        .unwrap();
+
+    // Now the process and download recipes should be accepted
+    assert!(is_lazy_bake_accepted(&brioche, process.clone()).await);
+    assert!(is_lazy_bake_accepted(&brioche, download.clone()).await);
+    assert!(!is_lazy_bake_accepted(&brioche, sync_hello_file.clone()).await);
+    assert!(!is_lazy_bake_accepted(&brioche, lazy_dir_with_expensive_recipes.clone()).await);
+
+    // Save the sync recipe
+    brioche_core::cache::save_bake(&brioche, sync_hello_file.hash(), hello_file.hash())
+        .await
+        .unwrap();
+
+    // Each recipe should be accepted now
+    assert!(is_lazy_bake_accepted(&brioche, process.clone()).await);
+    assert!(is_lazy_bake_accepted(&brioche, download.clone()).await);
+    assert!(is_lazy_bake_accepted(&brioche, sync_hello_file.clone()).await);
+    assert!(is_lazy_bake_accepted(&brioche, lazy_dir_with_expensive_recipes.clone()).await);
+
+    Ok(())
+}
+
+async fn brioche_test_with_http_cache(url: &str) -> (Brioche, brioche_test_support::TestContext) {
+    let store = object_store::http::HttpBuilder::new()
+        .with_url(url)
+        .with_retry(object_store::RetryConfig {
+            max_retries: 0,
+            ..Default::default()
+        })
+        .build()
+        .unwrap();
+
+    brioche_test_with_cache(Arc::new(store), false).await
+}
+
+async fn brioche_test_with_cache(
+    store: Arc<dyn object_store::ObjectStore>,
+    writable: bool,
+) -> (Brioche, brioche_test_support::TestContext) {
+    brioche_test_support::brioche_test_with(move |builder| {
+        builder
+            .cache_client(CacheClient {
+                store: Some(store),
+                writable,
+                ..Default::default()
+            })
+            .registry_client(RegistryClient::disabled())
+    })
+    .await
+}


### PR DESCRIPTION
Some background context: [`brioche-packages`](https://github.com/brioche-dev/brioche-packages) has a lot of packages now! Meanwhile, all the builds run on our self-hosted runners (currently: a mini PC and a Mac mini sitting in the garage). So we're definitely starting to feel the inefficiencies in our build pipeline!

The basic CI pipeline works like this:

1. Check all packages (sped up greatly by #255)
2. Run `brioche build --sync` for each package, one by one
3. Run `brioche build -e test --sync` for each package, one by one
4. Run `brioche publish` for each package, one by one

Currently, `brioche build` will always ensure the build result is available locally, by either baking each recipe or fetching its result from the remote cache. But for the `brioche-packages` CI pipeline, we never directly use the build result, so it'd be better to _not_ fetch the build result if the result is already in the cache. In fact, a build where _every_ package is a cache hit still takes ~30 minutes, due to a mix of JS evaluation and (completely useless) cache fetches!

This PR adds a new `--experimental-lazy` flag to the `brioche build` subcommand, which short-circuits if the build wouldn't save any new bakes to the cache. I used the term "experimental" because the current implementation has some limitations, the behavior could change over time, and it's tailored mainly for the needs of the `brioche-packages` repo. (I also wanted to leave room to bikeshed the name!)

A few miscellaneous notes:

- This option cannot be used with `--output`. We always need the build result to save the output, so it would never make sense to try and pass both flags.
- `--experimental-lazy` is mostly intended for use along with `--sync`. Nothing stops you from passing it without `--sync` though.
- When checking the remote cache, it doesn't care _which_ cache it comes from. I think this behavior makes sense, although I could also imagine situations where you might more control over which cache you're lazily checking against (but maybe that's too niche).
- Implementation-wise, it would probably be better if the `bake` function was "lazy" by default, where we could then explicitly fetch the build result afterward... but I have a feeling that would be complicated to do today. I've had some ideas for some major refactoring (with a few experiments locally), so might make sense to revisit this in the future.