### PR TITLE
chore: update console reporter to display sizes in kilobytes

### DIFF
--- a/crates/brioche-core/src/reporter/console.rs
+++ b/crates/brioche-core/src/reporter/console.rs
@@ -299,11 +299,11 @@ impl ConsoleReporter {
                         if let Some(finished_at) = finished_at {
                             let elapsed = finished_at.saturating_duration_since(job.created_at());
 
-                            let downloaded_size = bytesize::ByteSize(*downloaded_bytes).as_kb();
+                            let downloaded_size = bytesize::ByteSize(*downloaded_bytes);
                             let elapsed_duration = DisplayDuration(elapsed);
 
                             eprintln!(
-                                "Finished downloading {url} ({downloaded_size} kB) in {elapsed_duration}s"
+                                "Finished downloading {url} ({downloaded_size}) in {elapsed_duration}s"
                             );
                         }
                     }
@@ -315,10 +315,10 @@ impl ConsoleReporter {
                         if let Some(finished_at) = finished_at {
                             let elapsed = finished_at.saturating_duration_since(job.created_at());
 
-                            let read_size = bytesize::ByteSize(*read_bytes).as_kb();
+                            let read_size = bytesize::ByteSize(*read_bytes);
                             let elapsed_duration = DisplayDuration(elapsed);
 
-                            eprintln!("Finished unarchiving {read_size} kB in {elapsed_duration}s");
+                            eprintln!("Finished unarchiving {read_size} in {elapsed_duration}s");
                         }
                     }
                     UpdateJob::ProcessUpdateStatus { status } => {
@@ -429,11 +429,11 @@ impl ConsoleReporter {
                             crate::reporter::job::CacheFetchKind::Project => "project",
                         };
 
-                        let downloaded_size = bytesize::ByteSize(*downloaded_bytes).as_kb();
+                        let downloaded_size = bytesize::ByteSize(*downloaded_bytes);
                         let elapsed_duration = DisplayDuration(elapsed);
 
                         eprintln!(
-                            "Fetched {downloaded_size} kB for {fetch_kind} from cache in {elapsed_duration}s",
+                            "Fetched {downloaded_size} for {fetch_kind} from cache in {elapsed_duration}s",
                         );
                     }
                 }
@@ -727,11 +727,11 @@ impl superconsole::Component for JobComponent<'_> {
                     .saturating_sub(1)
                     .saturating_sub(line.len());
 
-                let downloaded_size = bytesize::ByteSize(*downloaded_bytes).as_kb();
-                let total_size = total_bytes.map(|value| bytesize::ByteSize(value).as_kb());
+                let downloaded_size = bytesize::ByteSize(*downloaded_bytes);
+                let total_size = total_bytes.map(bytesize::ByteSize);
                 let mut download_message = total_size.map_or_else(
-                    || format!("{downloaded_size} kB"),
-                    |total_size| format!("{downloaded_size} kB / {total_size} kB"),
+                    || format!("{downloaded_size}"),
+                    |total_size| format!("{downloaded_size} / {total_size}"),
                 );
                 let truncated_url = string_with_width(
                     url.as_str(),
@@ -784,12 +784,12 @@ impl superconsole::Component for JobComponent<'_> {
                     .saturating_sub(1)
                     .saturating_sub(line.len());
 
-                let read_size = bytesize::ByteSize(*read_bytes).as_kb();
-                let total_size = bytesize::ByteSize(*total_bytes).as_kb();
+                let read_size = bytesize::ByteSize(*read_bytes);
+                let total_size = bytesize::ByteSize(*total_bytes);
                 let unarchive_message = if job.is_complete() {
-                    format!("Unarchive: {read_size} kB")
+                    format!("Unarchive: {read_size}")
                 } else {
-                    format!("Unarchive: {read_size} kB / {total_size} kB")
+                    format!("Unarchive: {read_size} / {total_size}")
                 };
 
                 line.extend(progress_bar_spans(
@@ -897,17 +897,17 @@ impl superconsole::Component for JobComponent<'_> {
                     superconsole::Span::new_unstyled_lossy(" "),
                 ]);
 
-                let downloaded_size = bytesize::ByteSize(*downloaded_bytes).as_kb();
-                let total_size = total_bytes.map(|value| bytesize::ByteSize(value).as_kb());
+                let downloaded_size = bytesize::ByteSize(*downloaded_bytes);
+                let total_size = total_bytes.map(bytesize::ByteSize);
 
                 let fetch_kind = match kind {
                     super::job::CacheFetchKind::Bake => "artifact",
                     super::job::CacheFetchKind::Project => "project",
                 };
                 let fetching_message = if job.is_complete() {
-                    format!("Fetch {fetch_kind}: {downloaded_size} kB")
+                    format!("Fetch {fetch_kind}: {downloaded_size}")
                 } else if let Some(total_size) = total_size {
-                    format!("Fetch {fetch_kind}: {downloaded_size} kB / {total_size} kB")
+                    format!("Fetch {fetch_kind}: {downloaded_size} / {total_size}")
                 } else {
                     format!("Fetch {fetch_kind}")
                 };


### PR DESCRIPTION
Follow up of https://github.com/brioche-dev/brioche/pull/369 with the update of [bytesize](https://github.com/bytesize-rs/bytesize) to version 2.2.0. We can now use `.as_*` function to convert the byte size in something more idiomatic for the end user.

Here I decided to switch all the logs to kB instead of B. But it's a bit opinionated, what do you think @kylewlacy ?