### PR TITLE
Update CI to attest artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,6 +233,9 @@ jobs:
     if: github.event_name == 'push' && github.repository == 'brioche-dev/brioche'
     needs: [check, all-tests-passed, build-unpacked, build-packed]
     runs-on: ubuntu-24.04
+    permissions:
+      id-token: write
+      attestations: write
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v6
@@ -254,6 +257,18 @@ jobs:
           done
         env:
           BRIOCHE_CODESIGN_PRIVATE_KEY: ${{ secrets.BRIOCHE_CODESIGN_PRIVATE_KEY }}
+      - name: Attest artifacts
+        id: attest
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-path: |
+            artifacts/brioche-*.tar.xz
+            artifacts/brioche-*.tar.xz.sig
+      - name: Save attestation
+        run: |
+          cp "$attestation_bundle" "./artifacts/attestation.json"
+        env:
+          attestation_bundle: ${{ steps.attest.outputs.bundle-path }}
       # Upload the Brioche build for the current branch
       - name: Upload to S3
         run: |


### PR DESCRIPTION
This PR is a small add-on to the recent work restructuring build artifacts (#281).

This PR updates the CI process to [attest artifacts](https://docs.github.com/en/actions/concepts/security/artifact-attestations) using the [`actions/attest-build-provenance`](https://github.com/actions/attest-build-provenance) action. Additionally, the attestation is uploaded alongside the rest of the artifacts as `attestation.json` (so we can serve it through our infrastructure directly). This mirrors how attestation works in the (new) [`brioche-installer`](https://github.com/brioche-dev/brioche-installer) repo.

For now, the attestation is created, but not checked by anything, and I'm not sure when the installer will be updated to check it. But this was a first step so we can check attestation in the future, knowing that we'll have it available for any version >v0.1.5.