### PR TITLE
build: update object_store to version 0.12.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4924,8 +4924,9 @@ dependencies = [
 
 [[package]]
 name = "object_store"
-version = "0.12.3"
-source = "git+https://github.com/apache/arrow-rs-object-store.git?rev=8a7bc6e9ef94f889841620db597805728dfb37ad#8a7bc6e9ef94f889841620db597805728dfb37ad"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c1be0c6c22ec0817cdc77d3842f721a17fd30ab6965001415b5402a74e6b740"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/crates/brioche-core/Cargo.toml
+++ b/crates/brioche-core/Cargo.toml
@@ -65,7 +65,7 @@ json-canon = "0.1.3"
 lazy_format = "2.0.3"
 nix = { version = "0.30.1", features = ["user"] }
 num_enum = "0.7.3"
-object_store = { git = "https://github.com/apache/arrow-rs-object-store.git", rev = "8a7bc6e9ef94f889841620db597805728dfb37ad", features = [
+object_store = { version = "0.12.4", features = [
     "aws",
     "http",
 ] }

--- a/crates/brioche-test-support/Cargo.toml
+++ b/crates/brioche-test-support/Cargo.toml
@@ -12,7 +12,7 @@ directories = "6.0.0"
 futures = "0.3.31"
 hex = "0.4.3"
 mockito = "1.7.0"
-object_store = { git = "https://github.com/apache/arrow-rs-object-store.git", rev = "8a7bc6e9ef94f889841620db597805728dfb37ad" }
+object_store = "0.12.4"
 reqwest = "0.12.22"
 reqwest-middleware = "0.4.2"
 serde = { version = "1.0.219", features = ["derive"] }

--- a/crates/brioche/Cargo.toml
+++ b/crates/brioche/Cargo.toml
@@ -19,7 +19,7 @@ csv = "1.3.1"
 futures = "0.3.31"
 hex = "0.4.3"
 notify = "8.1.0"
-object_store = { git = "https://github.com/apache/arrow-rs-object-store.git", rev = "8a7bc6e9ef94f889841620db597805728dfb37ad" }
+object_store = "0.12.4"
 openssl = { version = "0.10.73", optional = true }
 reqwest = { version = "0.12.22", default-features = false, features = [
     "rustls-tls",


### PR DESCRIPTION
We don't need anymore to pin the `object_store` decency, since a new release has been done recently and it includes the work of this [PR](https://github.com/apache/arrow-rs-object-store/pull/441).