### PR TITLE
build: remove target setup from rust toolchain toml file

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,3 @@
 [toolchain]
 channel = "1.90"
 profile = "default"
-targets = ["x86_64-unknown-linux-musl"]


### PR DESCRIPTION
I saw it when I tried locally to setup a docker aarch64 image with Rust toolchain inside to build from scratch Brioche. I wasn't understanding why the build was really slow, and why running a command with Brioche was taken more time than usual. Until I saw that my rust toolchain was cross building to x86_64 architecture.

I'm not always testing a WIP Brioche locally, most of the time, I just rely on the install script to install the latest nightly. And for the few times I had to test locally Brioche (from a custom branch, etc), I think I wasn't paying too much attention to time execution (because I was used to using Brioche in a VM, but now I'm used to use it in a native environment 🥲 thus, the time execution are not the same).

So, I think we can remove this line from `rust-toolchain.toml` file, and if Brioche is built on a non supported environment, an error message will still be printed at runtime.