### PR TITLE
Work around race condition between "didOpen" and "diagnostic" LSP messages

### DIFF
--- a/crates/brioche-core/src/script/lsp.rs
+++ b/crates/brioche-core/src/script/lsp.rs
@@ -555,7 +555,7 @@ impl LanguageServer for BriocheLspServer {
             .await;
 
         let text_document_uri = &params.text_document.uri;
-        let load_result = self.load_document_if_not_loaded(text_document_uri).await;
+        let load_result = self.load_document(text_document_uri).await;
         if let Err(error) = load_result {
             tracing::warn!(
                 "failed to load document {text_document_uri} during diagnostic request: {error:#}"


### PR DESCRIPTION
This PR resolves a longstanding bug that could happen in the LSP, which could cause valid imports to show up with an error message like this upon first opening them:

> Cannot find module 'std'. Did you mean to set the 'moduleResolution' option to 'nodenext', or to add aliases to the 'paths' option?

After a _lot_ of debugging, I finally tracked down the problem. VS Code's LSP client sends the `didOpen` and `diagnostic` message at nearly the same time when opening a file. Our `diagnostic` message handler was using the method `.load_document_if_not_loaded` to ensure the file to get diagnostics for was already loaded, but this method races with the `.update_document` method.

In some cases, the `.update_document` method would have reached the point of loading the root module, but before all of its modules were loaded. Then, `.load_document_if_not_loaded` would short-circuit since it saw the root document was already loaded. This caused the TypeScript Language Service to see that some modules were "missing", since they were still being processed asynchronously.

## Reproducing the bug

I could pretty consistently reproduce the bug locally. I'm using Brioche v0.1.6 (built from source; commit [`e5305be`](https://github.com/brioche-dev/brioche/commit/e5305befd022ca0d1c648d13100b1056e76016f7)) and a fairly recent commit of `brioche-pacakges` ([`b6e16fa`](https://github.com/brioche-dev/brioche-packages/commit/b6e16fa839a1bbd8f269f740f7f8401bd50636c3)).

1. In VS Code, close all open tabs in `brioche-packages`, then close the window
2. Open the file `projects/helix/project.bri`
3. (Wait ~1 second for background async work to finish)
4. Open the file `projects/wabt/project.bri`
5. (Wait ~1 second for background async work to finish)
6. Open the file `projects/libint/project.bri`

Since this bug comes from a race condition, it varies which of the 3 projects above end up getting diagnostics. But usually `libint` ends up with red diagnostic squiggles for all of its imports.

## The fix

For now, I fixed the bug by just using `.load_document` instead of `.load_document_if_not_loaded` when handling the `diagnostic` message. This should avoid the race condition we saw, since `.load_document` will go through and process imports even if the top-level document was already processed.

I don't believe this is a sound solution, and there's likely more race conditions lurking in the LSP code. Realistically, the LSP code is pretty messy today, along with the "VFS" and "Projects" abstractions, and I think it's going to take some major effort to refactor all 3 to get them to a good point.