### PR TITLE
Support evaluating top-level exports that aren't functions

### DIFF
--- a/crates/brioche-core/tests/script_eval.rs
+++ b/crates/brioche-core/tests/script_eval.rs
@@ -14,6 +14,47 @@ async fn test_eval_basic() -> anyhow::Result<()> {
             "myproject/project.bri",
             r#"
                 export const project = {};
+                export default {
+                    briocheSerialize: () => {
+                        return {
+                            type: "directory",
+                            entries: {},
+                        }
+                    },
+                };
+            "#,
+        )
+        .await;
+
+    let (projects, project_hash) =
+        brioche_test_support::load_project(&brioche, &project_dir).await?;
+
+    let resolved = evaluate(
+        &brioche,
+        initialize_js_platform(),
+        &projects,
+        project_hash,
+        "default",
+    )
+    .await?
+    .value;
+
+    assert_eq!(resolved, brioche_test_support::dir_empty().into());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_eval_basic_function() -> anyhow::Result<()> {
+    let (brioche, context) = brioche_test_support::brioche_test().await;
+
+    let project_dir = context.mkdir("myproject").await;
+
+    context
+        .write_file(
+            "myproject/project.bri",
+            r#"
+                export const project = {};
                 export default () => {
                     return {
                         briocheSerialize: () => {


### PR DESCRIPTION
This is a small change that I think is better explained with an example:

```typescript
import * as std from "std";

// Now works with this PR!
export default std.bashRunnable`echo 'Hello world!'`;

// Previously, you needed to wrap it in a function:
// export default function () {
//   return std.bashRunnable`echo 'Hello world!'`;
// }
```

Whenever we evaluated an export e.g. in `brioche build`, `brioche run`, etc., we always checked that the export was a function, then called it. This PR is a slight change where we first check if the top-level export is a function, and only call it then!

I don't think this will have much impact today, as wrapping in a function lets us use explicit type annotations in `brioche-packages`. But I think this new approach is more consistent, since a top-level export can basically be any `std.RecipeLike` value. Long-term, I think this might give better ergonomics for some future features :slightly_smiling_face: 