### PR TITLE
feat(otel): refactor the code and add logging exporting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -778,7 +778,7 @@ dependencies = [
  "bitflags 2.9.1",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "lazy_static",
  "lazycell",
  "log",
@@ -801,7 +801,7 @@ dependencies = [
  "bitflags 2.9.1",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -1289,6 +1289,7 @@ dependencies = [
  "num_enum",
  "object_store",
  "opentelemetry",
+ "opentelemetry-appender-tracing",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
@@ -1590,7 +1591,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4400,7 +4401,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if 1.0.1",
- "windows-targets 0.48.5",
+ "windows-targets 0.53.2",
 ]
 
 [[package]]
@@ -5030,6 +5031,19 @@ dependencies = [
  "pin-project-lite",
  "thiserror 2.0.12",
  "tracing",
+]
+
+[[package]]
+name = "opentelemetry-appender-tracing"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e68f63eca5fad47e570e00e893094fc17be959c80c79a7d6ec1abdd5ae6ffc16"
+dependencies = [
+ "opentelemetry",
+ "tracing",
+ "tracing-core",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -8649,7 +8663,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/crates/brioche-core/Cargo.toml
+++ b/crates/brioche-core/Cargo.toml
@@ -71,12 +71,15 @@ object_store = { git = "https://github.com/apache/arrow-rs-object-store.git", re
 ] }
 opentelemetry = "0.30.0"
 opentelemetry-otlp = { version = "0.30.0", default-features = false, features = [
+    "logs",
+    "trace",
     "http-proto",
     "reqwest-blocking-client",
     "reqwest-rustls",
 ] }
+opentelemetry-appender-tracing = { version = "0.30.0", features = ["experimental_use_tracing_span_context"] }
 opentelemetry-semantic-conventions = "0.30.0"
-opentelemetry_sdk = { version = "0.30.0", features = ["rt-tokio"] }
+opentelemetry_sdk = { version = "0.30.0", features = ["logs", "trace", "rt-tokio"] }
 pathdiff = "0.2.3"
 pem-rfc7468 = { version = "0.7.0", features = ["std"] }
 petgraph = "0.8.2"

--- a/crates/brioche-core/src/reporter/otel.rs
+++ b/crates/brioche-core/src/reporter/otel.rs
@@ -1,0 +1,97 @@
+use opentelemetry::trace::TracerProvider as _;
+use opentelemetry_otlp::LogExporter;
+use opentelemetry_otlp::SpanExporter;
+use opentelemetry_sdk::logs::SdkLoggerProvider;
+use opentelemetry_sdk::trace::SdkTracer;
+use opentelemetry_sdk::trace::SdkTracerProvider;
+
+pub struct OtelProvider {
+    logger_provider: SdkLoggerProvider,
+    tracer_provider: SdkTracerProvider,
+}
+
+impl OtelProvider {
+    pub fn new() -> anyhow::Result<Self> {
+        let otel_enabled = matches!(
+            std::env::var("BRIOCHE_ENABLE_OTEL").as_deref(),
+            Ok("1" | "true")
+        );
+
+        let resource = Self::new_resource();
+
+        let logger_provider = Self::new_logger_provider(otel_enabled, &resource)?;
+        let tracer_provider = Self::new_tracer_provider(otel_enabled, &resource)?;
+
+        Ok(Self {
+            logger_provider,
+            tracer_provider,
+        })
+    }
+
+    #[must_use]
+    pub const fn get_logger_provider(&self) -> &SdkLoggerProvider {
+        &self.logger_provider
+    }
+
+    #[must_use]
+    pub fn get_tracer(&self) -> SdkTracer {
+        self.tracer_provider.tracer("brioche")
+    }
+
+    fn new_resource() -> opentelemetry_sdk::Resource {
+        opentelemetry_sdk::Resource::builder()
+            .with_service_name("brioche")
+            .with_attribute(opentelemetry::KeyValue::new(
+                opentelemetry_semantic_conventions::resource::SERVICE_VERSION,
+                env!("CARGO_PKG_VERSION"),
+            ))
+            .build()
+    }
+
+    pub fn new_logger_provider(
+        otel_enabled: bool,
+        resource: &opentelemetry_sdk::Resource,
+    ) -> anyhow::Result<SdkLoggerProvider> {
+        let logger_provider_builder = SdkLoggerProvider::builder();
+
+        let logger_provider = if otel_enabled {
+            let exporter = LogExporter::builder().with_http().build()?;
+
+            logger_provider_builder
+                .with_resource(resource.clone())
+                .with_batch_exporter(exporter)
+        } else {
+            logger_provider_builder
+        }
+        .build();
+
+        Ok(logger_provider)
+    }
+
+    pub fn new_tracer_provider(
+        otel_enabled: bool,
+        resource: &opentelemetry_sdk::Resource,
+    ) -> anyhow::Result<SdkTracerProvider> {
+        let tracer_provider_builder = SdkTracerProvider::builder();
+
+        let tracer_provider = if otel_enabled {
+            let exporter = SpanExporter::builder().with_http().build()?;
+
+            tracer_provider_builder
+                .with_resource(resource.clone())
+                .with_batch_exporter(exporter)
+        } else {
+            tracer_provider_builder
+        }
+        .build();
+
+        Ok(tracer_provider)
+    }
+}
+
+impl Drop for OtelProvider {
+    fn drop(&mut self) {
+        let _ = self.logger_provider.shutdown();
+        let _ = self.tracer_provider.shutdown();
+    }
+}


### PR DESCRIPTION
Following discussion on Discord, this PR adds the exporting of logs produced by `tracing` crate using OpenTelemetry format. These logs can then be collected by Otel Collectors and be displayed in APM stacks such as the one from Grafana: https://github.com/grafana/docker-otel-lgtm.

The logs are produced in conjunction with the traces, both are now exported to the collector if `BRIOCHE_ENABLE_OTEL` is set. Before this PR, only traces (with their spans and events) were reported:

<img width="707" height="624" alt="image" src="https://github.com/user-attachments/assets/894f874c-bce6-4317-97c9-f1028a8761a0" />

Now logs can be also accessed (example from [Loki in localhost](http://localhost:3000/a/grafana-lokiexplore-app/explore/service/brioche/logs?patterns=%5B%5D&from=now-1h&to=now&var-lineFormat=&var-ds=loki&var-filters=service_name%7C%3D%7Cbrioche&var-fields=&var-levels=&var-metadata=&var-jsonFields=&var-patterns=&var-lineFilterV2=&var-lineFilters=&timezone=browser&var-all-fields=&displayedFields=%5B%5D&urlColumns=%5B%5D&visualizationType=%22logs%22&prettifyLogMessage=false&sortOrder=%22Descending%22&wrapLogMessage=false)):

<img width="1790" height="1024" alt="image" src="https://github.com/user-attachments/assets/ff3d9753-0b1e-4060-bf54-1f3d5d48b9be" />

And bonus point, if you click on `logs for this span`, the associated logs will be displayed:

<img width="1790" height="1024" alt="image" src="https://github.com/user-attachments/assets/64a54846-876a-49b3-a81e-05ab7ef30886" />
