### PR TITLE
chore(cargo): resolve all the automatic fixables lints from pedantic

### DIFF
--- a/crates/brioche-core/benches/input.rs
+++ b/crates/brioche-core/benches/input.rs
@@ -32,7 +32,7 @@ fn bench_input(bencher: divan::Bencher, removal: Removal) {
                     &mut file,
                     &brioche_pack::Pack::Metadata {
                         resource_paths: vec![format!("{i}_resources").into()],
-                        format: "".to_string(),
+                        format: String::new(),
                         metadata: vec![],
                     },
                 )
@@ -104,7 +104,7 @@ fn bench_input_with_shared_resources(bencher: divan::Bencher, removal: Removal) 
                     &mut file,
                     &brioche_pack::Pack::Metadata {
                         resource_paths: vec!["common_resources".into()],
-                        format: "".to_string(),
+                        format: String::new(),
                         metadata: vec![],
                     },
                 )
@@ -181,7 +181,7 @@ fn bench_input_with_shared_ancestor_resources(bencher: divan::Bencher, removal: 
                         &mut inner_resource_file,
                         &brioche_pack::Pack::Metadata {
                             resource_paths: vec!["common_resources".into()],
-                            format: "".to_string(),
+                            format: String::new(),
                             metadata: vec![],
                         },
                     )
@@ -197,7 +197,7 @@ fn bench_input_with_shared_ancestor_resources(bencher: divan::Bencher, removal: 
                     &mut file,
                     &brioche_pack::Pack::Metadata {
                         resource_paths: vec![format!("resources{i}").into()],
-                        format: "".to_string(),
+                        format: String::new(),
                         metadata: vec![],
                     },
                 )
@@ -220,7 +220,7 @@ fn bench_input_with_shared_ancestor_resources(bencher: divan::Bencher, removal: 
                     &mut file,
                     &brioche_pack::Pack::Metadata {
                         resource_paths: vec!["shared.txt".into()],
-                        format: "".to_string(),
+                        format: String::new(),
                         metadata: vec![],
                     },
                 )

--- a/crates/brioche-core/src/bake.rs
+++ b/crates/brioche-core/src/bake.rs
@@ -249,49 +249,46 @@ async fn bake_inner(
         None => None,
     };
 
-    let result_artifact = match artifact_from_cache {
-        Some(artifact) => {
-            // Retrieved the artifact from the cache
-            Ok(artifact)
-        }
-        None => {
-            // Bake the recipe for real if we didn't get it from the registry
-            let bake_fut = {
-                let brioche = brioche.clone();
-                let meta = meta.clone();
-                async move {
-                    // Clone the recipe (but only if we are going to sync it)
-                    let input_recipe = if recipe.is_expensive_to_bake() {
-                        Some(recipe.value.clone())
-                    } else {
-                        None
-                    };
+    let result_artifact = if let Some(artifact) = artifact_from_cache {
+        // Retrieved the artifact from the cache
+        Ok(artifact)
+    } else {
+        // Bake the recipe for real if we didn't get it from the registry
+        let bake_fut = {
+            let brioche = brioche.clone();
+            let meta = meta.clone();
+            async move {
+                // Clone the recipe (but only if we are going to sync it)
+                let input_recipe = if recipe.is_expensive_to_bake() {
+                    Some(recipe.value.clone())
+                } else {
+                    None
+                };
 
-                    // Bake the recipe
-                    let baked = run_bake(&brioche, recipe.value, &meta).await?;
+                // Bake the recipe
+                let baked = run_bake(&brioche, recipe.value, &meta).await?;
 
-                    // Send expensive recipes to optionally be synced to
-                    // the registry right after we baked it
-                    if let Some(input_recipe) = input_recipe {
-                        brioche
-                            .sync_tx
-                            .send(crate::SyncMessage::StartSync {
-                                brioche: brioche.clone(),
-                                recipe: input_recipe,
-                                artifact: baked.clone(),
-                            })
-                            .await?;
-                    }
-
-                    anyhow::Ok(baked)
+                // Send expensive recipes to optionally be synced to
+                // the registry right after we baked it
+                if let Some(input_recipe) = input_recipe {
+                    brioche
+                        .sync_tx
+                        .send(crate::SyncMessage::StartSync {
+                            brioche: brioche.clone(),
+                            recipe: input_recipe,
+                            artifact: baked.clone(),
+                        })
+                        .await?;
                 }
-                .instrument(tracing::Span::current())
-            };
-            tokio::spawn(bake_fut).await?.map_err(|error| BakeFailed {
-                message: format!("{error:#}"),
-                meta: meta.clone(),
-            })
-        }
+
+                anyhow::Ok(baked)
+            }
+            .instrument(tracing::Span::current())
+        };
+        tokio::spawn(bake_fut).await?.map_err(|error| BakeFailed {
+            message: format!("{error:#}"),
+            meta: meta.clone(),
+        })
     };
 
     // Write the baked recipe to the database on success

--- a/crates/brioche-core/src/bake/process.rs
+++ b/crates/brioche-core/src/bake/process.rs
@@ -1650,7 +1650,7 @@ impl SandboxBackendSelector {
                 },
                 SandboxTemplate {
                     components: vec![SandboxTemplateComponent::Literal {
-                        value: r##"
+                        value: r#"
                         set -eu
                         mkdir "$BRIOCHE_OUTPUT"/new
                         touch "$BRIOCHE_OUTPUT"/new/touch.txt
@@ -1660,7 +1660,7 @@ impl SandboxBackendSelector {
                         rm "$BRIOCHE_OUTPUT"/existing/remove.txt
                         rm "$BRIOCHE_OUTPUT"/remove_dir/remove.txt
                         rmdir "$BRIOCHE_OUTPUT"/remove_dir
-                    "##
+                    "#
                         .into(),
                     }],
                 },

--- a/crates/brioche-core/src/input.rs
+++ b/crates/brioche-core/src/input.rs
@@ -45,7 +45,7 @@ pub async fn create_input(
     let (plan, root_node) = tokio::task::spawn_blocking({
         let input_path = options.input_path.to_owned();
         let remove_input = options.remove_input;
-        let resource_dir = options.resource_dir.map(|path| path.to_owned());
+        let resource_dir = options.resource_dir.map(std::borrow::ToOwned::to_owned);
         let input_resource_dirs = options.input_resource_dirs.to_owned();
         let meta = options.meta.clone();
         move || {

--- a/crates/brioche-core/src/object_store_utils.rs
+++ b/crates/brioche-core/src/object_store_utils.rs
@@ -158,7 +158,9 @@ impl object_store::CredentialProvider for AwsS3CredentialProvider {
         Ok(Arc::new(object_store::aws::AwsCredential {
             key_id: credentials.access_key_id().to_string(),
             secret_key: credentials.secret_access_key().to_string(),
-            token: credentials.session_token().map(|token| token.to_string()),
+            token: credentials
+                .session_token()
+                .map(std::string::ToString::to_string),
         }))
     }
 }
@@ -190,10 +192,10 @@ pub struct AwsS3Config {
 
 #[must_use]
 pub fn load_s3_config(config: &aws_config::SdkConfig) -> AwsS3Config {
-    let region = config.region().map(|region| region.to_string());
+    let region = config.region().map(std::string::ToString::to_string);
 
     let endpoint = if config.get_origin("endpoint_url").is_client_config() {
-        config.endpoint_url().map(|endpoint| endpoint.to_string())
+        config.endpoint_url().map(std::string::ToString::to_string)
     } else {
         config
             .service_config()
@@ -207,7 +209,7 @@ pub fn load_s3_config(config: &aws_config::SdkConfig) -> AwsS3Config {
                         .unwrap(),
                 )
             })
-            .or_else(|| config.endpoint_url().map(|endpoint| endpoint.to_string()))
+            .or_else(|| config.endpoint_url().map(std::string::ToString::to_string))
     };
 
     AwsS3Config {

--- a/crates/brioche-core/src/output.rs
+++ b/crates/brioche-core/src/output.rs
@@ -240,7 +240,7 @@ async fn create_output_inner<'a: 'async_recursion>(
                 let entry_path = options.output_path.join(path);
                 let resource_dir = options.resource_dir.map_or_else(
                     || options.output_path.join("brioche-resources.d"),
-                    |resource_dir| resource_dir.to_path_buf(),
+                    std::path::Path::to_path_buf,
                 );
 
                 match (&entry, link_lock) {

--- a/crates/brioche-core/src/process_events/display.rs
+++ b/crates/brioche-core/src/process_events/display.rs
@@ -79,10 +79,9 @@ where
                     // then retry
                     follow_events.recv()??;
                     continue;
-                } else {
-                    // We're at end of file, so we're done
-                    break;
                 }
+                // We're at end of file, so we're done
+                break;
             }
             Err(error) if error.is_unexpected_eof() => {
                 // We got an "unexpected EOF" error
@@ -97,10 +96,9 @@ where
 
                     // Retry the read
                     continue;
-                } else {
-                    // Otherwise, just bubble up the error
-                    return Err(error.into());
                 }
+                // Otherwise, just bubble up the error
+                return Err(error.into());
             }
             Err(error) => {
                 // For other kinds of errors, bubble it up

--- a/crates/brioche-core/src/project.rs
+++ b/crates/brioche-core/src/project.rs
@@ -300,7 +300,7 @@ impl Projects {
         let local_paths = projects
             .local_paths(project_hash)
             .with_context(|| format!("project not found for hash {project_hash}"))?;
-        Ok(local_paths.map(|path| path.to_owned()).collect())
+        Ok(local_paths.map(std::borrow::ToOwned::to_owned).collect())
     }
 
     pub fn validate_no_dirty_lockfiles(&self) -> anyhow::Result<()> {

--- a/crates/brioche-core/src/project/analyze.rs
+++ b/crates/brioche-core/src/project/analyze.rs
@@ -308,23 +308,22 @@ pub async fn analyze_module(
         std::str::from_utf8(&contents).with_context(|| format!("{display_path}: invalid UTF-8"))?;
 
     let parsed_module;
-    let module = match module {
-        Some(module) => module,
-        None => {
-            let parsed = biome_js_parser::parse(
-                contents,
-                biome_js_syntax::JsFileSource::ts()
-                    .with_module_kind(biome_js_syntax::ModuleKind::Module),
-                biome_js_parser::JsParserOptions::default(),
-            )
-            .cast::<biome_js_syntax::JsModule>()
-            .expect("failed to cast module");
+    let module = if let Some(module) = module {
+        module
+    } else {
+        let parsed = biome_js_parser::parse(
+            contents,
+            biome_js_syntax::JsFileSource::ts()
+                .with_module_kind(biome_js_syntax::ModuleKind::Module),
+            biome_js_parser::JsParserOptions::default(),
+        )
+        .cast::<biome_js_syntax::JsModule>()
+        .expect("failed to cast module");
 
-            parsed_module = parsed
-                .try_tree()
-                .with_context(|| format!("{display_path}: failed to parse module"))?;
-            &parsed_module
-        }
+        parsed_module = parsed
+            .try_tree()
+            .with_context(|| format!("{display_path}: failed to parse module"))?;
+        &parsed_module
     };
 
     let display_location = |offset| {
@@ -447,7 +446,7 @@ where
                 .with_context(|| format!("{location}: invalid import specifier"))?;
             Ok(Some(import_specifier))
         })
-        .filter_map(|result| result.transpose())
+        .filter_map(std::result::Result::transpose)
 }
 
 pub fn find_statics<'a, D>(
@@ -631,7 +630,7 @@ where
                 _ => Ok(None),
             }
         })
-        .filter_map(|result| result.transpose())
+        .filter_map(std::result::Result::transpose)
 }
 
 pub fn expression_to_json(

--- a/crates/brioche-core/src/project/load.rs
+++ b/crates/brioche-core/src/project/load.rs
@@ -39,8 +39,8 @@ pub async fn load_project(
                 &LoadProjectConfig {
                     projects,
                     brioche,
-                    locking,
                     validation,
+                    locking,
                 },
                 &path,
             ))
@@ -244,8 +244,8 @@ async fn build_project_graph(
 
             entry.insert(ProjectNodeDetails {
                 project_analysis,
-                lockfile_path,
                 lockfile,
+                lockfile_path,
                 workspace,
                 dependency_errors,
             });
@@ -258,8 +258,8 @@ async fn build_project_graph(
 
     Ok(ProjectGraph {
         graph,
-        expected_hashes,
         nodes_by_path,
+        expected_hashes,
         project_details,
     })
 }

--- a/crates/brioche-core/src/recipe.rs
+++ b/crates/brioche-core/src/recipe.rs
@@ -223,11 +223,11 @@ pub async fn get_recipes(
 
             let batch_records = sqlx::query_as_with::<_, (String, String), _>(
                 &format!(
-                    r#"
+                    r"
                         SELECT recipe_hash, recipe_json
                         FROM recipes
                         WHERE recipe_hash IN ({placeholders})
-                    "#,
+                    ",
                 ),
                 arguments,
             )
@@ -324,11 +324,11 @@ where
 
         let result = sqlx::query_with(
             &format!(
-                r#"
+                r"
                         INSERT INTO recipes (recipe_hash, recipe_json)
                         VALUES {placeholders}
                         ON CONFLICT (recipe_hash) DO NOTHING
-                    "#
+                    "
             ),
             arguments,
         )
@@ -367,7 +367,7 @@ pub struct WithMeta<T> {
 
 impl<T> WithMeta<T> {
     pub const fn new(value: T, meta: Arc<Meta>) -> Self {
-        Self { value, meta }
+        Self { meta, value }
     }
 
     pub fn without_meta(value: T) -> Self {
@@ -1258,7 +1258,9 @@ pub struct CompleteProcessTemplate {
 impl CompleteProcessTemplate {
     #[must_use]
     pub fn is_empty(&self) -> bool {
-        self.components.iter().all(|component| component.is_empty())
+        self.components
+            .iter()
+            .all(CompleteProcessTemplateComponent::is_empty)
     }
 
     #[must_use]

--- a/crates/brioche-core/src/references.rs
+++ b/crates/brioche-core/src/references.rs
@@ -435,11 +435,11 @@ pub async fn local_recipes(
 
         let batch_known_recipes = sqlx::query_as_with::<_, (String,), _>(
             &format!(
-                r#"
+                r"
                     SELECT recipe_hash
                     FROM recipes
                     WHERE recipe_hash IN ({placeholders})
-                "#,
+                ",
             ),
             arguments,
         )

--- a/crates/brioche-core/src/reporter/console.rs
+++ b/crates/brioche-core/src/reporter/console.rs
@@ -521,7 +521,7 @@ fn print_job_content(jobs: &HashMap<JobId, Job>, stream: &JobOutputStream, conte
 
     let content = content
         .strip_suffix(b"\n")
-        .map_or_else(|| content, |content| content.into());
+        .map_or_else(|| content, std::convert::Into::into);
 
     for line in content.lines() {
         let line = bstr::BStr::new(line);
@@ -594,7 +594,7 @@ impl superconsole::Component for JobsComponent {
             .flat_map(|(stream, content)| {
                 let content = content
                     .strip_suffix(b"\n")
-                    .map_or_else(|| content, |content| content.into());
+                    .map_or_else(|| content, std::convert::Into::into);
                 let lines_rev = content
                     .lines()
                     .rev()

--- a/crates/brioche-core/src/script/evaluate.rs
+++ b/crates/brioche-core/src/script/evaluate.rs
@@ -119,9 +119,8 @@ async fn evaluate_with_deno(
                             deno_core::error::JsError::from_v8_exception(&mut js_scope, exception)
                         ))
                         .with_context(|| format!("error when calling {export}"));
-                    } else {
-                        anyhow::bail!("unknown error when calling {export}");
                     }
+                    anyhow::bail!("unknown error when calling {export}");
                 };
                 deno_core::v8::Global::new(&mut js_scope, result)
             };
@@ -156,9 +155,8 @@ async fn evaluate_with_deno(
                             deno_core::error::JsError::from_v8_exception(&mut js_scope, exception)
                         ))
                         .with_context(|| format!("error when serializing result from {export}"));
-                    } else {
-                        anyhow::bail!("unknown error when serializing result from {export}");
                     }
+                    anyhow::bail!("unknown error when serializing result from {export}");
                 };
 
                 deno_core::v8::Global::new(&mut js_scope, serialized_result)

--- a/crates/brioche-core/src/script/lsp.rs
+++ b/crates/brioche-core/src/script/lsp.rs
@@ -5,7 +5,19 @@ use std::sync::Arc;
 use anyhow::Context as _;
 use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::request::GotoTypeDefinitionResponse;
-use tower_lsp::lsp_types::*;
+use tower_lsp::lsp_types::{
+    CompletionItem, CompletionOptions, CompletionParams, CompletionResponse, Diagnostic,
+    DiagnosticOptions, DiagnosticServerCapabilities, DidChangeTextDocumentParams,
+    DidOpenTextDocumentParams, DidSaveTextDocumentParams, DocumentDiagnosticParams,
+    DocumentDiagnosticReport, DocumentDiagnosticReportResult, DocumentFormattingParams,
+    DocumentHighlight, DocumentHighlightParams, FullDocumentDiagnosticReport, GotoDefinitionParams,
+    GotoDefinitionResponse, Hover, HoverParams, HoverProviderCapability, InitializeParams,
+    InitializeResult, InitializedParams, Location, MessageType, OneOf, Position,
+    PrepareRenameResponse, Range, ReferenceParams, RelatedFullDocumentDiagnosticReport,
+    RenameOptions, RenameParams, ServerCapabilities, TextDocumentIdentifier,
+    TextDocumentPositionParams, TextDocumentSyncCapability, TextDocumentSyncKind, TextEdit,
+    WorkspaceEdit,
+};
 use tower_lsp::{Client, LanguageServer};
 
 use crate::project::{ProjectLocking, ProjectValidation, Projects};
@@ -823,9 +835,8 @@ fn call_method(
                 exception,
             ))
             .with_context(|| format!("error when calling {method_name:?}"));
-        } else {
-            anyhow::bail!("unknown error when calling {method_name:?}");
         }
+        anyhow::bail!("unknown error when calling {method_name:?}");
     };
 
     let result = serde_v8::from_v8(&mut js_scope, result)?;

--- a/crates/brioche-core/src/script/specifier.rs
+++ b/crates/brioche-core/src/script/specifier.rs
@@ -233,7 +233,7 @@ pub fn resolve(
 
             let new_subpath = subpath
                 .parent()
-                .map_or_else(|| RelativePathBuf::from(""), |parent| parent.to_owned())
+                .map_or_else(|| RelativePathBuf::from(""), std::borrow::ToOwned::to_owned)
                 .join(specifier_path);
 
             let candidates = [
@@ -268,7 +268,7 @@ pub fn resolve(
                 )) => {
                     let new_subpath = subpath
                         .parent()
-                        .map_or_else(|| RelativePathBuf::from(""), |parent| parent.to_owned())
+                        .map_or_else(|| RelativePathBuf::from(""), std::borrow::ToOwned::to_owned)
                         .join_normalized(specifier_path);
 
                     let candidate_module_path = new_subpath.to_logical_path(&project_root);

--- a/crates/brioche-core/src/utils/output_buffer.rs
+++ b/crates/brioche-core/src/utils/output_buffer.rs
@@ -74,12 +74,12 @@ where
             let oldest_content = self
                 .partial_prepend
                 .first_entry()
-                .map(|entry| entry.into_mut())
+                .map(std::collections::btree_map::OccupiedEntry::into_mut)
                 .or_else(|| self.contents.get_mut(0).map(|(_, content)| content))
                 .or_else(|| {
                     self.partial_append
                         .first_entry()
-                        .map(|entry| entry.into_mut())
+                        .map(std::collections::btree_map::OccupiedEntry::into_mut)
                 });
             let Some(oldest_content) = oldest_content else {
                 break;
@@ -176,7 +176,7 @@ where
                     let content_start = complete.len().saturating_sub(remaining_bytes);
                     &complete[content_start..]
                 });
-                let complete_content_length = complete_content.map_or(0, |complete| complete.len());
+                let complete_content_length = complete_content.map_or(0, <[u8]>::len);
 
                 // If we have a separator (newline) to add, truncate it
                 // so it fits within the remaining space
@@ -185,7 +185,7 @@ where
                     let separator_start = separator.len().saturating_sub(remaining_bytes);
                     &separator[separator_start..]
                 });
-                let separator_length = separator.map_or(0, |separator| separator.len());
+                let separator_length = separator.map_or(0, <[u8]>::len);
 
                 // Truncate the partial content to fit within whatever
                 // space we have left over
@@ -201,8 +201,8 @@ where
         self.total_bytes = self
             .total_bytes
             .saturating_add(partial_content.len())
-            .saturating_add(complete_content.map_or(0, |content| content.len()))
-            .saturating_add(separator.map_or(0, |separator| separator.len()));
+            .saturating_add(complete_content.map_or(0, <[u8]>::len))
+            .saturating_add(separator.map_or(0, <[u8]>::len));
 
         if let Some(complete_content) = complete_content {
             let prior_partial = self.partial_prepend.remove(&stream);

--- a/crates/brioche-core/tests/lsp_completions.rs
+++ b/crates/brioche-core/tests/lsp_completions.rs
@@ -409,9 +409,9 @@ async fn test_lsp_completions_in_unsaved_edited_file() -> anyhow::Result<()> {
     let project_root = context
         .write_file(
             "myproject/project.bri",
-            indoc::indoc! {r#"
+            indoc::indoc! {r"
                 // File on disk is effectively empty
-            "#},
+            "},
         )
         .await;
 

--- a/crates/brioche-core/tests/project_load.rs
+++ b/crates/brioche-core/tests/project_load.rs
@@ -15,9 +15,9 @@ async fn test_project_load_simple() -> anyhow::Result<()> {
     context
         .write_file(
             "myproject/project.bri",
-            r#"
+            r"
                 export const project = {};
-            "#,
+            ",
         )
         .await;
 
@@ -41,7 +41,7 @@ async fn test_project_load_simple_no_definition() -> anyhow::Result<()> {
     let (brioche, context) = brioche_test_support::brioche_test().await;
 
     let project_dir = context.mkdir("myproject").await;
-    context.write_file("myproject/project.bri", r#""#).await;
+    context.write_file("myproject/project.bri", r"").await;
 
     let (projects, project_hash) =
         brioche_test_support::load_project(&brioche, &project_dir).await?;
@@ -75,9 +75,9 @@ async fn test_project_load_with_workspace_dep() -> anyhow::Result<()> {
     context
         .write_file(
             "myworkspace/foo/project.bri",
-            r#"
+            r"
                 // Workspace foo
-            "#,
+            ",
         )
         .await;
 
@@ -85,9 +85,9 @@ async fn test_project_load_with_workspace_dep() -> anyhow::Result<()> {
         .local_registry_project(async |path| {
             tokio::fs::write(
                 path.join("project.bri"),
-                r#"
+                r"
                     // Registry foo
-                "#,
+                ",
             )
             .await
             .unwrap();
@@ -158,9 +158,9 @@ async fn test_project_load_with_workspace_dep_implied() -> anyhow::Result<()> {
     context
         .write_file(
             "myworkspace/foo/project.bri",
-            r#"
+            r"
                 // Workspace foo
-            "#,
+            ",
         )
         .await;
 
@@ -168,9 +168,9 @@ async fn test_project_load_with_workspace_dep_implied() -> anyhow::Result<()> {
         .local_registry_project(async |path| {
             tokio::fs::write(
                 path.join("project.bri"),
-                r#"
+                r"
                     // Registry foo
-                "#,
+                ",
             )
             .await
             .unwrap();
@@ -245,9 +245,9 @@ async fn test_project_load_with_path_dep() -> anyhow::Result<()> {
     context
         .write_file(
             "depproject/project.bri",
-            r#"
+            r"
                 export const project = {};
-            "#,
+            ",
         )
         .await;
 
@@ -281,9 +281,9 @@ async fn test_project_load_with_local_registry_dep() -> anyhow::Result<()> {
         .local_registry_project(async |path| {
             tokio::fs::write(
                 path.join("project.bri"),
-                r#"
+                r"
                     export const project = {};
-                "#,
+                ",
             )
             .await
             .unwrap();
@@ -340,9 +340,9 @@ async fn test_project_load_with_local_registry_dep_implied() -> anyhow::Result<(
         .local_registry_project(async |path| {
             tokio::fs::write(
                 path.join("project.bri"),
-                r#"
+                r"
                     export const project = {};
-                "#,
+                ",
             )
             .await
             .unwrap();
@@ -395,9 +395,9 @@ async fn test_project_load_with_local_registry_dep_implied_nested() -> anyhow::R
         .local_registry_project(async |path| {
             tokio::fs::write(
                 path.join("project.bri"),
-                r#"
+                r"
                     // foo
-                "#,
+                ",
             )
             .await
             .unwrap();
@@ -458,9 +458,9 @@ async fn test_project_load_with_local_registry_dep_imported() -> anyhow::Result<
         .local_registry_project(async |path| {
             tokio::fs::write(
                 path.join("project.bri"),
-                r#"
+                r"
                     export const project = {};
-                "#,
+                ",
             )
             .await
             .unwrap();
@@ -520,9 +520,9 @@ async fn test_project_load_with_remote_registry_dep() -> anyhow::Result<()> {
         .cached_registry_project(&cache, async |path| {
             tokio::fs::write(
                 path.join("project.bri"),
-                r#"
+                r"
                     export const project = {};
-                "#,
+                ",
             )
             .await
             .unwrap();
@@ -939,10 +939,10 @@ async fn test_project_load_with_remote_registry_deps_with_common_children() -> a
         .cached_registry_project(&cache, async |path| {
             tokio::fs::write(
                 path.join("project.bri"),
-                r#"
+                r"
                     export const a = 1;
                     export const b = 2;
-                "#,
+                ",
             )
             .await
             .unwrap();
@@ -1179,9 +1179,9 @@ async fn test_project_load_with_locked_registry_dep() -> anyhow::Result<()> {
         .cached_registry_project(&cache, async |path| {
             tokio::fs::write(
                 path.join("project.bri"),
-                r#"
+                r"
                     export const project = {};
-                "#,
+                ",
             )
             .await
             .unwrap();
@@ -1300,9 +1300,9 @@ async fn test_project_load_complex() -> anyhow::Result<()> {
         .local_registry_project(async |path| {
             tokio::fs::write(
                 path.join("project.bri"),
-                r#"
+                r"
                     export const project = {};
-                "#,
+                ",
             )
             .await
             .unwrap();
@@ -1427,9 +1427,9 @@ async fn test_project_load_complex_implied() -> anyhow::Result<()> {
         .local_registry_project(async |path| {
             tokio::fs::write(
                 path.join("project.bri"),
-                r#"
+                r"
                     // Empty project
-                "#,
+                ",
             )
             .await
             .unwrap();
@@ -1764,9 +1764,9 @@ async fn test_project_load_with_remote_registry_dep_hash_mismatch_error() -> any
         context
             .write_file(
                 "foo/project.bri",
-                r#"
+                r"
                     // Foo
-                "#,
+                ",
             )
             .await;
         let (projects, foo_hash) =

--- a/crates/brioche-core/tests/project_load_cyclic.rs
+++ b/crates/brioche-core/tests/project_load_cyclic.rs
@@ -448,9 +448,9 @@ async fn test_project_load_cyclic_complex() -> anyhow::Result<()> {
     context
         .write_file(
             "baz/h/project.bri",
-            r#"
+            r"
                 // Empty project
-            "#,
+            ",
         )
         .await;
 

--- a/crates/brioche-core/tests/script_check.rs
+++ b/crates/brioche-core/tests/script_check.rs
@@ -135,10 +135,10 @@ async fn test_check_import_valid() -> anyhow::Result<()> {
         .local_registry_project(async |path| {
             tokio::fs::write(
                 path.join("project.bri"),
-                r#"
+                r"
                     export const project = {};
                     export const foo: number = 123;
-                "#,
+                ",
             )
             .await
             .unwrap();

--- a/crates/brioche-core/tests/script_project_analyze.rs
+++ b/crates/brioche-core/tests/script_project_analyze.rs
@@ -36,9 +36,9 @@ async fn test_analyze_simple_project() -> anyhow::Result<()> {
     context
         .write_file(
             "myproject/project.bri",
-            r#"
+            r"
                 export const project = {};
-            "#,
+            ",
         )
         .await;
 
@@ -414,13 +414,13 @@ async fn test_analyze_static_brioche_include_template_escape_error() -> anyhow::
     context
         .write_file(
             "myproject/project.bri",
-            r#"
+            r"
                 Brioche.includeFile(`foo`);
 
                 export function () {
                     return Brioche.includeDirectory(`\$bar`);
                 }
-            "#,
+            ",
         )
         .await;
 
@@ -440,13 +440,13 @@ async fn test_analyze_static_brioche_include_invalid() -> anyhow::Result<()> {
     context
         .write_file(
             "myproject/project.bri",
-            r#"
+            r"
                 const x = Brioche.includeFile(`${123}`);
 
                 export function () {
                     return x;
                 }
-            "#,
+            ",
         )
         .await;
 

--- a/crates/brioche-core/tests/script_specifiers.rs
+++ b/crates/brioche-core/tests/script_specifiers.rs
@@ -68,9 +68,9 @@ async fn test_specifier_resolve_relative() -> anyhow::Result<()> {
     context
         .write_file(
             "myproject/project.bri",
-            r#"
+            r"
                 export const project = {};
-            "#,
+            ",
         )
         .await;
     let foo_hello_path = context
@@ -116,9 +116,9 @@ async fn test_specifier_resolve_project_relative() -> anyhow::Result<()> {
     context
         .write_file(
             "myproject/project.bri",
-            r#"
+            r"
                 export const project = {};
-            "#,
+            ",
         )
         .await;
     let foo_hello_path = context
@@ -164,9 +164,9 @@ async fn test_specifier_resolve_relative_dir() -> anyhow::Result<()> {
     let main_path = context
         .write_file(
             "myproject/project.bri",
-            r#"
+            r"
                 export const project = {};
-            "#,
+            ",
         )
         .await;
     let foo_hello_path = context
@@ -221,9 +221,9 @@ async fn test_specifier_resolve_project_relative_dir() -> anyhow::Result<()> {
     let main_path = context
         .write_file(
             "myproject/project.bri",
-            r#"
+            r"
                 export const project = {};
-            "#,
+            ",
         )
         .await;
     let foo_hello_path = context
@@ -287,9 +287,9 @@ async fn test_specifier_resolve_subproject() -> anyhow::Result<()> {
         .local_registry_project(async |path| {
             tokio::fs::write(
                 path.join("project.bri"),
-                r#"
+                r"
                         export const project = {};
-                    "#,
+                    ",
             )
             .await
             .unwrap();

--- a/crates/brioche-core/tests/sync_to_cache.rs
+++ b/crates/brioche-core/tests/sync_to_cache.rs
@@ -39,10 +39,10 @@ async fn test_sync_to_cache_process_and_complete_process() -> anyhow::Result<()>
         .temp_project(async |path| {
             tokio::fs::write(
                 path.join("project.bri"),
-                r#"
+                r"
                     // dummy project
                     export const project = {};
-                "#,
+                ",
             )
             .await
             .unwrap();


### PR DESCRIPTION
Run `cargo clippy --all-targets --all-features --fix` with the pedantic lints set in the `Cargo.toml` file.

It just to reduce the noise when trying to build Brioche with pedantic lints. 