### PR TITLE
Add git auth and move code fetching into Brioche core

### DIFF
--- a/crates/brioche-core/src/download.rs
+++ b/crates/brioche-core/src/download.rs
@@ -9,6 +9,18 @@ use crate::{
     reporter::job::{NewJob, UpdateJob},
 };
 
+fn parse_git_repository_url(repository: &url::Url) -> anyhow::Result<gix::Url> {
+    repository
+        .as_str()
+        .try_into()
+        .with_context(|| format!("failed to parse git repository URL: {repository}"))
+}
+
+fn parse_git_commit_id(commit: &str) -> anyhow::Result<gix::hash::ObjectId> {
+    gix::hash::ObjectId::from_hex(commit.as_bytes())
+        .with_context(|| format!("invalid git commit hash {commit}"))
+}
+
 #[tracing::instrument(skip_all, fields(%url))]
 pub async fn download(
     brioche: &Brioche,
@@ -99,10 +111,7 @@ pub async fn fetch_git_commit_for_ref(
 
     // gix uses a blocking client, so spawn a separate thread to fetch
     std::thread::spawn({
-        let repository: gix::Url = repository
-            .as_str()
-            .try_into()
-            .with_context(|| format!("failed to parse git repository URL: {repository}"))?;
+        let repository = parse_git_repository_url(repository)?;
         move || {
             // For proper authentication, we need to create a config
             let config = gix::config::File::from_globals().unwrap_or_default();
@@ -291,10 +300,7 @@ pub async fn git_checkout(
         std::fs::create_dir_all(&temp_dir)
             .with_context(|| format!("failed to create {}", temp_dir.display()))?;
 
-        let repository: gix::Url = repository
-            .as_str()
-            .try_into()
-            .with_context(|| format!("failed to parse git repository URL: {repository}"))?;
+        let repository = parse_git_repository_url(&repository)?;
         let mut prepare_fetch = gix::clone::PrepareFetch::new(
             repository,
             &temp_dir,
@@ -308,8 +314,7 @@ pub async fn git_checkout(
         let should_interrupt = AtomicBool::new(false);
         let (repo, _) = prepare_fetch.fetch_only(gix::progress::Discard, &should_interrupt)?;
 
-        let commit_id = gix::hash::ObjectId::from_hex(commit.as_bytes())
-            .with_context(|| format!("invalid git commit hash {commit}"))?;
+        let commit_id = parse_git_commit_id(&commit)?;
         let commit = repo.find_commit(commit_id).with_context(|| {
             format!("commit {commit_id} not found after fetching ref {reference}")
         })?;

--- a/crates/brioche-core/src/download.rs
+++ b/crates/brioche-core/src/download.rs
@@ -1,3 +1,5 @@
+use std::{path::Path, sync::atomic::AtomicBool};
+
 use anyhow::Context as _;
 use futures::TryStreamExt as _;
 use tokio_util::compat::FuturesAsyncReadCompatExt as _;
@@ -102,6 +104,30 @@ pub async fn fetch_git_commit_for_ref(
             .try_into()
             .with_context(|| format!("failed to parse git repository URL: {repository}"))?;
         move || {
+            // For proper authentication, we need to create a config
+            let config = gix::config::File::from_globals().unwrap_or_default();
+
+            // Get credential helpers from config
+            let (mut cascade, _action, _prompt_options) = match gix::config::credential_helpers(
+                repository.clone(),
+                &config,
+                false,
+                |_| true,
+                gix::open::permissions::Environment::all(),
+                false,
+            ) {
+                Ok(result) => result,
+                Err(error) => {
+                    let _ = tx.send(Err(error.into()));
+                    return;
+                }
+            };
+
+            // Authenticate function that uses the cascade
+            let auth = move |action: gix::credentials::helper::Action| {
+                cascade.invoke(action, gix::prompt::Options::default())
+            };
+
             // Connect to the repository by URL
             let transport = gix::protocol::transport::client::blocking_io::connect::connect(
                 repository,
@@ -115,14 +141,11 @@ pub async fn fetch_git_commit_for_ref(
                 }
             };
 
-            // Perform a handshake to get the remote's capabilities.
-            // Authentication is disabled
-            #[expect(clippy::result_large_err)]
-            let empty_auth = |_| Ok(None);
+            // Perform a handshake with authentication support
             let outcome = gix::protocol::handshake(
                 &mut transport,
                 gix::protocol::transport::Service::UploadPack,
-                empty_auth,
+                auth,
                 vec![],
                 &mut gix::progress::Discard,
             );
@@ -210,4 +233,132 @@ pub async fn fetch_git_commit_for_ref(
 
     let commit = object_id.to_string();
     Ok(commit)
+}
+
+pub async fn git_checkout(
+    repository: &url::Url,
+    reference: &str,
+    commit: &str,
+    output_dir: &Path,
+) -> anyhow::Result<()> {
+    #[derive(Clone)]
+    struct RepoObjectFinder {
+        repo: gix::Repository,
+    }
+
+    impl gix::objs::Find for RepoObjectFinder {
+        fn try_find<'a>(
+            &self,
+            id: &gix::hash::oid,
+            buffer: &'a mut Vec<u8>,
+        ) -> Result<Option<gix::objs::Data<'a>>, gix::objs::find::Error> {
+            let Some(object) = self.repo.try_find_object(id).map_err(|error| error.0)? else {
+                return Ok(None);
+            };
+
+            buffer.clear();
+            buffer.extend_from_slice(&object.data);
+
+            Ok(Some(gix::objs::Data::new(object.kind, buffer.as_slice())))
+        }
+    }
+
+    let repository = repository.clone();
+    let reference = reference.to_string();
+    let commit = commit.to_string();
+    let output_dir = output_dir.to_path_buf();
+
+    tokio::task::spawn_blocking(move || {
+        if output_dir.exists() {
+            return Ok(());
+        }
+
+        let parent_dir = output_dir
+            .parent()
+            .with_context(|| format!("checkout path {} had no parent", output_dir.display()))?;
+        std::fs::create_dir_all(parent_dir)
+            .with_context(|| format!("failed to create {}", parent_dir.display()))?;
+
+        let temp_dir = parent_dir.join(format!("checkout-tmp-{}", ulid::Ulid::new()));
+        if temp_dir.exists() {
+            std::fs::remove_dir_all(&temp_dir).with_context(|| {
+                format!(
+                    "failed to remove temporary directory {}",
+                    temp_dir.display()
+                )
+            })?;
+        }
+        std::fs::create_dir_all(&temp_dir)
+            .with_context(|| format!("failed to create {}", temp_dir.display()))?;
+
+        let repository: gix::Url = repository
+            .as_str()
+            .try_into()
+            .with_context(|| format!("failed to parse git repository URL: {repository}"))?;
+        let mut prepare_fetch = gix::clone::PrepareFetch::new(
+            repository,
+            &temp_dir,
+            gix::create::Kind::WithWorktree,
+            gix::create::Options::default(),
+            gix::open::Options::default(),
+        )?
+        .with_ref_name(Some(reference.as_str()))
+        .map_err(anyhow::Error::from)?;
+
+        let should_interrupt = AtomicBool::new(false);
+        let (repo, _) = prepare_fetch.fetch_only(gix::progress::Discard, &should_interrupt)?;
+
+        let commit_id = gix::hash::ObjectId::from_hex(commit.as_bytes())
+            .with_context(|| format!("invalid git commit hash {commit}"))?;
+        let commit = repo.find_commit(commit_id).with_context(|| {
+            format!("commit {commit_id} not found after fetching ref {reference}")
+        })?;
+        let tree_id = commit.tree_id()?.detach();
+        let mut index = repo.index_from_tree(&tree_id)?;
+
+        let mut checkout_options =
+            repo.checkout_options(gix::worktree::stack::state::attributes::Source::IdMapping)?;
+        checkout_options.destination_is_initially_empty = true;
+
+        let finder = RepoObjectFinder { repo: repo.clone() };
+        let files_progress = gix::progress::Discard;
+        let bytes_progress = gix::progress::Discard;
+        gix::worktree::state::checkout(
+            &mut index,
+            repo.workdir()
+                .with_context(|| format!("repository {} has no workdir", temp_dir.display()))?,
+            finder,
+            &files_progress,
+            &bytes_progress,
+            &should_interrupt,
+            checkout_options,
+        )?;
+        index.write(Default::default())?;
+
+        let dot_git_dir = temp_dir.join(".git");
+        if dot_git_dir.exists() {
+            std::fs::remove_dir_all(&dot_git_dir)
+                .with_context(|| format!("failed to remove {}", dot_git_dir.display()))?;
+        }
+
+        match std::fs::rename(&temp_dir, &output_dir) {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+                std::fs::remove_dir_all(&temp_dir).with_context(|| {
+                    format!("failed to remove {} after rename race", temp_dir.display())
+                })?;
+                Ok(())
+            }
+            Err(error) => Err(error).with_context(|| {
+                format!(
+                    "failed to move git checkout from {} to {}",
+                    temp_dir.display(),
+                    output_dir.display()
+                )
+            }),
+        }
+    })
+    .await??;
+
+    Ok(())
 }

--- a/crates/brioche-core/src/download.rs
+++ b/crates/brioche-core/src/download.rs
@@ -1,4 +1,8 @@
-use std::{path::Path, sync::atomic::AtomicBool};
+use std::{
+    borrow::Cow,
+    path::{Component, Path, PathBuf},
+    sync::atomic::AtomicBool,
+};
 
 use anyhow::Context as _;
 use futures::TryStreamExt as _;
@@ -19,6 +23,243 @@ fn parse_git_repository_url(repository: &url::Url) -> anyhow::Result<gix::Url> {
 fn parse_git_commit_id(commit: &str) -> anyhow::Result<gix::hash::ObjectId> {
     gix::hash::ObjectId::from_hex(commit.as_bytes())
         .with_context(|| format!("invalid git commit hash {commit}"))
+}
+
+fn brioche_git_signature() -> gix::actor::Signature {
+    gix::actor::Signature {
+        name: "Brioche".into(),
+        email: "github@brioche.dev".into(),
+        time: gix::date::Time::now_local_or_utc(),
+    }
+}
+
+#[derive(Clone)]
+struct RepoObjectFinder {
+    repo: gix::Repository,
+}
+
+impl gix::objs::Find for RepoObjectFinder {
+    fn try_find<'a>(
+        &self,
+        id: &gix::hash::oid,
+        buffer: &'a mut Vec<u8>,
+    ) -> Result<Option<gix::objs::Data<'a>>, gix::objs::find::Error> {
+        let Some(object) = self.repo.try_find_object(id).map_err(|error| error.0)? else {
+            return Ok(None);
+        };
+
+        buffer.clear();
+        buffer.extend_from_slice(&object.data);
+
+        Ok(Some(gix::objs::Data::new(object.kind, buffer.as_slice())))
+    }
+}
+
+fn fetch_git_repo(
+    repository: &gix::Url,
+    output_dir: &Path,
+    reference: Option<&str>,
+) -> anyhow::Result<gix::Repository> {
+    if let Some(parent_dir) = output_dir.parent() {
+        std::fs::create_dir_all(parent_dir)
+            .with_context(|| format!("failed to create {}", parent_dir.display()))?;
+    }
+    std::fs::create_dir_all(output_dir)
+        .with_context(|| format!("failed to create {}", output_dir.display()))?;
+
+    let mut prepare_fetch = gix::clone::PrepareFetch::new(
+        repository.clone(),
+        output_dir,
+        gix::create::Kind::WithWorktree,
+        gix::create::Options::default(),
+        gix::open::Options::default(),
+    )?;
+
+    if let Some(reference) = reference {
+        prepare_fetch = prepare_fetch
+            .with_ref_name(Some(reference))
+            .map_err(anyhow::Error::from)?;
+    }
+
+    let should_interrupt = AtomicBool::new(false);
+    let (repo, _) = prepare_fetch.fetch_only(gix::progress::Discard, &should_interrupt)?;
+    Ok(repo)
+}
+
+fn checkout_repo_worktree(
+    repo: &gix::Repository,
+    commit_id: gix::hash::ObjectId,
+) -> anyhow::Result<()> {
+    let commit = repo
+        .find_commit(commit_id)
+        .with_context(|| format!("commit {commit_id} not found after fetching repository"))?;
+    let tree_id = commit.tree_id()?.detach();
+    let mut index = repo.index_from_tree(&tree_id)?;
+
+    let mut checkout_options =
+        repo.checkout_options(gix::worktree::stack::state::attributes::Source::IdMapping)?;
+    checkout_options.destination_is_initially_empty = true;
+
+    let finder = RepoObjectFinder { repo: repo.clone() };
+    let files_progress = gix::progress::Discard;
+    let bytes_progress = gix::progress::Discard;
+    let should_interrupt = AtomicBool::new(false);
+    gix::worktree::state::checkout(
+        &mut index,
+        repo.workdir()
+            .with_context(|| format!("repository {} has no workdir", repo.git_dir().display()))?,
+        finder,
+        &files_progress,
+        &bytes_progress,
+        &should_interrupt,
+        checkout_options,
+    )?;
+    index.write(Default::default())?;
+
+    Ok(())
+}
+
+fn normalize_git_url_path(path: PathBuf) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::Prefix(prefix) => normalized.push(prefix.as_os_str()),
+            Component::RootDir => normalized.push(component.as_os_str()),
+            Component::CurDir => {}
+            Component::ParentDir => {
+                normalized.pop();
+            }
+            Component::Normal(part) => normalized.push(part),
+        }
+    }
+
+    normalized
+}
+
+fn resolve_submodule_url(
+    parent_repository: &gix::Url,
+    submodule_url: &gix::Url,
+) -> anyhow::Result<gix::Url> {
+    let submodule_path =
+        gix::path::from_bstr(Cow::Borrowed(submodule_url.path.as_ref())).into_owned();
+    if submodule_url.host.is_some() || submodule_path.is_absolute() {
+        return Ok(submodule_url.clone());
+    }
+
+    let parent_path =
+        gix::path::from_bstr(Cow::Borrowed(parent_repository.path.as_ref())).into_owned();
+    let parent_dir = parent_path
+        .parent()
+        .map(Path::to_path_buf)
+        .unwrap_or_default();
+    let resolved_path = normalize_git_url_path(parent_dir.join(submodule_path));
+
+    anyhow::ensure!(
+        !resolved_path.as_os_str().is_empty(),
+        "failed to resolve relative submodule URL {submodule_url} against {parent_repository}"
+    );
+
+    let mut resolved_url = parent_repository.clone();
+    resolved_url.path = gix::path::into_bstr(resolved_path).into_owned();
+    resolved_url.serialize_alternative_form = false;
+
+    Ok(resolved_url)
+}
+
+fn populate_submodules(
+    repo: &gix::Repository,
+    repository: &gix::Url,
+    recurse_submodules: bool,
+) -> anyhow::Result<()> {
+    let Some(submodules) = repo.submodules()? else {
+        return Ok(());
+    };
+
+    for submodule in submodules {
+        let submodule_path = submodule.path()?;
+        let Some(submodule_commit) = submodule.index_id()? else {
+            continue;
+        };
+        let submodule_url = resolve_submodule_url(repository, &submodule.url()?)?;
+        let submodule_work_dir = submodule.work_dir()?;
+
+        checkout_git_repo(
+            &submodule_url,
+            None,
+            submodule_commit,
+            &submodule_work_dir,
+            recurse_submodules,
+            None,
+        )
+        .with_context(|| {
+            format!(
+                "failed to checkout submodule '{}' at '{}'",
+                String::from_utf8_lossy(submodule_path.as_ref()),
+                submodule_work_dir.display()
+            )
+        })?;
+    }
+
+    Ok(())
+}
+
+fn checkout_git_repo(
+    repository: &gix::Url,
+    reference: Option<&str>,
+    commit_id: gix::hash::ObjectId,
+    output_dir: &Path,
+    recurse_submodules: bool,
+    tag_name: Option<&str>,
+) -> anyhow::Result<()> {
+    let repo = fetch_git_repo(repository, output_dir, reference)?;
+    checkout_repo_worktree(&repo, commit_id)?;
+
+    if recurse_submodules {
+        populate_submodules(&repo, repository, recurse_submodules)?;
+    }
+
+    if let Some(tag_name) = tag_name {
+        let tagger = brioche_git_signature();
+        let mut time_buf = gix::date::parse::TimeBuf::default();
+        repo.tag(
+            tag_name,
+            commit_id,
+            gix::objs::Kind::Commit,
+            Some(tagger.to_ref(&mut time_buf)),
+            "",
+            gix::refs::transaction::PreviousValue::Any,
+        )?;
+    }
+
+    Ok(())
+}
+
+fn remove_git_metadata(path: &Path) -> anyhow::Result<()> {
+    let Ok(entries) = std::fs::read_dir(path) else {
+        return Ok(());
+    };
+
+    for entry in entries {
+        let entry = entry?;
+        let entry_path = entry.path();
+        if entry.file_name() == ".git" {
+            let file_type = entry.file_type()?;
+            if file_type.is_dir() {
+                std::fs::remove_dir_all(&entry_path)
+                    .with_context(|| format!("failed to remove {}", entry_path.display()))?;
+            } else {
+                std::fs::remove_file(&entry_path)
+                    .with_context(|| format!("failed to remove {}", entry_path.display()))?;
+            }
+            continue;
+        }
+
+        if entry.file_type()?.is_dir() {
+            remove_git_metadata(&entry_path)?;
+        }
+    }
+
+    Ok(())
 }
 
 #[tracing::instrument(skip_all, fields(%url))]
@@ -249,33 +490,15 @@ pub async fn git_checkout(
     reference: &str,
     commit: &str,
     output_dir: &Path,
+    recurse_submodules: bool,
+    keep_git_dir: bool,
+    tag_name: Option<&str>,
 ) -> anyhow::Result<()> {
-    #[derive(Clone)]
-    struct RepoObjectFinder {
-        repo: gix::Repository,
-    }
-
-    impl gix::objs::Find for RepoObjectFinder {
-        fn try_find<'a>(
-            &self,
-            id: &gix::hash::oid,
-            buffer: &'a mut Vec<u8>,
-        ) -> Result<Option<gix::objs::Data<'a>>, gix::objs::find::Error> {
-            let Some(object) = self.repo.try_find_object(id).map_err(|error| error.0)? else {
-                return Ok(None);
-            };
-
-            buffer.clear();
-            buffer.extend_from_slice(&object.data);
-
-            Ok(Some(gix::objs::Data::new(object.kind, buffer.as_slice())))
-        }
-    }
-
     let repository = repository.clone();
     let reference = reference.to_string();
     let commit = commit.to_string();
     let output_dir = output_dir.to_path_buf();
+    let tag_name = tag_name.map(std::borrow::ToOwned::to_owned);
 
     tokio::task::spawn_blocking(move || {
         if output_dir.exists() {
@@ -301,49 +524,23 @@ pub async fn git_checkout(
             .with_context(|| format!("failed to create {}", temp_dir.display()))?;
 
         let repository = parse_git_repository_url(&repository)?;
-        let mut prepare_fetch = gix::clone::PrepareFetch::new(
-            repository,
-            &temp_dir,
-            gix::create::Kind::WithWorktree,
-            gix::create::Options::default(),
-            gix::open::Options::default(),
-        )?
-        .with_ref_name(Some(reference.as_str()))
-        .map_err(anyhow::Error::from)?;
-
-        let should_interrupt = AtomicBool::new(false);
-        let (repo, _) = prepare_fetch.fetch_only(gix::progress::Discard, &should_interrupt)?;
-
         let commit_id = parse_git_commit_id(&commit)?;
-        let commit = repo.find_commit(commit_id).with_context(|| {
-            format!("commit {commit_id} not found after fetching ref {reference}")
+        checkout_git_repo(
+            &repository,
+            Some(reference.as_str()),
+            commit_id,
+            &temp_dir,
+            recurse_submodules,
+            tag_name.as_deref(),
+        )
+        .with_context(|| {
+            format!(
+                "commit {commit_id} not found after fetching ref {reference} from repository {repository}"
+            )
         })?;
-        let tree_id = commit.tree_id()?.detach();
-        let mut index = repo.index_from_tree(&tree_id)?;
 
-        let mut checkout_options =
-            repo.checkout_options(gix::worktree::stack::state::attributes::Source::IdMapping)?;
-        checkout_options.destination_is_initially_empty = true;
-
-        let finder = RepoObjectFinder { repo: repo.clone() };
-        let files_progress = gix::progress::Discard;
-        let bytes_progress = gix::progress::Discard;
-        gix::worktree::state::checkout(
-            &mut index,
-            repo.workdir()
-                .with_context(|| format!("repository {} has no workdir", temp_dir.display()))?,
-            finder,
-            &files_progress,
-            &bytes_progress,
-            &should_interrupt,
-            checkout_options,
-        )?;
-        index.write(Default::default())?;
-
-        let dot_git_dir = temp_dir.join(".git");
-        if dot_git_dir.exists() {
-            std::fs::remove_dir_all(&dot_git_dir)
-                .with_context(|| format!("failed to remove {}", dot_git_dir.display()))?;
+        if !keep_git_dir {
+            remove_git_metadata(&temp_dir)?;
         }
 
         match std::fs::rename(&temp_dir, &output_dir) {

--- a/crates/brioche-core/src/project.rs
+++ b/crates/brioche-core/src/project.rs
@@ -4,7 +4,7 @@ use std::{
     sync::Arc,
 };
 
-use analyze::{GitRefOptions, StaticOutput, StaticOutputKind, StaticQuery};
+use analyze::{GitRefOptions, StaticInclude, StaticOutput, StaticOutputKind, StaticQuery};
 use anyhow::Context as _;
 use relative_path::{PathExt as _, RelativePath, RelativePathBuf};
 
@@ -461,7 +461,11 @@ impl ProjectsInner {
                 project.dependencies.iter().map(|(dep_name, dep_ref)| {
                     let dep_hash = match dep_ref {
                         DependencyRef::WorkspaceMember { path: dep_path } => {
-                            ProjectHash::from_serializable(&ProjectEntry::WorkspaceMember { workspace: *workspace_hash, path: dep_path.clone() }).expect("failed to calculate ProjectHash")
+                            ProjectHash::from_project_entry(&ProjectEntry::WorkspaceMember {
+                                workspace: *workspace_hash,
+                                path: dep_path.clone(),
+                            })
+                            .expect("failed to calculate ProjectHash")
                         },
                         DependencyRef::Project(project_hash) => {
                             *project_hash
@@ -647,7 +651,12 @@ impl ProjectsInner {
         let Some(statics) = project.statics.get(&module_path) else {
             return Ok(None);
         };
-        let Some(Some(output)) = statics.get(static_query) else {
+        let output = statics.get(static_query).or_else(|| match static_query {
+            StaticQuery::GitRef(options) => statics.get(&StaticQuery::GitCheckout(options.clone())),
+            StaticQuery::GitCheckout(options) => statics.get(&StaticQuery::GitRef(options.clone())),
+            _ => None,
+        });
+        let Some(Some(output)) = output else {
             return Ok(None);
         };
         Ok(Some(output.clone()))
@@ -684,6 +693,106 @@ pub struct Project {
     #[serde_as(as = "HashMap<_, Vec<(_, _)>>")]
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub statics: HashMap<RelativePathBuf, BTreeMap<StaticQuery, Option<StaticOutput>>>,
+}
+
+#[serde_with::serde_as]
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct HashableProject {
+    definition: ProjectDefinition,
+    dependencies: HashMap<String, DependencyRef>,
+    modules: HashMap<RelativePathBuf, FileId>,
+    #[serde_as(as = "HashMap<_, Vec<(_, _)>>")]
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    statics: HashMap<RelativePathBuf, BTreeMap<HashableStaticQuery, Option<StaticOutput>>>,
+}
+
+impl From<&Project> for HashableProject {
+    fn from(project: &Project) -> Self {
+        let statics = project
+            .statics
+            .iter()
+            .map(|(path, statics)| {
+                let statics = statics
+                    .iter()
+                    .map(|(query, output)| (HashableStaticQuery::from(query), output.clone()))
+                    .collect();
+                (path.clone(), statics)
+            })
+            .collect();
+
+        Self {
+            definition: project.definition.clone(),
+            dependencies: project.dependencies.clone(),
+            modules: project.modules.clone(),
+            statics,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, serde::Serialize)]
+#[serde(tag = "type")]
+#[serde(rename_all = "snake_case")]
+enum HashableStaticQuery {
+    Include(StaticInclude),
+    Glob { patterns: Vec<String> },
+    Download { url: url::Url },
+    GitRef(GitRefOptions),
+}
+
+impl From<&StaticQuery> for HashableStaticQuery {
+    fn from(query: &StaticQuery) -> Self {
+        match query {
+            StaticQuery::Include(include) => Self::Include(include.clone()),
+            StaticQuery::Glob { patterns } => Self::Glob {
+                patterns: patterns.clone(),
+            },
+            StaticQuery::Download { url } => Self::Download { url: url.clone() },
+            StaticQuery::GitRef(options) | StaticQuery::GitCheckout(options) => {
+                Self::GitRef(options.clone())
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(tag = "type")]
+#[serde(rename_all = "snake_case")]
+enum HashableProjectEntry {
+    WorkspaceMember {
+        workspace: WorkspaceHash,
+        path: RelativePathBuf,
+    },
+    #[serde(untagged)]
+    Project(HashableProject),
+}
+
+impl From<&ProjectEntry> for HashableProjectEntry {
+    fn from(project_entry: &ProjectEntry) -> Self {
+        match project_entry {
+            ProjectEntry::WorkspaceMember { workspace, path } => Self::WorkspaceMember {
+                workspace: *workspace,
+                path: path.clone(),
+            },
+            ProjectEntry::Project(project) => Self::Project(HashableProject::from(&**project)),
+        }
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+struct HashableWorkspace {
+    members: BTreeMap<RelativePathBuf, HashableProject>,
+}
+
+impl From<&Workspace> for HashableWorkspace {
+    fn from(workspace: &Workspace) -> Self {
+        let members = workspace
+            .members
+            .iter()
+            .map(|(path, project)| (path.clone(), HashableProject::from(&**project)))
+            .collect();
+        Self { members }
+    }
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -753,8 +862,16 @@ impl ProjectHash {
         Ok(Self(hash))
     }
 
+    pub fn from_project(project: &Project) -> anyhow::Result<Self> {
+        Self::from_serializable(&HashableProject::from(project))
+    }
+
+    pub fn from_project_entry(project_entry: &ProjectEntry) -> anyhow::Result<Self> {
+        Self::from_serializable(&HashableProjectEntry::from(project_entry))
+    }
+
     pub fn validate_matches(&self, project: &Project) -> anyhow::Result<()> {
-        let actual_hash = Self::from_serializable(project)?;
+        let actual_hash = Self::from_project(project)?;
         anyhow::ensure!(
             self == &actual_hash,
             "project hash does not match expected hash"
@@ -920,8 +1037,12 @@ impl WorkspaceHash {
         Ok(Self(hash))
     }
 
+    pub fn from_workspace(workspace: &Workspace) -> anyhow::Result<Self> {
+        Self::from_serializable(&HashableWorkspace::from(workspace))
+    }
+
     pub fn validate_matches(&self, workspace: &Workspace) -> anyhow::Result<()> {
-        let actual_hash = Self::from_serializable(workspace)?;
+        let actual_hash = Self::from_workspace(workspace)?;
         anyhow::ensure!(
             self == &actual_hash,
             "workspace hash does not match expected hash"
@@ -1032,7 +1153,8 @@ fn project_lockfile(project: &Project) -> Lockfile {
 
                 downloads.insert(url.clone(), hash.clone());
             }
-            StaticQuery::GitRef(GitRefOptions { repository, ref_ }) => {
+            StaticQuery::GitRef(GitRefOptions { repository, ref_ })
+            | StaticQuery::GitCheckout(GitRefOptions { repository, ref_ }) => {
                 let Some(StaticOutput::Kind(StaticOutputKind::GitRef { commit })) = output else {
                     continue;
                 };

--- a/crates/brioche-core/src/project.rs
+++ b/crates/brioche-core/src/project.rs
@@ -4,7 +4,9 @@ use std::{
     sync::Arc,
 };
 
-use analyze::{GitRefOptions, StaticInclude, StaticOutput, StaticOutputKind, StaticQuery};
+use analyze::{
+    GitCheckoutQuery, GitRefOptions, StaticInclude, StaticOutput, StaticOutputKind, StaticQuery,
+};
 use anyhow::Context as _;
 use relative_path::{PathExt as _, RelativePath, RelativePathBuf};
 
@@ -652,8 +654,15 @@ impl ProjectsInner {
             return Ok(None);
         };
         let output = statics.get(static_query).or_else(|| match static_query {
-            StaticQuery::GitRef(options) => statics.get(&StaticQuery::GitCheckout(options.clone())),
-            StaticQuery::GitCheckout(options) => statics.get(&StaticQuery::GitRef(options.clone())),
+            StaticQuery::GitRef(options) => statics.iter().find_map(|(query, output)| {
+                let StaticQuery::GitCheckout(checkout) = query else {
+                    return None;
+                };
+                (checkout.git_ref_options() == *options).then_some(output)
+            }),
+            StaticQuery::GitCheckout(options) => {
+                statics.get(&StaticQuery::GitRef(options.git_ref_options()))
+            }
             _ => None,
         });
         let Some(Some(output)) = output else {
@@ -748,10 +757,33 @@ impl From<&StaticQuery> for HashableStaticQuery {
                 patterns: patterns.clone(),
             },
             StaticQuery::Download { url } => Self::Download { url: url.clone() },
-            StaticQuery::GitRef(options) | StaticQuery::GitCheckout(options) => {
-                Self::GitRef(options.clone())
-            }
+            StaticQuery::GitRef(options) => Self::GitRef(options.clone()),
+            StaticQuery::GitCheckout(options) => Self::GitRef(options.git_ref_options()),
         }
+    }
+}
+
+impl From<&GitCheckoutQuery> for GitRefOptions {
+    fn from(value: &GitCheckoutQuery) -> Self {
+        value.git_ref_options()
+    }
+}
+
+impl From<GitCheckoutQuery> for GitRefOptions {
+    fn from(value: GitCheckoutQuery) -> Self {
+        value.git_ref_options()
+    }
+}
+
+impl PartialEq<GitRefOptions> for GitCheckoutQuery {
+    fn eq(&self, other: &GitRefOptions) -> bool {
+        self.repository == other.repository && self.ref_ == other.ref_
+    }
+}
+
+impl PartialEq<GitCheckoutQuery> for GitRefOptions {
+    fn eq(&self, other: &GitCheckoutQuery) -> bool {
+        other == self
     }
 }
 
@@ -1153,8 +1185,20 @@ fn project_lockfile(project: &Project) -> Lockfile {
 
                 downloads.insert(url.clone(), hash.clone());
             }
-            StaticQuery::GitRef(GitRefOptions { repository, ref_ })
-            | StaticQuery::GitCheckout(GitRefOptions { repository, ref_ }) => {
+            StaticQuery::GitRef(GitRefOptions { repository, ref_ }) => {
+                let Some(StaticOutput::Kind(StaticOutputKind::GitRef { commit })) = output else {
+                    continue;
+                };
+
+                let repo_refs: &mut BTreeMap<_, _> =
+                    git_refs.entry(repository.clone()).or_default();
+                repo_refs.insert(ref_.clone(), commit.clone());
+            }
+            StaticQuery::GitCheckout(GitCheckoutQuery {
+                repository,
+                ref_,
+                options: _,
+            }) => {
                 let Some(StaticOutput::Kind(StaticOutputKind::GitRef { commit })) = output else {
                     continue;
                 };

--- a/crates/brioche-core/src/project/analyze.rs
+++ b/crates/brioche-core/src/project/analyze.rs
@@ -74,6 +74,7 @@ pub enum StaticQuery {
     Glob { patterns: Vec<String> },
     Download { url: url::Url },
     GitRef(GitRefOptions),
+    GitCheckout(GitRefOptions),
 }
 
 impl StaticQuery {
@@ -106,7 +107,6 @@ impl StaticQuery {
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize)]
 pub struct GitRefOptions {
     pub repository: url::Url,
-
     #[serde(rename = "ref")]
     pub ref_: String,
 }
@@ -684,11 +684,17 @@ where
                     };
 
                     // Parse the options
-                    let options = serde_json::from_value(options).with_context(|| {
+                    let options: GitRefOptions = serde_json::from_value(options).with_context(|| {
                         format!("{location}: invalid options for Brioche.{callee_member_text}, expected an object with the keys `repository` and `ref`")
                     })?;
 
-                    Ok(Some(StaticQuery::GitRef(options)))
+                    let static_query = match callee_member_text {
+                        "gitRef" => StaticQuery::GitRef(options),
+                        "gitCheckout" => StaticQuery::GitCheckout(options),
+                        _ => unreachable!("unexpected callee member text"),
+                    };
+
+                    Ok(Some(static_query))
                 }
                 _ => Ok(None),
             }

--- a/crates/brioche-core/src/project/analyze.rs
+++ b/crates/brioche-core/src/project/analyze.rs
@@ -74,7 +74,7 @@ pub enum StaticQuery {
     Glob { patterns: Vec<String> },
     Download { url: url::Url },
     GitRef(GitRefOptions),
-    GitCheckout(GitRefOptions),
+    GitCheckout(GitCheckoutQuery),
 }
 
 impl StaticQuery {
@@ -109,6 +109,57 @@ pub struct GitRefOptions {
     pub repository: url::Url,
     #[serde(rename = "ref")]
     pub ref_: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GitCheckoutQuery {
+    pub repository: url::Url,
+    #[serde(rename = "ref")]
+    pub ref_: String,
+    #[serde(default)]
+    pub options: GitCheckoutOptions,
+}
+
+impl GitCheckoutQuery {
+    #[must_use]
+    pub fn git_ref_options(&self) -> GitRefOptions {
+        GitRefOptions {
+            repository: self.repository.clone(),
+            ref_: self.ref_.clone(),
+        }
+    }
+}
+
+#[derive(
+    Debug, Default, Clone, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
+)]
+#[serde(rename_all = "camelCase")]
+pub struct GitCheckoutOptions {
+    #[serde(default)]
+    pub keep_git_dir: bool,
+    #[serde(default)]
+    pub submodules: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tag: Option<GitCheckoutTag>,
+}
+
+impl GitCheckoutOptions {
+    pub fn normalized_tag(&self, ref_: &str) -> Option<String> {
+        match &self.tag {
+            None => None,
+            Some(GitCheckoutTag::Name(tag)) => Some(tag.clone()),
+            Some(GitCheckoutTag::UseRef(true)) => Some(ref_.to_string()),
+            Some(GitCheckoutTag::UseRef(false)) => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize)]
+#[serde(untagged)]
+pub enum GitCheckoutTag {
+    UseRef(bool),
+    Name(String),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -684,13 +735,23 @@ where
                     };
 
                     // Parse the options
-                    let options: GitRefOptions = serde_json::from_value(options).with_context(|| {
-                        format!("{location}: invalid options for Brioche.{callee_member_text}, expected an object with the keys `repository` and `ref`")
-                    })?;
-
                     let static_query = match callee_member_text {
-                        "gitRef" => StaticQuery::GitRef(options),
-                        "gitCheckout" => StaticQuery::GitCheckout(options),
+                        "gitRef" => {
+                            let options: GitRefOptions =
+                                serde_json::from_value(options).with_context(|| {
+                                    format!("{location}: invalid options for Brioche.{callee_member_text}, expected an object with the keys `repository` and `ref`")
+                                })?;
+
+                            StaticQuery::GitRef(options)
+                        }
+                        "gitCheckout" => {
+                            let options: GitCheckoutQuery =
+                                serde_json::from_value(options).with_context(|| {
+                                    format!("{location}: invalid options for Brioche.{callee_member_text}, expected an object with the keys `repository`, `ref`, and optional `options`")
+                                })?;
+
+                            StaticQuery::GitCheckout(options)
+                        }
                         _ => unreachable!("unexpected callee member text"),
                     };
 

--- a/crates/brioche-core/src/project/artifact.rs
+++ b/crates/brioche-core/src/project/artifact.rs
@@ -168,7 +168,7 @@ pub async fn save_projects_from_artifact(
                         workspace: workspace_hash,
                         path: member_path,
                     };
-                    let project_entry_hash = ProjectHash::from_serializable(&project_entry)?;
+                    let project_entry_hash = ProjectHash::from_project_entry(&project_entry)?;
                     anyhow::ensure!(
                         project_hash == project_entry_hash,
                         "project hash {project_hash} did not match hash for workspace member for symlink {target}"
@@ -305,7 +305,9 @@ async fn project_artifact(
                     )
                     .await?;
                 }
-                StaticQuery::Download { .. } | StaticQuery::GitRef { .. } => {
+                StaticQuery::Download { .. }
+                | StaticQuery::GitRef(..)
+                | StaticQuery::GitCheckout(..) => {
                     // Nothing to add
                 }
             }

--- a/crates/brioche-core/src/project/load.rs
+++ b/crates/brioche-core/src/project/load.rs
@@ -926,9 +926,7 @@ async fn resolve_locked_git_ref(
                 })?
         }
         (None, ProjectLocking::Locked) => {
-            anyhow::bail!(
-                "commit for git repo '{repository}' ref '{ref_}' not found in lockfile"
-            );
+            anyhow::bail!("commit for git repo '{repository}' ref '{ref_}' not found in lockfile");
         }
     };
 

--- a/crates/brioche-core/src/project/load.rs
+++ b/crates/brioche-core/src/project/load.rs
@@ -903,6 +903,45 @@ struct WorkspaceInfo {
     path: PathBuf,
 }
 
+async fn resolve_locked_git_ref(
+    locking: ProjectLocking,
+    lockfile: &mut LockfileState,
+    repository: &url::Url,
+    ref_: &str,
+) -> anyhow::Result<String> {
+    let current_commit = lockfile.current_lockfile.as_ref().and_then(|lockfile| {
+        lockfile
+            .git_refs
+            .get(repository)
+            .and_then(|repo_refs| repo_refs.get(ref_))
+    });
+
+    let commit = match (current_commit, locking) {
+        (Some(commit), _) => commit.clone(),
+        (None, ProjectLocking::Unlocked) => {
+            crate::download::fetch_git_commit_for_ref(repository, ref_)
+                .await
+                .with_context(|| {
+                    format!("failed to fetch ref '{ref_}' from git repo '{repository}'")
+                })?
+        }
+        (None, ProjectLocking::Locked) => {
+            anyhow::bail!(
+                "commit for git repo '{repository}' ref '{ref_}' not found in lockfile"
+            );
+        }
+    };
+
+    let repo_refs = lockfile
+        .fresh_lockfile
+        .git_refs
+        .entry(repository.clone())
+        .or_default();
+    repo_refs.insert(ref_.to_string(), commit.clone());
+
+    Ok(commit)
+}
+
 async fn resolve_static(
     brioche: &Brioche,
     project_root: &Path,
@@ -1160,72 +1199,12 @@ async fn resolve_static(
             }))
         }
         StaticQuery::GitRef(GitRefOptions { repository, ref_ }) => {
-            let current_commit = lockfile.current_lockfile.as_ref().and_then(|lockfile| {
-                lockfile
-                    .git_refs
-                    .get(repository)
-                    .and_then(|repo_refs| repo_refs.get(ref_))
-            });
-
-            let commit = match (current_commit, locking) {
-                (Some(commit), _) => commit.clone(),
-                (None, ProjectLocking::Unlocked) => {
-                    // Fetch the current commit hash of the git ref from the repo
-                    crate::download::fetch_git_commit_for_ref(repository, ref_)
-                        .await
-                        .with_context(|| {
-                            format!("failed to fetch ref '{ref_}' from git repo '{repository}'")
-                        })?
-                }
-                (None, ProjectLocking::Locked) => {
-                    // Error out if the git ref isn't in the lockfile but where
-                    // updating the lockfile is disabled
-                    anyhow::bail!(
-                        "commit for git repo '{repository}' ref '{ref_}' not found in lockfile"
-                    );
-                }
-            };
-
-            // Update the new lockfile with the commit
-            let repo_refs = lockfile
-                .fresh_lockfile
-                .git_refs
-                .entry(repository.clone())
-                .or_default();
-            repo_refs.insert(ref_.clone(), commit.clone());
+            let commit = resolve_locked_git_ref(locking, lockfile, repository, ref_).await?;
 
             Ok(StaticOutput::Kind(StaticOutputKind::GitRef { commit }))
         }
         StaticQuery::GitCheckout(GitRefOptions { repository, ref_ }) => {
-            let current_commit = lockfile.current_lockfile.as_ref().and_then(|lockfile| {
-                lockfile
-                    .git_refs
-                    .get(repository)
-                    .and_then(|repo_refs| repo_refs.get(ref_))
-            });
-
-            let commit = match (current_commit, locking) {
-                (Some(commit), _) => commit.clone(),
-                (None, ProjectLocking::Unlocked) => {
-                    crate::download::fetch_git_commit_for_ref(repository, ref_)
-                        .await
-                        .with_context(|| {
-                            format!("failed to fetch ref '{ref_}' from git repo '{repository}'")
-                        })?
-                }
-                (None, ProjectLocking::Locked) => {
-                    anyhow::bail!(
-                        "commit for git repo '{repository}' ref '{ref_}' not found in lockfile"
-                    );
-                }
-            };
-
-            let repo_refs = lockfile
-                .fresh_lockfile
-                .git_refs
-                .entry(repository.clone())
-                .or_default();
-            repo_refs.insert(ref_.clone(), commit.clone());
+            let commit = resolve_locked_git_ref(locking, lockfile, repository, ref_).await?;
 
             Ok(StaticOutput::Kind(StaticOutputKind::GitRef { commit }))
         }

--- a/crates/brioche-core/src/project/load.rs
+++ b/crates/brioche-core/src/project/load.rs
@@ -1201,8 +1201,9 @@ async fn resolve_static(
 
             Ok(StaticOutput::Kind(StaticOutputKind::GitRef { commit }))
         }
-        StaticQuery::GitCheckout(GitRefOptions { repository, ref_ }) => {
-            let commit = resolve_locked_git_ref(locking, lockfile, repository, ref_).await?;
+        StaticQuery::GitCheckout(query) => {
+            let commit =
+                resolve_locked_git_ref(locking, lockfile, &query.repository, &query.ref_).await?;
 
             Ok(StaticOutput::Kind(StaticOutputKind::GitRef { commit }))
         }

--- a/crates/brioche-core/src/project/load.rs
+++ b/crates/brioche-core/src/project/load.rs
@@ -519,7 +519,7 @@ async fn load_project_inner(
         if group_projects.len() == 1 {
             let (node, project) = group_projects.into_iter().next().unwrap();
             let project_entry = ProjectEntry::Project(project);
-            let project_hash = ProjectHash::from_serializable(&project_entry)?;
+            let project_hash = ProjectHash::from_project_entry(&project_entry)?;
 
             group_project_entries.push((node, project_entry, project_hash));
         } else {
@@ -542,7 +542,7 @@ async fn load_project_inner(
                     })
                     .collect(),
             };
-            let workspace_hash = WorkspaceHash::from_serializable(&group_workspace)?;
+            let workspace_hash = WorkspaceHash::from_workspace(&group_workspace)?;
 
             workspaces.push((workspace_hash, Arc::new(group_workspace)));
             for node in group_projects.keys() {
@@ -552,7 +552,7 @@ async fn load_project_inner(
                     workspace: workspace_hash,
                     path: member_path.clone(),
                 };
-                let project_hash = ProjectHash::from_serializable(&project_entry)?;
+                let project_hash = ProjectHash::from_project_entry(&project_entry)?;
 
                 group_project_entries.push((*node, project_entry, project_hash));
             }
@@ -1187,6 +1187,39 @@ async fn resolve_static(
             };
 
             // Update the new lockfile with the commit
+            let repo_refs = lockfile
+                .fresh_lockfile
+                .git_refs
+                .entry(repository.clone())
+                .or_default();
+            repo_refs.insert(ref_.clone(), commit.clone());
+
+            Ok(StaticOutput::Kind(StaticOutputKind::GitRef { commit }))
+        }
+        StaticQuery::GitCheckout(GitRefOptions { repository, ref_ }) => {
+            let current_commit = lockfile.current_lockfile.as_ref().and_then(|lockfile| {
+                lockfile
+                    .git_refs
+                    .get(repository)
+                    .and_then(|repo_refs| repo_refs.get(ref_))
+            });
+
+            let commit = match (current_commit, locking) {
+                (Some(commit), _) => commit.clone(),
+                (None, ProjectLocking::Unlocked) => {
+                    crate::download::fetch_git_commit_for_ref(repository, ref_)
+                        .await
+                        .with_context(|| {
+                            format!("failed to fetch ref '{ref_}' from git repo '{repository}'")
+                        })?
+                }
+                (None, ProjectLocking::Locked) => {
+                    anyhow::bail!(
+                        "commit for git repo '{repository}' ref '{ref_}' not found in lockfile"
+                    );
+                }
+            };
+
             let repo_refs = lockfile
                 .fresh_lockfile
                 .git_refs

--- a/crates/brioche-core/src/script/bridge.rs
+++ b/crates/brioche-core/src/script/bridge.rs
@@ -14,22 +14,51 @@ use crate::{
     blob::BlobHash,
     project::{
         ProjectHash, ProjectLocking, ProjectValidation, Projects,
-        analyze::{GitRefOptions, StaticInclude, StaticOutput, StaticOutputKind, StaticQuery},
+        analyze::{
+            GitCheckoutQuery, GitRefOptions, StaticInclude, StaticOutput, StaticOutputKind,
+            StaticQuery,
+        },
     },
     recipe::{Artifact, DownloadRecipe, Recipe, WithMeta},
 };
 
 use super::specifier::{self, BriocheImportSpecifier, BriocheModuleSpecifier};
 
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+struct ResolvedGitCheckoutOptions {
+    keep_git_dir: bool,
+    submodules: bool,
+    tag: Option<String>,
+}
+
+fn resolve_git_checkout_options(
+    query: &GitCheckoutQuery,
+) -> anyhow::Result<ResolvedGitCheckoutOptions> {
+    let tag = query.options.normalized_tag(&query.ref_);
+    anyhow::ensure!(
+        query.options.keep_git_dir || tag.is_none(),
+        "Cannot use 'tag' without 'keepGitDir' enabled"
+    );
+
+    Ok(ResolvedGitCheckoutOptions {
+        keep_git_dir: query.options.keep_git_dir,
+        submodules: query.options.submodules,
+        tag,
+    })
+}
+
 fn git_checkout_output_dir(
     brioche: &Brioche,
-    repository: &url::Url,
+    query: &GitCheckoutQuery,
     commit: &str,
 ) -> anyhow::Result<PathBuf> {
+    let options = resolve_git_checkout_options(query)?;
     let mut cache_key_hasher = crate::Hasher::new_sha256();
-    cache_key_hasher.update(repository.as_str().as_bytes());
+    cache_key_hasher.update(query.repository.as_str().as_bytes());
     cache_key_hasher.update(b"\0");
     cache_key_hasher.update(commit.as_bytes());
+    cache_key_hasher.update(b"\0");
+    cache_key_hasher.update(&serde_json::to_vec(&options)?);
     let cache_key = match cache_key_hasher.finish()? {
         crate::Hash::Sha256 { value } => hex::encode(value),
     };
@@ -39,17 +68,28 @@ fn git_checkout_output_dir(
 
 async fn ensure_git_checkout(
     brioche: &Brioche,
-    repository: &url::Url,
-    ref_: &str,
+    query: &GitCheckoutQuery,
     commit: &str,
 ) -> anyhow::Result<PathBuf> {
-    let output_dir = git_checkout_output_dir(brioche, repository, commit)?;
+    let options = resolve_git_checkout_options(query)?;
+    let output_dir = git_checkout_output_dir(brioche, query, commit)?;
     if !tokio::fs::try_exists(&output_dir).await? {
-        crate::download::git_checkout(repository, ref_, commit, &output_dir)
-            .await
-            .with_context(|| {
-                format!("failed to checkout ref '{ref_}' ({commit}) from git repo '{repository}'")
-            })?;
+        crate::download::git_checkout(
+            &query.repository,
+            &query.ref_,
+            commit,
+            &output_dir,
+            options.submodules,
+            options.keep_git_dir,
+            options.tag.as_deref(),
+        )
+        .await
+        .with_context(|| {
+            format!(
+                "failed to checkout ref '{}' ({commit}) from git repo '{}'",
+                query.ref_, query.repository
+            )
+        })?;
     }
 
     Ok(output_dir)
@@ -83,11 +123,10 @@ async fn import_directory_recipe(brioche: &Brioche, path: &Path) -> anyhow::Resu
 
 async fn load_git_checkout_recipe(
     brioche: &Brioche,
-    repository: &url::Url,
-    ref_: &str,
+    query: &GitCheckoutQuery,
     commit: &str,
 ) -> anyhow::Result<Recipe> {
-    let output_dir = ensure_git_checkout(brioche, repository, ref_, commit).await?;
+    let output_dir = ensure_git_checkout(brioche, query, commit).await?;
     import_directory_recipe(brioche, &output_dir).await
 }
 
@@ -323,7 +362,7 @@ impl RuntimeBridge {
                                         StaticQuery::GitRef(GitRefOptions { repository, ref_ }) => {
                                             anyhow::anyhow!("failed to resolve {callee}({{ repository: \"{repository}\", ref: {ref_:?} }}) from {specifier}, were the repository and ref values passed in as string literals?")
                                         }
-                                        StaticQuery::GitCheckout(GitRefOptions { repository, ref_ }) => {
+                                        StaticQuery::GitCheckout(GitCheckoutQuery { repository, ref_, options: _ }) => {
                                             anyhow::anyhow!("failed to resolve {callee}({{ repository: \"{repository}\", ref: {ref_:?} }}) from {specifier}, were the repository and ref values passed in as string literals?")
                                         }
                                     };
@@ -367,13 +406,8 @@ impl RuntimeBridge {
                                             repository: git_ref.repository,
                                             commit,
                                         },
-                                        StaticQuery::GitCheckout(git_ref) => {
-                                            let recipe = load_git_checkout_recipe(
-                                                &brioche,
-                                                &git_ref.repository,
-                                                &git_ref.ref_,
-                                                &commit,
-                                            )
+                                        StaticQuery::GitCheckout(git_checkout) => {
+                                            let recipe = load_git_checkout_recipe(&brioche, &git_checkout, &commit)
                                             .await;
                                             let recipe = match recipe {
                                                 Ok(recipe) => recipe,

--- a/crates/brioche-core/src/script/bridge.rs
+++ b/crates/brioche-core/src/script/bridge.rs
@@ -1,4 +1,4 @@
-use std::{path::PathBuf, sync::Arc};
+use std::{collections::HashMap, path::PathBuf, sync::Arc};
 
 use anyhow::Context as _;
 use joinery::JoinableIterator as _;
@@ -16,6 +16,57 @@ use crate::{
 };
 
 use super::specifier::{self, BriocheImportSpecifier, BriocheModuleSpecifier};
+
+async fn load_git_checkout_recipe(
+    brioche: &Brioche,
+    repository: &url::Url,
+    ref_: &str,
+    commit: &str,
+) -> anyhow::Result<Recipe> {
+    let mut cache_key_hasher = crate::Hasher::new_sha256();
+    cache_key_hasher.update(repository.as_str().as_bytes());
+    cache_key_hasher.update(b"\0");
+    cache_key_hasher.update(commit.as_bytes());
+    let cache_key = match cache_key_hasher.finish()? {
+        crate::Hash::Sha256 { value } => hex::encode(value),
+    };
+
+    let output_dir = brioche.data_dir.join("git-checkouts").join(cache_key);
+    if !tokio::fs::try_exists(&output_dir).await? {
+        crate::download::git_checkout(repository, ref_, commit, &output_dir)
+            .await
+            .with_context(|| {
+                format!("failed to checkout ref '{ref_}' ({commit}) from git repo '{repository}'")
+            })?;
+    }
+
+    let mut saved_paths = HashMap::default();
+    let meta = Arc::default();
+    let artifact = crate::input::create_input(
+        brioche,
+        crate::input::InputOptions {
+            input_path: &output_dir,
+            remove_input: false,
+            resource_dir: None,
+            input_resource_dirs: &[],
+            saved_paths: &mut saved_paths,
+            meta: &meta,
+        },
+    )
+    .await?;
+
+    let crate::recipe::Artifact::Directory(_) = &artifact.value else {
+        anyhow::bail!(
+            "git checkout at {} was not a directory",
+            output_dir.display()
+        );
+    };
+
+    let recipe = crate::recipe::Recipe::from(artifact.value);
+    crate::recipe::save_recipes(brioche, [&recipe]).await?;
+
+    Ok(recipe)
+}
 
 /// A type used to call Brioche functions across Tokio runtimes. This is used
 /// to interact with Brioche from JavaScript code, due to restrictions that
@@ -249,6 +300,9 @@ impl RuntimeBridge {
                                         StaticQuery::GitRef(GitRefOptions { repository, ref_ }) => {
                                             anyhow::anyhow!("failed to resolve {callee}({{ repository: \"{repository}\", ref: {ref_:?} }}) from {specifier}, were the repository and ref values passed in as string literals?")
                                         }
+                                        StaticQuery::GitCheckout(GitRefOptions { repository, ref_ }) => {
+                                            anyhow::anyhow!("failed to resolve {callee}({{ repository: \"{repository}\", ref: {ref_:?} }}) from {specifier}, were the repository and ref values passed in as string literals?")
+                                        }
                                     };
                                     let _ = result_tx.send(Err(error));
                                     return;
@@ -285,14 +339,33 @@ impl RuntimeBridge {
                                     }))
                                 }
                                 StaticOutput::Kind(StaticOutputKind::GitRef { commit }) => {
-                                    let StaticQuery::GitRef(git_ref) = options.query else {
-                                        let _ = result_tx.send(Err(anyhow::anyhow!("invalid 'git_ref' static output kind for non-git ref static")));
-                                        return;
-                                    };
+                                    match options.query {
+                                        StaticQuery::GitRef(git_ref) => GetStaticResult::GitRef {
+                                            repository: git_ref.repository,
+                                            commit,
+                                        },
+                                        StaticQuery::GitCheckout(git_ref) => {
+                                            let recipe = load_git_checkout_recipe(
+                                                &brioche,
+                                                &git_ref.repository,
+                                                &git_ref.ref_,
+                                                &commit,
+                                            )
+                                            .await;
+                                            let recipe = match recipe {
+                                                Ok(recipe) => recipe,
+                                                Err(error) => {
+                                                    let _ = result_tx.send(Err(error));
+                                                    return;
+                                                }
+                                            };
 
-                                    GetStaticResult::GitRef {
-                                        repository: git_ref.repository,
-                                        commit,
+                                            GetStaticResult::Recipe(recipe)
+                                        }
+                                        _ => {
+                                            let _ = result_tx.send(Err(anyhow::anyhow!("invalid 'git_ref' static output kind for non-git static")));
+                                            return;
+                                        }
                                     }
                                 }
                             };
@@ -532,6 +605,7 @@ impl GetStaticOptions {
             StaticQuery::Glob { .. } => "Brioche.glob",
             StaticQuery::Download { .. } => "Brioche.download",
             StaticQuery::GitRef(..) => "Brioche.gitRef",
+            StaticQuery::GitCheckout(..) => "Brioche.gitCheckout",
         }
     }
 }

--- a/crates/brioche-core/src/script/bridge.rs
+++ b/crates/brioche-core/src/script/bridge.rs
@@ -1,4 +1,8 @@
-use std::{collections::HashMap, path::PathBuf, sync::Arc};
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 use anyhow::Context as _;
 use joinery::JoinableIterator as _;
@@ -17,12 +21,11 @@ use crate::{
 
 use super::specifier::{self, BriocheImportSpecifier, BriocheModuleSpecifier};
 
-async fn load_git_checkout_recipe(
+fn git_checkout_output_dir(
     brioche: &Brioche,
     repository: &url::Url,
-    ref_: &str,
     commit: &str,
-) -> anyhow::Result<Recipe> {
+) -> anyhow::Result<PathBuf> {
     let mut cache_key_hasher = crate::Hasher::new_sha256();
     cache_key_hasher.update(repository.as_str().as_bytes());
     cache_key_hasher.update(b"\0");
@@ -31,7 +34,16 @@ async fn load_git_checkout_recipe(
         crate::Hash::Sha256 { value } => hex::encode(value),
     };
 
-    let output_dir = brioche.data_dir.join("git-checkouts").join(cache_key);
+    Ok(brioche.data_dir.join("git-checkouts").join(cache_key))
+}
+
+async fn ensure_git_checkout(
+    brioche: &Brioche,
+    repository: &url::Url,
+    ref_: &str,
+    commit: &str,
+) -> anyhow::Result<PathBuf> {
+    let output_dir = git_checkout_output_dir(brioche, repository, commit)?;
     if !tokio::fs::try_exists(&output_dir).await? {
         crate::download::git_checkout(repository, ref_, commit, &output_dir)
             .await
@@ -40,12 +52,16 @@ async fn load_git_checkout_recipe(
             })?;
     }
 
+    Ok(output_dir)
+}
+
+async fn import_directory_recipe(brioche: &Brioche, path: &Path) -> anyhow::Result<Recipe> {
     let mut saved_paths = HashMap::default();
     let meta = Arc::default();
     let artifact = crate::input::create_input(
         brioche,
         crate::input::InputOptions {
-            input_path: &output_dir,
+            input_path: path,
             remove_input: false,
             resource_dir: None,
             input_resource_dirs: &[],
@@ -56,16 +72,23 @@ async fn load_git_checkout_recipe(
     .await?;
 
     let crate::recipe::Artifact::Directory(_) = &artifact.value else {
-        anyhow::bail!(
-            "git checkout at {} was not a directory",
-            output_dir.display()
-        );
+        anyhow::bail!("git checkout at {} was not a directory", path.display());
     };
 
     let recipe = crate::recipe::Recipe::from(artifact.value);
     crate::recipe::save_recipes(brioche, [&recipe]).await?;
 
     Ok(recipe)
+}
+
+async fn load_git_checkout_recipe(
+    brioche: &Brioche,
+    repository: &url::Url,
+    ref_: &str,
+    commit: &str,
+) -> anyhow::Result<Recipe> {
+    let output_dir = ensure_git_checkout(brioche, repository, ref_, commit).await?;
+    import_directory_recipe(brioche, &output_dir).await
 }
 
 /// A type used to call Brioche functions across Tokio runtimes. This is used

--- a/crates/brioche-core/tests/script_eval.rs
+++ b/crates/brioche-core/tests/script_eval.rs
@@ -3,6 +3,108 @@ use brioche_core::{
     script::{evaluate::evaluate, initialize_js_platform},
 };
 
+fn test_git_signature() -> gix::actor::Signature {
+    gix::actor::Signature {
+        name: "Brioche Test".into(),
+        email: "brioche@example.com".into(),
+        time: gix::date::Time {
+            seconds: 0,
+            offset: 0,
+        },
+    }
+}
+
+fn create_test_commit(
+    repo: &gix::Repository,
+    files: &[(&str, &str)],
+    parent: Option<gix::hash::ObjectId>,
+    message: &str,
+) -> anyhow::Result<gix::hash::ObjectId> {
+    let mut entries = files
+        .iter()
+        .map(|(name, content)| {
+            let blob_id = repo
+                .write_object(gix::objs::Blob {
+                    data: content.as_bytes().to_vec(),
+                })?
+                .detach();
+
+            anyhow::Ok(gix::objs::tree::Entry {
+                mode: gix::objs::tree::EntryKind::Blob.into(),
+                filename: (*name).into(),
+                oid: blob_id,
+            })
+        })
+        .collect::<anyhow::Result<Vec<_>>>()?;
+    entries.sort();
+
+    let tree_id = repo.write_object(gix::objs::Tree { entries })?.detach();
+    let signature = test_git_signature();
+    let commit_id = repo
+        .write_object(gix::objs::Commit {
+            tree: tree_id,
+            parents: parent.into_iter().collect(),
+            author: signature.clone(),
+            committer: signature,
+            encoding: None,
+            message: message.into(),
+            extra_headers: Vec::new(),
+        })?
+        .detach();
+
+    Ok(commit_id)
+}
+
+fn create_test_git_repo(
+    repo_dir: &std::path::Path,
+) -> anyhow::Result<(url::Url, String, String, String)> {
+    let repo = gix::init_bare(repo_dir)?;
+
+    let main_commit = create_test_commit(&repo, &[("shared.txt", "main\n")], None, "main")?;
+    repo.reference(
+        "refs/heads/main",
+        main_commit,
+        gix::refs::transaction::PreviousValue::Any,
+        "test main",
+    )?;
+
+    let feature1_commit = create_test_commit(
+        &repo,
+        &[("feature.txt", "feature1\n"), ("shared.txt", "main\n")],
+        Some(main_commit),
+        "feature1",
+    )?;
+    repo.reference(
+        "refs/heads/feature1",
+        feature1_commit,
+        gix::refs::transaction::PreviousValue::Any,
+        "test feature1",
+    )?;
+
+    let feature2_commit = create_test_commit(
+        &repo,
+        &[("feature.txt", "feature2\n"), ("shared.txt", "main\n")],
+        Some(main_commit),
+        "feature2",
+    )?;
+    repo.reference(
+        "refs/heads/feature2",
+        feature2_commit,
+        gix::refs::transaction::PreviousValue::Any,
+        "test feature2",
+    )?;
+
+    let repo_url = url::Url::from_directory_path(repo_dir)
+        .map_err(|()| anyhow::anyhow!("failed to create file URL for {}", repo_dir.display()))?;
+
+    Ok((
+        repo_url,
+        main_commit.to_string(),
+        feature1_commit.to_string(),
+        feature2_commit.to_string(),
+    ))
+}
+
 #[tokio::test]
 async fn test_eval_basic() -> anyhow::Result<()> {
     let (brioche, context) = brioche_test_support::brioche_test().await;
@@ -862,76 +964,41 @@ async fn test_eval_brioche_git_ref() -> anyhow::Result<()> {
 async fn test_eval_brioche_git_checkout() -> anyhow::Result<()> {
     let (brioche, context) = brioche_test_support::brioche_test().await;
 
-    let mut mock_repo = mockito::Server::new_async().await;
-    let mock_repo_url = mock_repo.url();
+    let repo_dir = context.mkdir("repo").await;
+    let (repo_url, _, _, _) = create_test_git_repo(&repo_dir)?;
 
-    // Mock a git "handshake" server response for protocol version 2
-    let mock_git_info_refs_response = b"001e# service=git-upload-pack\n0000000eversion 2\n0000";
-    let mock_git_info_refs = mock_repo
-        .mock("GET", "/info/refs?service=git-upload-pack")
-        .with_header(
-            "Content-Type",
-            "application/x-git-upload-pack-advertisement",
-        )
-        .with_header("Cache-Control", "no-cache")
-        .with_body(mock_git_info_refs_response)
-        .expect(1)
-        .create();
-
-    // Mock a git "ls-refs" response, with one branch named "main" with a
-    // commit hash of "0123456789abcdef01234567890123456789abcd"
-    let mock_git_upload_pack_response =
-        b"003d0123456789abcdef01234567890123456789abcd refs/heads/main\n0000";
-    let mock_git_upload_pack = mock_repo
-        .mock("POST", "/git-upload-pack")
-        .with_header("Content-Type", "application/x-git-upload-pack-result")
-        .with_header("Cache-Control", "no-cache")
-        .with_body(mock_git_upload_pack_response)
-        .expect(1)
-        .create();
-
-    // From Brioche's perspective, `Brioche.gitCheckout()` is treated
-    // the same as `Brioche.gitRef()`. In practice, it will actually checkout
-    // the ref, but that's implemented at the packaging layer
     let project_dir = context.mkdir("myproject").await;
     context
         .write_file(
             "myproject/project.bri",
             r#"
+                export const project = {};
+
                 globalThis.Brioche = {
                     gitCheckout: async ({ repository, ref }) => {
-                        return await Deno.core.ops.op_brioche_get_static(
-                            import.meta.url,
-                            {
-                                type: "git_ref",
-                                repository,
-                                ref,
+                        return {
+                            briocheSerialize: async () => {
+                                return await Deno.core.ops.op_brioche_get_static(
+                                    import.meta.url,
+                                    {
+                                        type: "git_checkout",
+                                        repository,
+                                        ref,
+                                    },
+                                );
                             },
-                        );
+                        };
                     }
-                }
+                };
 
                 export default async () => {
-                    const gitCheckout = await Brioche.gitCheckout({
+                    return await Brioche.gitCheckout({
                         repository: "<REPO_URL>",
                         ref: "main",
                     });
-                    return {
-                        briocheSerialize: async () => {
-                            return {
-                                type: "create_file",
-                                content: JSON.stringify(gitCheckout),
-                                executable: false,
-                                resources: {
-                                    type: "directory",
-                                    entries: {},
-                                },
-                            };
-                        },
-                    };
                 };
             "#
-            .replace("<REPO_URL>", &mock_repo_url),
+            .replace("<REPO_URL>", repo_url.as_str()),
         )
         .await;
 
@@ -948,21 +1015,20 @@ async fn test_eval_brioche_git_checkout() -> anyhow::Result<()> {
     .await?
     .value;
 
-    let brioche_core::recipe::Recipe::CreateFile { content, .. } = resolved else {
-        panic!("expected create_file recipe, got {resolved:?}");
-    };
-
-    mock_git_info_refs.assert_async().await;
-    mock_git_upload_pack.assert_async().await;
-
-    let git_ref: serde_json::Value = serde_json::from_slice(&content)?;
     assert_eq!(
-        git_ref,
-        serde_json::json!({
-            "staticKind": "git_ref",
-            "repository": format!("{mock_repo_url}/"),
-            "commit": "0123456789abcdef01234567890123456789abcd",
-        }),
+        resolved,
+        brioche_test_support::dir(
+            &brioche,
+            [(
+                "shared.txt",
+                brioche_test_support::file(
+                    brioche_test_support::blob(&brioche, "main\n").await,
+                    false,
+                ),
+            )],
+        )
+        .await
+        .into(),
     );
 
     Ok(())
@@ -972,45 +1038,17 @@ async fn test_eval_brioche_git_checkout() -> anyhow::Result<()> {
 async fn test_eval_brioche_git_ref_and_git_checkout() -> anyhow::Result<()> {
     let (brioche, context) = brioche_test_support::brioche_test().await;
 
-    let mut mock_repo = mockito::Server::new_async().await;
-    let mock_repo_url = mock_repo.url();
+    let repo_dir = context.mkdir("repo").await;
+    let (repo_url, main_commit, feature1_commit, feature2_commit) =
+        create_test_git_repo(&repo_dir)?;
 
-    // Mock a git "handshake" server response for protocol version 2
-    // TODO: Update code so each repo only gets evaluated once
-    let mock_git_info_refs_response = b"001e# service=git-upload-pack\n0000000eversion 2\n0000";
-    let mock_git_info_refs = mock_repo
-        .mock("GET", "/info/refs?service=git-upload-pack")
-        .with_header(
-            "Content-Type",
-            "application/x-git-upload-pack-advertisement",
-        )
-        .with_header("Cache-Control", "no-cache")
-        .with_body(mock_git_info_refs_response)
-        .expect_at_least(1)
-        .create();
-
-    // Mock a git "ls-refs" response, with three branches:
-    // - "main" with commit hash "0123456789abcdef01234567890123456789abcd"
-    // - "feature1" with commit hash "abcdef0123456789abcdef012345678901234567"
-    // - "feature2" with commit hash "0000000000111111111122222222223333333333"
-    let mock_git_upload_pack_response =
-        b"003d0123456789abcdef01234567890123456789abcd refs/heads/main\n0041abcdef0123456789abcdef012345678901234567 refs/heads/feature1\n00410000000000111111111122222222223333333333 refs/heads/feature2\n0000";
-    let mock_git_upload_pack = mock_repo
-        .mock("POST", "/git-upload-pack")
-        .with_header("Content-Type", "application/x-git-upload-pack-result")
-        .with_header("Cache-Control", "no-cache")
-        .with_body(mock_git_upload_pack_response)
-        .expect_at_least(1)
-        .create();
-
-    // From Brioche's perspective, `Brioche.gitCheckout()` is treated
-    // the same as `Brioche.gitRef()`. In practice, it will actually checkout
-    // the ref, but that's implemented at the packaging layer
     let project_dir = context.mkdir("myproject").await;
     context
         .write_file(
             "myproject/project.bri",
             r#"
+                export const project = {};
+
                 globalThis.Brioche = {
                     gitRef: async ({ repository, ref }) => {
                         return await Deno.core.ops.op_brioche_get_static(
@@ -1019,20 +1057,22 @@ async fn test_eval_brioche_git_ref_and_git_checkout() -> anyhow::Result<()> {
                                 type: "git_ref",
                                 repository,
                                 ref,
-                                callee: "Brioche.gitRef",
                             },
                         );
                     },
                     gitCheckout: async ({ repository, ref }) => {
-                        return await Deno.core.ops.op_brioche_get_static(
-                            import.meta.url,
-                            {
-                                type: "git_ref",
-                                repository,
-                                ref,
-                                callee: "Brioche.gitCheckout",
+                        return {
+                            briocheSerialize: async () => {
+                                return await Deno.core.ops.op_brioche_get_static(
+                                    import.meta.url,
+                                    {
+                                        type: "git_checkout",
+                                        repository,
+                                        ref,
+                                    },
+                                );
                             },
-                        );
+                        };
                     },
                 };
 
@@ -1041,15 +1081,15 @@ async fn test_eval_brioche_git_ref_and_git_checkout() -> anyhow::Result<()> {
                         repository: "<REPO_URL>",
                         ref: "main",
                     });
-                    const gitCheckoutFeature1 = await Brioche.gitCheckout({
+                    const gitCheckoutFeat1 = await Brioche.gitCheckout({
                         repository: "<REPO_URL>",
                         ref: "feature1",
                     });
-                    const gitRefFeature2 = await Brioche.gitRef({
+                    const gitRefFeat2 = await Brioche.gitRef({
                         repository: "<REPO_URL>",
                         ref: "feature2",
                     });
-                    const gitCheckoutFeature2 = await Brioche.gitCheckout({
+                    const gitCheckoutFeat2 = await Brioche.gitCheckout({
                         repository: "<REPO_URL>",
                         ref: "feature2",
                     });
@@ -1059,9 +1099,9 @@ async fn test_eval_brioche_git_ref_and_git_checkout() -> anyhow::Result<()> {
                                 type: "create_file",
                                 content: JSON.stringify({
                                     gitRefMain,
-                                    gitCheckoutFeature1,
-                                    gitRefFeature2,
-                                    gitCheckoutFeature2,
+                                    gitCheckoutFeat1,
+                                    gitRefFeat2,
+                                    gitCheckoutFeat2,
                                 }),
                                 executable: false,
                                 resources: {
@@ -1073,7 +1113,7 @@ async fn test_eval_brioche_git_ref_and_git_checkout() -> anyhow::Result<()> {
                     };
                 };
             "#
-            .replace("<REPO_URL>", &mock_repo_url),
+            .replace("<REPO_URL>", repo_url.as_str()),
         )
         .await;
 
@@ -1094,35 +1134,26 @@ async fn test_eval_brioche_git_ref_and_git_checkout() -> anyhow::Result<()> {
         panic!("expected create_file recipe, got {resolved:?}");
     };
 
-    mock_git_info_refs.assert_async().await;
-    mock_git_upload_pack.assert_async().await;
-
     let git_ref: serde_json::Value = serde_json::from_slice(&content)?;
     assert_eq!(
         git_ref,
         serde_json::json!({
             "gitRefMain": {
                 "staticKind": "git_ref",
-                "repository": format!("{mock_repo_url}/"),
-                "commit": "0123456789abcdef01234567890123456789abcd",
+                "repository": repo_url.as_str(),
+                "commit": main_commit,
             },
-            "gitCheckoutFeature1": {
+            "gitCheckoutFeat1": {},
+            "gitRefFeat2": {
                 "staticKind": "git_ref",
-                "repository": format!("{mock_repo_url}/"),
-                "commit": "abcdef0123456789abcdef012345678901234567",
+                "repository": repo_url.as_str(),
+                "commit": feature2_commit,
             },
-            "gitRefFeature2": {
-                "staticKind": "git_ref",
-                "repository": format!("{mock_repo_url}/"),
-                "commit": "0000000000111111111122222222223333333333",
-            },
-            "gitCheckoutFeature2": {
-                "staticKind": "git_ref",
-                "repository": format!("{mock_repo_url}/"),
-                "commit": "0000000000111111111122222222223333333333",
-            },
+            "gitCheckoutFeat2": {},
         }),
     );
+
+    assert_eq!(feature1_commit.len(), 40);
 
     Ok(())
 }

--- a/crates/brioche-core/tests/script_eval.rs
+++ b/crates/brioche-core/tests/script_eval.rs
@@ -1,3 +1,4 @@
+use anyhow::Context as _;
 use brioche_core::{
     recipe::Directory,
     script::{evaluate::evaluate, initialize_js_platform},
@@ -14,26 +15,43 @@ fn test_git_signature() -> gix::actor::Signature {
     }
 }
 
-fn create_test_commit(
+enum TestCommitEntry<'a> {
+    File { name: &'a str, content: &'a str },
+    Submodule { name: &'a str, commit: gix::hash::ObjectId },
+}
+
+fn file_repo_url(repo_dir: &std::path::Path) -> anyhow::Result<url::Url> {
+    url::Url::from_directory_path(repo_dir)
+        .map_err(|()| anyhow::anyhow!("failed to create file URL for {}", repo_dir.display()))
+}
+
+fn create_test_commit_with_entries(
     repo: &gix::Repository,
-    files: &[(&str, &str)],
+    entries: &[TestCommitEntry<'_>],
     parent: Option<gix::hash::ObjectId>,
     message: &str,
 ) -> anyhow::Result<gix::hash::ObjectId> {
-    let mut entries = files
+    let mut entries = entries
         .iter()
-        .map(|(name, content)| {
-            let blob_id = repo
-                .write_object(gix::objs::Blob {
-                    data: content.as_bytes().to_vec(),
-                })?
-                .detach();
+        .map(|entry| match entry {
+            TestCommitEntry::File { name, content } => {
+                let blob_id = repo
+                    .write_object(gix::objs::Blob {
+                        data: content.as_bytes().to_vec(),
+                    })?
+                    .detach();
 
-            anyhow::Ok(gix::objs::tree::Entry {
-                mode: gix::objs::tree::EntryKind::Blob.into(),
+                anyhow::Ok(gix::objs::tree::Entry {
+                    mode: gix::objs::tree::EntryKind::Blob.into(),
+                    filename: (*name).into(),
+                    oid: blob_id,
+                })
+            }
+            TestCommitEntry::Submodule { name, commit } => anyhow::Ok(gix::objs::tree::Entry {
+                mode: gix::objs::tree::EntryKind::Commit.into(),
                 filename: (*name).into(),
-                oid: blob_id,
-            })
+                oid: *commit,
+            }),
         })
         .collect::<anyhow::Result<Vec<_>>>()?;
     entries.sort();
@@ -53,6 +71,22 @@ fn create_test_commit(
         .detach();
 
     Ok(commit_id)
+}
+
+fn create_test_commit(
+    repo: &gix::Repository,
+    files: &[(&str, &str)],
+    parent: Option<gix::hash::ObjectId>,
+    message: &str,
+) -> anyhow::Result<gix::hash::ObjectId> {
+    let entries = files
+        .iter()
+        .map(|(name, content)| TestCommitEntry::File {
+            name,
+            content,
+        })
+        .collect::<Vec<_>>();
+    create_test_commit_with_entries(repo, &entries, parent, message)
 }
 
 fn create_test_git_repo(
@@ -94,8 +128,7 @@ fn create_test_git_repo(
         "test feature2",
     )?;
 
-    let repo_url = url::Url::from_directory_path(repo_dir)
-        .map_err(|()| anyhow::anyhow!("failed to create file URL for {}", repo_dir.display()))?;
+    let repo_url = file_repo_url(repo_dir)?;
 
     Ok((
         repo_url,
@@ -103,6 +136,109 @@ fn create_test_git_repo(
         feature1_commit.to_string(),
         feature2_commit.to_string(),
     ))
+}
+
+fn create_test_git_repo_with_recursive_submodules(
+    repo_dir: &std::path::Path,
+    submodule_repo_dir: &std::path::Path,
+    nested_repo_dir: &std::path::Path,
+) -> anyhow::Result<url::Url> {
+    let nested_repo = gix::init_bare(nested_repo_dir)?;
+    let nested_commit = create_test_commit(&nested_repo, &[("leaf.txt", "leaf\n")], None, "leaf")?;
+    nested_repo.reference(
+        "refs/heads/main",
+        nested_commit,
+        gix::refs::transaction::PreviousValue::Any,
+        "test nested main",
+    )?;
+    let nested_repo_url = file_repo_url(nested_repo_dir)?;
+
+    let submodule_repo = gix::init_bare(submodule_repo_dir)?;
+    let submodule_gitmodules = format!(
+        "[submodule \"nested\"]\n\tpath = nested\n\turl = {}\n",
+        nested_repo_url
+    );
+    let submodule_commit = create_test_commit_with_entries(
+        &submodule_repo,
+        &[
+            TestCommitEntry::File {
+                name: ".gitmodules",
+                content: &submodule_gitmodules,
+            },
+            TestCommitEntry::File {
+                name: "module.txt",
+                content: "module\n",
+            },
+            TestCommitEntry::Submodule {
+                name: "nested",
+                commit: nested_commit,
+            },
+        ],
+        None,
+        "submodule",
+    )?;
+    submodule_repo.reference(
+        "refs/heads/main",
+        submodule_commit,
+        gix::refs::transaction::PreviousValue::Any,
+        "test submodule main",
+    )?;
+    let submodule_repo_url = file_repo_url(submodule_repo_dir)?;
+
+    let repo = gix::init_bare(repo_dir)?;
+    let root_gitmodules = format!(
+        "[submodule \"submodule\"]\n\tpath = submodule\n\turl = {}\n",
+        submodule_repo_url
+    );
+    let root_commit = create_test_commit_with_entries(
+        &repo,
+        &[
+            TestCommitEntry::File {
+                name: ".gitmodules",
+                content: &root_gitmodules,
+            },
+            TestCommitEntry::File {
+                name: "root.txt",
+                content: "root\n",
+            },
+            TestCommitEntry::Submodule {
+                name: "submodule",
+                commit: submodule_commit,
+            },
+        ],
+        None,
+        "root",
+    )?;
+    repo.reference(
+        "refs/heads/main",
+        root_commit,
+        gix::refs::transaction::PreviousValue::Any,
+        "test root main",
+    )?;
+
+    file_repo_url(repo_dir)
+}
+
+async fn single_git_checkout_dir(
+    brioche: &brioche_core::Brioche,
+) -> anyhow::Result<std::path::PathBuf> {
+    let checkout_root = brioche.data_dir.join("git-checkouts");
+    let mut entries = tokio::fs::read_dir(&checkout_root)
+        .await
+        .with_context(|| format!("failed to read {}", checkout_root.display()))?;
+    let mut paths = vec![];
+    while let Some(entry) = entries.next_entry().await? {
+        paths.push(entry.path());
+    }
+
+    anyhow::ensure!(
+        paths.len() == 1,
+        "expected exactly one git checkout dir in {}, found {}",
+        checkout_root.display(),
+        paths.len()
+    );
+
+    Ok(paths.pop().expect("one path exists"))
 }
 
 #[tokio::test]
@@ -1030,6 +1166,505 @@ async fn test_eval_brioche_git_checkout() -> anyhow::Result<()> {
         .await
         .into(),
     );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_eval_brioche_git_checkout_keep_git_dir() -> anyhow::Result<()> {
+    let (brioche, context) = brioche_test_support::brioche_test().await;
+
+    let repo_dir = context.mkdir("repo").await;
+    let (repo_url, _, _, _) = create_test_git_repo(&repo_dir)?;
+
+    let project_dir = context.mkdir("myproject").await;
+    context
+        .write_file(
+            "myproject/project.bri",
+            r#"
+                export const project = {};
+
+                globalThis.Brioche = {
+                    gitCheckout: async ({ repository, ref, options }) => {
+                        return {
+                            briocheSerialize: async () => {
+                                return await Deno.core.ops.op_brioche_get_static(
+                                    import.meta.url,
+                                    {
+                                        type: "git_checkout",
+                                        repository,
+                                        ref,
+                                        options,
+                                    },
+                                );
+                            },
+                        };
+                    }
+                };
+
+                export default async () => {
+                    return await Brioche.gitCheckout({
+                        repository: "<REPO_URL>",
+                        ref: "main",
+                        options: {
+                            keepGitDir: true,
+                        },
+                    });
+                };
+            "#
+            .replace("<REPO_URL>", repo_url.as_str()),
+        )
+        .await;
+
+    let (projects, project_hash) =
+        brioche_test_support::load_project(&brioche, &project_dir).await?;
+
+    let _resolved = evaluate(
+        &brioche,
+        initialize_js_platform(),
+        &projects,
+        project_hash,
+        "default",
+    )
+    .await?
+    .value;
+
+    let checkout_dir = single_git_checkout_dir(&brioche).await?;
+    assert!(tokio::fs::try_exists(checkout_dir.join(".git/HEAD")).await?);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_eval_brioche_git_checkout_with_tag() -> anyhow::Result<()> {
+    let (brioche, context) = brioche_test_support::brioche_test().await;
+
+    let repo_dir = context.mkdir("repo").await;
+    let (repo_url, _, _, _) = create_test_git_repo(&repo_dir)?;
+
+    let project_dir = context.mkdir("myproject").await;
+    context
+        .write_file(
+            "myproject/project.bri",
+            r#"
+                export const project = {};
+
+                globalThis.Brioche = {
+                    gitCheckout: async ({ repository, ref, options }) => {
+                        return {
+                            briocheSerialize: async () => {
+                                return await Deno.core.ops.op_brioche_get_static(
+                                    import.meta.url,
+                                    {
+                                        type: "git_checkout",
+                                        repository,
+                                        ref,
+                                        options,
+                                    },
+                                );
+                            },
+                        };
+                    }
+                };
+
+                export default async () => {
+                    return await Brioche.gitCheckout({
+                        repository: "<REPO_URL>",
+                        ref: "main",
+                        options: {
+                            keepGitDir: true,
+                            tag: true,
+                        },
+                    });
+                };
+            "#
+            .replace("<REPO_URL>", repo_url.as_str()),
+        )
+        .await;
+
+    let (projects, project_hash) =
+        brioche_test_support::load_project(&brioche, &project_dir).await?;
+
+    let _resolved = evaluate(
+        &brioche,
+        initialize_js_platform(),
+        &projects,
+        project_hash,
+        "default",
+    )
+    .await?
+    .value;
+
+    let checkout_dir = single_git_checkout_dir(&brioche).await?;
+    let tag_ref_path = checkout_dir.join(".git/refs/tags/main");
+    assert!(tokio::fs::try_exists(&tag_ref_path).await?);
+    let tag_ref = tokio::fs::read_to_string(&tag_ref_path).await?;
+    assert!(!tag_ref.trim().is_empty());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_eval_brioche_git_checkout_tag_requires_keep_git_dir() -> anyhow::Result<()> {
+    let (brioche, context) = brioche_test_support::brioche_test().await;
+
+    let repo_dir = context.mkdir("repo").await;
+    let (repo_url, _, _, _) = create_test_git_repo(&repo_dir)?;
+
+    let project_dir = context.mkdir("myproject").await;
+    context
+        .write_file(
+            "myproject/project.bri",
+            r#"
+                export const project = {};
+
+                globalThis.Brioche = {
+                    gitCheckout: async ({ repository, ref, options }) => {
+                        return {
+                            briocheSerialize: async () => {
+                                return await Deno.core.ops.op_brioche_get_static(
+                                    import.meta.url,
+                                    {
+                                        type: "git_checkout",
+                                        repository,
+                                        ref,
+                                        options,
+                                    },
+                                );
+                            },
+                        };
+                    }
+                };
+
+                export default async () => {
+                    return await Brioche.gitCheckout({
+                        repository: "<REPO_URL>",
+                        ref: "main",
+                        options: {
+                            tag: "release",
+                        },
+                    });
+                };
+            "#
+            .replace("<REPO_URL>", repo_url.as_str()),
+        )
+        .await;
+
+    let (projects, project_hash) =
+        brioche_test_support::load_project(&brioche, &project_dir).await?;
+
+    let error = evaluate(
+        &brioche,
+        initialize_js_platform(),
+        &projects,
+        project_hash,
+        "default",
+    )
+    .await
+    .expect_err("git checkout tag without keepGitDir should fail");
+
+    assert!(error.to_string().contains("Cannot use 'tag' without 'keepGitDir' enabled"));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_eval_brioche_git_checkout_without_submodules() -> anyhow::Result<()> {
+    let (brioche, context) = brioche_test_support::brioche_test().await;
+
+    let repo_dir = context.mkdir("repo").await;
+    let submodule_repo_dir = context.mkdir("submodule-repo").await;
+    let nested_repo_dir = context.mkdir("nested-repo").await;
+    let repo_url = create_test_git_repo_with_recursive_submodules(
+        &repo_dir,
+        &submodule_repo_dir,
+        &nested_repo_dir,
+    )?;
+
+    let project_dir = context.mkdir("myproject").await;
+    context
+        .write_file(
+            "myproject/project.bri",
+            r#"
+                export const project = {};
+
+                globalThis.Brioche = {
+                    gitCheckout: async ({ repository, ref, options }) => {
+                        return {
+                            briocheSerialize: async () => {
+                                return await Deno.core.ops.op_brioche_get_static(
+                                    import.meta.url,
+                                    {
+                                        type: "git_checkout",
+                                        repository,
+                                        ref,
+                                        options,
+                                    },
+                                );
+                            },
+                        };
+                    }
+                };
+
+                export default async () => {
+                    return await Brioche.gitCheckout({
+                        repository: "<REPO_URL>",
+                        ref: "main",
+                    });
+                };
+            "#
+            .replace("<REPO_URL>", repo_url.as_str()),
+        )
+        .await;
+
+    let (projects, project_hash) =
+        brioche_test_support::load_project(&brioche, &project_dir).await?;
+
+    let resolved = evaluate(
+        &brioche,
+        initialize_js_platform(),
+        &projects,
+        project_hash,
+        "default",
+    )
+    .await?
+    .value;
+
+    let root_gitmodules_blob = brioche_test_support::blob(
+        &brioche,
+        format!(
+            "[submodule \"submodule\"]\n\tpath = submodule\n\turl = {}\n",
+            file_repo_url(&submodule_repo_dir)?
+        ),
+    )
+    .await;
+    let root_blob = brioche_test_support::blob(&brioche, "root\n").await;
+
+    assert_eq!(
+        resolved,
+        brioche_test_support::dir(
+            &brioche,
+            [
+                (
+                    ".gitmodules",
+                    brioche_test_support::file(root_gitmodules_blob, false),
+                ),
+                (
+                    "root.txt",
+                    brioche_test_support::file(root_blob, false),
+                ),
+                ("submodule", brioche_test_support::dir_empty()),
+            ],
+        )
+        .await
+        .into(),
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_eval_brioche_git_checkout_with_submodules() -> anyhow::Result<()> {
+    let (brioche, context) = brioche_test_support::brioche_test().await;
+
+    let repo_dir = context.mkdir("repo").await;
+    let submodule_repo_dir = context.mkdir("submodule-repo").await;
+    let nested_repo_dir = context.mkdir("nested-repo").await;
+    let repo_url = create_test_git_repo_with_recursive_submodules(
+        &repo_dir,
+        &submodule_repo_dir,
+        &nested_repo_dir,
+    )?;
+
+    let project_dir = context.mkdir("myproject").await;
+    context
+        .write_file(
+            "myproject/project.bri",
+            r#"
+                export const project = {};
+
+                globalThis.Brioche = {
+                    gitCheckout: async ({ repository, ref, options }) => {
+                        return {
+                            briocheSerialize: async () => {
+                                return await Deno.core.ops.op_brioche_get_static(
+                                    import.meta.url,
+                                    {
+                                        type: "git_checkout",
+                                        repository,
+                                        ref,
+                                        options,
+                                    },
+                                );
+                            },
+                        };
+                    }
+                };
+
+                export default async () => {
+                    return await Brioche.gitCheckout({
+                        repository: "<REPO_URL>",
+                        ref: "main",
+                        options: {
+                            submodules: true,
+                        },
+                    });
+                };
+            "#
+            .replace("<REPO_URL>", repo_url.as_str()),
+        )
+        .await;
+
+    let (projects, project_hash) =
+        brioche_test_support::load_project(&brioche, &project_dir).await?;
+
+    let resolved = evaluate(
+        &brioche,
+        initialize_js_platform(),
+        &projects,
+        project_hash,
+        "default",
+    )
+    .await?
+    .value;
+
+    let root_gitmodules_blob = brioche_test_support::blob(
+        &brioche,
+        format!(
+            "[submodule \"submodule\"]\n\tpath = submodule\n\turl = {}\n",
+            file_repo_url(&submodule_repo_dir)?
+        ),
+    )
+    .await;
+    let submodule_gitmodules_blob = brioche_test_support::blob(
+        &brioche,
+        format!(
+            "[submodule \"nested\"]\n\tpath = nested\n\turl = {}\n",
+            file_repo_url(&nested_repo_dir)?
+        ),
+    )
+    .await;
+    let root_blob = brioche_test_support::blob(&brioche, "root\n").await;
+    let module_blob = brioche_test_support::blob(&brioche, "module\n").await;
+    let leaf_blob = brioche_test_support::blob(&brioche, "leaf\n").await;
+
+    let nested_dir = brioche_test_support::dir(
+        &brioche,
+        [(
+            "leaf.txt",
+            brioche_test_support::file(leaf_blob, false),
+        )],
+    )
+    .await;
+    let submodule_dir = brioche_test_support::dir(
+        &brioche,
+        [
+            (
+                ".gitmodules",
+                brioche_test_support::file(submodule_gitmodules_blob, false),
+            ),
+            (
+                "module.txt",
+                brioche_test_support::file(module_blob, false),
+            ),
+            ("nested", nested_dir),
+        ],
+    )
+    .await;
+
+    assert_eq!(
+        resolved,
+        brioche_test_support::dir(
+            &brioche,
+            [
+                (
+                    ".gitmodules",
+                    brioche_test_support::file(root_gitmodules_blob, false),
+                ),
+                (
+                    "root.txt",
+                    brioche_test_support::file(root_blob, false),
+                ),
+                ("submodule", submodule_dir),
+            ],
+        )
+        .await
+        .into(),
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_eval_brioche_git_checkout_with_submodules_keep_git_dir() -> anyhow::Result<()> {
+    let (brioche, context) = brioche_test_support::brioche_test().await;
+
+    let repo_dir = context.mkdir("repo").await;
+    let submodule_repo_dir = context.mkdir("submodule-repo").await;
+    let nested_repo_dir = context.mkdir("nested-repo").await;
+    let repo_url = create_test_git_repo_with_recursive_submodules(
+        &repo_dir,
+        &submodule_repo_dir,
+        &nested_repo_dir,
+    )?;
+
+    let project_dir = context.mkdir("myproject").await;
+    context
+        .write_file(
+            "myproject/project.bri",
+            r#"
+                export const project = {};
+
+                globalThis.Brioche = {
+                    gitCheckout: async ({ repository, ref, options }) => {
+                        return {
+                            briocheSerialize: async () => {
+                                return await Deno.core.ops.op_brioche_get_static(
+                                    import.meta.url,
+                                    {
+                                        type: "git_checkout",
+                                        repository,
+                                        ref,
+                                        options,
+                                    },
+                                );
+                            },
+                        };
+                    }
+                };
+
+                export default async () => {
+                    return await Brioche.gitCheckout({
+                        repository: "<REPO_URL>",
+                        ref: "main",
+                        options: {
+                            keepGitDir: true,
+                            submodules: true,
+                        },
+                    });
+                };
+            "#
+            .replace("<REPO_URL>", repo_url.as_str()),
+        )
+        .await;
+
+    let (projects, project_hash) =
+        brioche_test_support::load_project(&brioche, &project_dir).await?;
+
+    let _resolved = evaluate(
+        &brioche,
+        initialize_js_platform(),
+        &projects,
+        project_hash,
+        "default",
+    )
+    .await?
+    .value;
+
+    let checkout_dir = single_git_checkout_dir(&brioche).await?;
+    assert!(tokio::fs::try_exists(checkout_dir.join(".git/HEAD")).await?);
+    assert!(tokio::fs::try_exists(checkout_dir.join("submodule/.git/HEAD")).await?);
+    assert!(tokio::fs::try_exists(checkout_dir.join("submodule/nested/.git/HEAD")).await?);
 
     Ok(())
 }


### PR DESCRIPTION
From a developer perspective I think, `Brioche.gitCheckout(...)` should work with the environment that is already configured on the host system to access source repositories, whether that is a workstation or a CI runner.

If repository access depends on SSH keys, credentials, authenticated HTTPS, custom certificate stores or corporate CAs, Brioche should be able to use that same environment for fetching source. These things should not be part of the user packages and be checked in somewhere.

## Proposal

Currently core only resolves and locks git refs, while the actual checkout code is left to the users packages. This is why I propose this change.

My proposal here tries to move the code fetch completely into core. This separation is already common in other systems like Cargo or `Bitbake` which separate code fetch from the actual build for that reason. They even fetch all the dependencies first so that the build does not need network access anymore and can operate on prefetched and cached source. While i do not go this far, i moved the fetch into Brioche and let the packages access the fetched repositories.

(this also needs changes on the package side in std/extra/extra_global.bri)

The core idea is that fetching a repository is an environment-dependent operation, while building from that repository is a reproducible package operation. Repository access may depend on host-level configuration such as SSH agents, SSH keys, credential helpers, authenticated HTTPS setup, certificate stores, or corporate CAs.

## Summary of my Changes

- Core analyzes `gitCheckout` as its own static query, including the existing options such as `keepGitDir`, `tag` and `submodules`.
- During project loading, core still resolves the ref to a locked commit, just like `gitRef`.
- This keeps lockfile behavior and project identity commit-based instead of tying them to the materialized checkout contents.
- During runtime bridging, core takes the locked commit plus the checkout options and decides where the checkout should live in the checkout cache.
- In the download layer, core performs the actual repository fetch and checkout using `gix`
- Once the checkout exists on disk, core imports it as a normal Brioche directory recipe.
- From that point on, the rest of the pipeline sees an ordinary directory input and does not need to care how the git repository was fetched.

## Feedback

I still need to completely review the code myself again, so this is still WIP. But I would like to get feedback, especially on the approach, which might be controversial.

## Needed Changes in extra_global.bri

For testing i have used this `std/extra/extra_global.bri`

```typescript
import { type Recipe, type Directory, createRecipe } from "/core/recipes";
import { source } from "/core/source.bri";
import type { GitRefOptions } from "/core/global.bri";

/**
 * Options for the `Brioche.gitCheckout` function.
 *
 * @param keepGitDir - Set to true to keep the `.git` directory. Defaults to false.
 * @param submodules - Set to true to recursively checkout git submodules too.
 * @param tag - Create an annotated git tag on the checkout commit. Pass a
 *   string to use as the tag name, or `true` to use the `ref` value.
 */
interface BriocheGitCheckoutOptions {
  keepGitDir?: boolean;
  submodules?: boolean;
  tag?: boolean | string;
}

/**
 * Options for checking out a git repository.
 *
 * @param options - Extra options for the checkout. See the `BriocheGitCheckoutOptions` interface.
 */
interface GitCheckoutInit extends GitRefOptions {
  options?: BriocheGitCheckoutOptions;
}

declare global {
  // eslint-disable-next-line
  namespace Brioche {
    /**
     * Checkout a git repository from a specific git ref. The repository
     * will be cloned without any history. This function must be called with
     * constant strings for both the repository and ref. The commit hash
     * will be saved in the lockfile, so the same commit hash will be used
     * until the lockfile is updated.
     *
     * @description See also the function `Brioche.gitRef`, which directly returns the
     * resolved commit hash instead.
     *
     * @param options - Options for the git checkout.
     *
     * @returns The checked out repository without history
     *
     * @example
     * ```typescript
     * import * as std from "std";
     *
     * // Check out the main branch from the Brioche repository. The commit
     * // hash will be locked when first run, and will not change until the
     * // lockfile is updated
     * const source = Brioche.gitCheckout({
     *   repository: "https://github.com/brioche-dev/brioche.git",
     *   ref: "main",
     * });
     * ```
     */
    function gitCheckout(options: GitCheckoutInit): Recipe<Directory>;
  }
}

(globalThis as any).Brioche ??= {};
(globalThis as any).Brioche.gitCheckout ??= (
  init: GitCheckoutInit,
): Recipe<Directory> => {
  const sourceFrame = source({ depth: 1 }).at(0);
  if (sourceFrame === undefined) {
    throw new Error(
      `Could not find source file to resolve git ref '${init.ref}' from repository '${init.repository}'`,
    );
  }

  return createRecipe(["directory"], {
    sourceDepth: 1,
    briocheSerialize: async () => {
      return await (globalThis as any).Deno.core.ops.op_brioche_get_static(
        sourceFrame.fileName,
        {
          type: "git_checkout",
          repository: init.repository,
          ref: init.ref,
          options: init.options,
        },
      );
    },
  });
};

```
