### PR TITLE
Update Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,12 +11,12 @@ updates:
     schedule:
       interval: "weekly"
       day: "sunday"
-    # Update all the dependencies:
+    # Update the direct dependencies and not the indirect ones,
+    # since there are too many ones, and dependabot reaches its 1h timeout most of the time):
     # - direct: explicitly defined dependencies in the Cargo.toml file
     # - indirect: transient dependencies in the Cargo.lock file
     allow:
       - dependency-type: direct
-      - dependency-type: indirect
     # As for now, disable the update of biome dependencies
     # See: https://github.com/biomejs/biome/issues/5151
     ignore:


### PR DESCRIPTION
This PR updates the schedule time for Dependabot update checking to be more aligned with https://github.com/brioche-dev/brioche-packages/pull/1416. The schedule time is now set on Sunday. Dependabot will run it at a random time during the day, and if a PR has to be opened, we'll have it before the beginning Monday. This way on Monday, we can merge it whenever we're ready !

Also this PR tweaks the Cargo update checking, since on this repository, there are currently too much dependencies in the `Cargo.lock` file, and this job always exits in timeout (see the last run https://github.com/brioche-dev/brioche/actions/runs/18421205694). So, it's better to update at least the direct dependencies, than nothing. The indirect dependencies will be updated by ourself.