### PR TITLE
Update CI pipeline to publish releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,6 +241,10 @@ jobs:
       attestations: write
       contents: write
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          path: checkout
       - name: Download artifacts
         uses: actions/download-artifact@v6
         with:
@@ -303,7 +307,7 @@ jobs:
           S3_ENDPOINT: ${{ secrets.R2_S3_ENDPOINT }}
         run: |
           # Validate Cargo.toml version matches release version
-          crate_version=$(cargo metadata --format-version=1 | jq -r '.packages | map(select(.name == "brioche")) | first.version')
+          crate_version=$(cargo metadata --manifest-path checkout/Cargo.toml --format-version=1 | jq -r '.packages | map(select(.name == "brioche")) | first.version')
           if [ "$GITHUB_REF_NAME" != "v${crate_version}" ]; then
             echo "Version does not match!"
             echo "Git ref name: $GITHUB_REF_NAME"


### PR DESCRIPTION
This PR updates our GitHub Actions CI workflow to handle releases. When pushing a tag named `v*` (e.g. `v0.1.6`), the new CI pipeline will:

1. Validate that the tag name matches the Brioche version in `Cargo.toml` (to make sure that the tag and the version returned by `--version` match)
2. Create a draft GitHub release
3. Add the artifacts to the GitHub release
4. Upload the release artifacts to `https://releases.brioche.dev/v${version}` with an update manifest

After this process completes, **there are two manual steps needed to stabilize the release**:

1. Update `https://releases.brioche.dev/channels/stable/latest-version.txt` to the latest version number
2. Publish the draft GitHub release

...plus having the changelog + release notes + announcement post, of course :slightly_smiling_face:

---

I tested this process with a few release candidate releases already, to make sure everything works end-to-end:

- ~~`v0.1.6-rc.1`~~ (build failed)
- [`v0.1.6-rc.2`](https://github.com/brioche-dev/brioche/releases/tag/v0.1.6-rc.2)
- ~~`v0.1.6-rc.3`~~ (build failed)
- [`v0.1.6-rc.4`](https://github.com/brioche-dev/brioche/releases/tag/v0.1.6-rc.4)