### PR TITLE
Add internal post-install step for Brioche installation and updates

### DIFF
--- a/crates/brioche/src/main.rs
+++ b/crates/brioche/src/main.rs
@@ -19,6 +19,8 @@ mod run;
 mod run_sandbox;
 mod self_update;
 
+const CURRENT_VERSION: &str = env!("CARGO_PKG_VERSION");
+
 #[derive(Debug, Parser)]
 #[command(version)]
 enum Args {
@@ -76,6 +78,7 @@ enum Args {
     RunSandbox(run_sandbox::RunSandboxArgs),
 }
 
+#[expect(clippy::print_stdout)]
 fn main() -> anyhow::Result<ExitCode> {
     let args = Args::parse();
 
@@ -176,8 +179,9 @@ fn main() -> anyhow::Result<ExitCode> {
         Args::SelfPostInstall => {
             // This subcommand is called by the installer / self-updater after
             // installation is complete. This gives us a chance to migrate,
-            // clean up, or perform setup after installation. For now, this
-            // is a no-op.
+            // clean up, or perform setup after installation. For now, we just
+            // print a success message.
+            println!("Brioche v{CURRENT_VERSION} is now installed");
             Ok(ExitCode::SUCCESS)
         }
         Args::Analyze(args) => {

--- a/crates/brioche/src/self_update.rs
+++ b/crates/brioche/src/self_update.rs
@@ -10,7 +10,7 @@ use futures::{TryFutureExt as _, TryStreamExt as _};
 use sha2::Digest as _;
 use tokio::io::{AsyncBufReadExt as _, AsyncSeekExt as _, AsyncWriteExt as _};
 
-const CURRENT_VERSION: &str = env!("CARGO_PKG_VERSION");
+use crate::CURRENT_VERSION;
 
 static BRIOCHE_RELEASES_URL: LazyLock<url::Url> = LazyLock::new(|| {
     let custom_releases_url = option_env!("BRIOCHE_CUSTOM_RELEASES_URL");


### PR DESCRIPTION
This PR introduces a new internal subcommand: `brioche self-post-install`. Currently, when called, it just prints a simple message:

```
Brioche v{CURRENT_VERSION} is now installed
```

This PR also updates the `self-update` subcommand to call `brioche self-post-install` on the newly-installed version.  Since this command just prints a message, this doesn't do much today, but it does at least validate that the new version is working as expected (or prints a warning with some tips if the command fails... which could be a sign that something is very broken).

Of course, this doesn't provide much value today. But my hope is that the new self-update process (part of #281) can last well into the future, so this gives us a place to hook into for things like migrations or one-off cleanup tasks when going from older versions to newer versions. The benefit of doing this _now_ is that future versions can always assume that the `self-post-install` command is called during the update process.

When calling `self-post-install`, the self-updater sets 2 extra env vars:

- `BRIOCHE_SELF_POST_INSTALL_SOURCE=self-update` (so the post-install step can tell apart e.g. a new install vs. an update)
- `BRIOCHE_SELF_POST_INSTALL_PREVIOUS_VERSION` (set to the version doing the self-update, so the post-install step can do different things depending on what version we're coming from)