### PR TITLE
Fix panic when enabling OpenTelemetry output

### DIFF
--- a/crates/brioche-core/Cargo.toml
+++ b/crates/brioche-core/Cargo.toml
@@ -72,6 +72,7 @@ object_store = { git = "https://github.com/apache/arrow-rs-object-store.git", re
 opentelemetry = "0.30.0"
 opentelemetry-otlp = { version = "0.30.0", default-features = false, features = [
     "http-proto",
+    "reqwest-blocking-client",
     "reqwest-rustls",
 ] }
 opentelemetry-semantic-conventions = "0.30.0"

--- a/crates/brioche-core/src/reporter/console.rs
+++ b/crates/brioche-core/src/reporter/console.rs
@@ -6,7 +6,6 @@ use std::{
 
 use bstr::ByteSlice as _;
 use opentelemetry::trace::TracerProvider as _;
-use opentelemetry_otlp::WithHttpConfig as _;
 use superconsole::style::Stylize as _;
 use tracing_subscriber::{Layer as _, layer::SubscriberExt as _, util::SubscriberInitExt as _};
 
@@ -138,7 +137,6 @@ pub fn start_console_reporter(
     if brioche_otel_enabled {
         let exporter = opentelemetry_otlp::SpanExporter::builder()
             .with_http()
-            .with_http_client(reqwest::Client::new())
             .build()?;
         let provider = opentelemetry_sdk::trace::SdkTracerProvider::builder()
             .with_batch_exporter(exporter)


### PR DESCRIPTION
I was trying out Grafana for showing Brioche's OpenTelemetry traces today, and I found out that enabling the OpenTelemetry output (setting `BRIOCHE_ENABLE_OTEL=1` and `OTEL_EXPORTER_OTLP_ENDPOINT`) was causing a panic:

```
thread 'OpenTelemetry.Traces.BatchProcessor' panicked at $HOME/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/hyper-util-0.1.15/src/client/legacy/connect/dns.rs:119:24:
there is no reactor running, must be called from the context of a Tokio 1.x runtime
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

I found out that this related to how we constructed the OTLP HTTP client (we were using the async client, but `opentelemetry-otlp` started expecting the blocking client at some point I think). I tried explicitly passing `request::blocking::Client::new()` instead, but hit another weird error. What ultimately worked was just enabling the `reqwest-blocking-client` feature for `opentelemetry-otlp` and just using the default client.