### PR TITLE
refactor(ci): use latest version of `brioche-dev/setup-brioche` to simplify Brioche installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,25 +171,18 @@ jobs:
         include:
           - name: x86_64-linux
             runs-on: ubuntu-22.04
+            brioche-release-channel: "stable"
           - name: aarch64-linux
             runs-on: ubuntu-22.04-arm
-            nightly: "true"
+            brioche-release-channel: "nightly"
     runs-on: ${{ matrix.runs-on }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
       - name: Install Brioche
-        if: matrix.nightly != 'true'
         uses: brioche-dev/setup-brioche@v1
-      - name: Install Brioche (nightly)
-        if: matrix.nightly == 'true'
-        run: |
-          mkdir -p ~/.local/bin
-          curl -L https://development-content.brioche.dev/github.com/brioche-dev/brioche/branches/main/$PLATFORM/brioche -o ~/.local/bin/brioche
-          chmod +x ~/.local/bin/brioche
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
-        env:
-          PLATFORM: ${{ matrix.name }}
+        with:
+          version: ${{ matrix.brioche-release-channel }}
       - name: Build Brioche
         # HACK: Added a workaround for bug fixed by https://github.com/brioche-dev/brioche/pull/216
         # TODO: Update when Brioche >0.1.5 is released


### PR DESCRIPTION
Following the release of https://github.com/brioche-dev/setup-brioche/releases/tag/v1.4.0, we can now make use of the latest capability of the Brioche GitHub Action in the CI to streamline the installation of Brioche. 