### PR TITLE
feat(archive): add the same dedup logic as in the other part of the codebase

### DIFF
--- a/crates/brioche-core/src/cache/archive.rs
+++ b/crates/brioche-core/src/cache/archive.rs
@@ -738,8 +738,9 @@ pub async fn read_artifact_archive(
         insert_into_artifact(&mut result, &entry.path, &entry.path.components, entry.node)?;
     }
 
-    // Process directory references: copy subtrees from source paths to target paths
-    for (target_path, source_path) in references {
+    // Resolve references deepest-first so source subtrees are fully populated
+    // before being copied
+    for (target_path, source_path) in references.into_iter().rev() {
         copy_artifact_subtree(&mut result, &target_path, &source_path)?;
     }
 

--- a/crates/brioche-core/src/cache/archive.rs
+++ b/crates/brioche-core/src/cache/archive.rs
@@ -368,6 +368,7 @@ pub async fn read_artifact_archive(
     }
 
     let mut entries = vec![];
+    let mut references = vec![];
     let mut artifact_blobs = BTreeSet::new();
     let mut blobs = BTreeMap::new();
     let mut blob_offset = 0;
@@ -516,6 +517,15 @@ pub async fn read_artifact_archive(
                 );
 
                 chunk_offset += length;
+            }
+            b"R" => {
+                // Reference tag: read the target path and the source path
+
+                let target_path = read_path(reader).await?;
+                let source_path = read_path(reader).await?;
+
+                // Store the reference to process after all entries are read
+                references.push((target_path, source_path));
             }
             tag => {
                 // Unknown tag
@@ -726,6 +736,11 @@ pub async fn read_artifact_archive(
     let mut result: Option<ArtifactBuilder> = None;
     for entry in entries {
         insert_into_artifact(&mut result, &entry.path, &entry.path.components, entry.node)?;
+    }
+
+    // Process directory references: copy subtrees from source paths to target paths
+    for (target_path, source_path) in references {
+        copy_artifact_subtree(&mut result, &target_path, &source_path)?;
     }
 
     let mut new_recipes = HashMap::new();
@@ -943,6 +958,88 @@ fn insert_into_artifact(
     Ok(())
 }
 
+/// Copy a subtree from `source_path` to `target_path` within the artifact builder.
+fn copy_artifact_subtree(
+    root: &mut Option<ArtifactBuilder>,
+    target_path: &ArtifactPath,
+    source_path: &ArtifactPath,
+) -> anyhow::Result<()> {
+    // First, find and clone the source subtree
+    let source_subtree = get_subtree(root.as_ref(), &source_path.components)
+        .with_context(|| {
+            format!(
+                "reference source path {:?} not found",
+                source_path.display_pretty()
+            )
+        })?
+        .clone();
+
+    // Then, insert the cloned subtree at the target path
+    set_subtree(root, &target_path.components, source_subtree).with_context(|| {
+        format!(
+            "failed to set reference target path {:?}",
+            target_path.display_pretty()
+        )
+    })?;
+
+    Ok(())
+}
+
+/// Get a reference to a subtree at the given path components.
+fn get_subtree<'a>(
+    container: Option<&'a ArtifactBuilder>,
+    components: &[ArtifactPathComponent],
+) -> Option<&'a ArtifactBuilder> {
+    match components {
+        [] => container,
+        [ArtifactPathComponent::DirectoryEntry(name), rest @ ..] => {
+            let ArtifactBuilder::Directory { entries } = container.as_ref()? else {
+                return None;
+            };
+            let entry = entries.get(name)?;
+            get_subtree(entry.as_ref(), rest)
+        }
+        [ArtifactPathComponent::FileResources, rest @ ..] => {
+            let ArtifactBuilder::File { resources, .. } = container.as_ref()? else {
+                return None;
+            };
+            get_subtree(resources.as_ref().as_ref(), rest)
+        }
+    }
+}
+
+/// Set a subtree at the given path components.
+fn set_subtree(
+    container: &mut Option<ArtifactBuilder>,
+    components: &[ArtifactPathComponent],
+    subtree: ArtifactBuilder,
+) -> anyhow::Result<()> {
+    match components {
+        [] => {
+            *container = Some(subtree);
+            Ok(())
+        }
+        [ArtifactPathComponent::DirectoryEntry(name), rest @ ..] => {
+            let container = container.get_or_insert_with(ArtifactBuilder::empty_dir);
+            let ArtifactBuilder::Directory { entries } = container else {
+                anyhow::bail!("tried to descend into non-directory");
+            };
+            let entry = entries.entry(name.to_owned()).or_default();
+            set_subtree(entry, rest, subtree)
+        }
+        [ArtifactPathComponent::FileResources, rest @ ..] => {
+            let Some(container) = container else {
+                anyhow::bail!("tried to set resources on non-existent file");
+            };
+            let ArtifactBuilder::File { resources, .. } = container else {
+                anyhow::bail!("tried to set resources on non-file");
+            };
+            set_subtree(resources.as_mut(), rest, subtree)
+        }
+    }
+}
+
+#[derive(Clone)]
 enum ArtifactBuilder {
     File {
         executable: bool,

--- a/crates/brioche-core/src/cache/archive.rs
+++ b/crates/brioche-core/src/cache/archive.rs
@@ -738,15 +738,20 @@ pub async fn read_artifact_archive(
         insert_into_artifact(&mut result, &entry.path, &entry.path.components, entry.node)?;
     }
 
-    // Resolve references deepest-first so source subtrees are fully populated
-    // before being copied
-    for (target_path, source_path) in references.into_iter().rev() {
-        copy_artifact_subtree(&mut result, &target_path, &source_path)?;
+    // Record each reference as a placeholder in the tree. Sources are
+    // resolved lazily during artifact construction, so insertion order
+    // doesn't matter.
+    for (target_path, source_path) in references {
+        set_subtree(
+            &mut result,
+            &target_path.components,
+            ArtifactBuilder::Reference { source_path },
+        )?;
     }
 
+    let result_root = result.context("no artifact entries in archive")?;
     let mut new_recipes = HashMap::new();
-    let result = result.context("no artifact entries in archive")?;
-    let result = result.build(&mut new_recipes);
+    let result = build_artifact(&result_root, &mut new_recipes)?;
 
     brioche.reporter.update_job(
         job_id,
@@ -959,33 +964,6 @@ fn insert_into_artifact(
     Ok(())
 }
 
-/// Copy a subtree from `source_path` to `target_path` within the artifact builder.
-fn copy_artifact_subtree(
-    root: &mut Option<ArtifactBuilder>,
-    target_path: &ArtifactPath,
-    source_path: &ArtifactPath,
-) -> anyhow::Result<()> {
-    // First, find and clone the source subtree
-    let source_subtree = get_subtree(root.as_ref(), &source_path.components)
-        .with_context(|| {
-            format!(
-                "reference source path {:?} not found",
-                source_path.display_pretty()
-            )
-        })?
-        .clone();
-
-    // Then, insert the cloned subtree at the target path
-    set_subtree(root, &target_path.components, source_subtree).with_context(|| {
-        format!(
-            "failed to set reference target path {:?}",
-            target_path.display_pretty()
-        )
-    })?;
-
-    Ok(())
-}
-
 /// Get a reference to a subtree at the given path components.
 fn get_subtree<'a>(
     container: Option<&'a ArtifactBuilder>,
@@ -1040,7 +1018,6 @@ fn set_subtree(
     }
 }
 
-#[derive(Clone)]
 enum ArtifactBuilder {
     File {
         executable: bool,
@@ -1052,6 +1029,9 @@ enum ArtifactBuilder {
     },
     Directory {
         entries: HashMap<bstr::BString, Option<Self>>,
+    },
+    Reference {
+        source_path: ArtifactPath,
     },
 }
 
@@ -1080,48 +1060,85 @@ impl ArtifactBuilder {
             entries: HashMap::new(),
         }
     }
+}
 
-    fn build(self, new_recipes: &mut HashMap<RecipeHash, Recipe>) -> Artifact {
-        match self {
-            Self::File {
-                executable,
-                content_blob,
-                resources,
-            } => {
-                let resources = resources.unwrap_or_else(Self::empty_dir);
-                let resources = resources.build(new_recipes);
-                let Artifact::Directory(resources) = resources else {
-                    panic!("file resources builder did not return a directory");
-                };
+/// Build the final `Artifact` from the partial builder tree, resolving
+/// `Reference` placeholders against the same tree.
+fn build_artifact(
+    root: &ArtifactBuilder,
+    new_recipes: &mut HashMap<RecipeHash, Recipe>,
+) -> anyhow::Result<Artifact> {
+    // Identity-keyed memo so each unique subtree converts to an `Artifact`
+    // exactly once, regardless of how many references resolve to it.
+    let mut memo = HashMap::new();
+    build_artifact_node(root, root, &mut memo, new_recipes)
+}
 
-                Artifact::File(crate::recipe::File {
-                    content_blob,
-                    executable,
-                    resources,
-                })
-            }
-            Self::Symlink { target } => Artifact::Symlink { target },
-            Self::Directory { entries } => {
-                let mut entry_artifact_hashes = BTreeMap::new();
-                let entries = entries
-                    .into_iter()
-                    .filter_map(|(name, entry)| Some((name, entry?)));
-                for (name, entry) in entries {
-                    let entry = entry.build(new_recipes);
-                    let entry_hash = entry.hash();
-
-                    entry_artifact_hashes.insert(name, entry_hash);
-                    new_recipes
-                        .entry(entry_hash)
-                        .or_insert_with(|| Recipe::from(entry));
-                }
-
-                Artifact::Directory(crate::recipe::Directory::from_entries(
-                    entry_artifact_hashes,
-                ))
-            }
-        }
+fn build_artifact_node(
+    node: &ArtifactBuilder,
+    root: &ArtifactBuilder,
+    memo: &mut HashMap<usize, Artifact>,
+    new_recipes: &mut HashMap<RecipeHash, Recipe>,
+) -> anyhow::Result<Artifact> {
+    let key = std::ptr::from_ref(node).addr();
+    if let Some(cached) = memo.get(&key) {
+        return Ok(cached.clone());
     }
+
+    let artifact = match node {
+        ArtifactBuilder::File {
+            executable,
+            content_blob,
+            resources,
+        } => {
+            let resources = match resources.as_ref().as_ref() {
+                Some(resources) => {
+                    let resources = build_artifact_node(resources, root, memo, new_recipes)?;
+                    let Artifact::Directory(resources) = resources else {
+                        anyhow::bail!("file resources builder did not return a directory");
+                    };
+                    resources
+                }
+                None => crate::recipe::Directory::default(),
+            };
+            Artifact::File(crate::recipe::File {
+                content_blob: *content_blob,
+                executable: *executable,
+                resources,
+            })
+        }
+        ArtifactBuilder::Symlink { target } => Artifact::Symlink {
+            target: target.clone(),
+        },
+        ArtifactBuilder::Directory { entries } => {
+            let entries = entries
+                .iter()
+                .filter_map(|(name, entry)| Some((name, entry.as_ref()?)))
+                .map(|(name, entry)| {
+                    let artifact = build_artifact_node(entry, root, memo, new_recipes)?;
+                    let hash = artifact.hash();
+                    new_recipes
+                        .entry(hash)
+                        .or_insert_with(|| Recipe::from(artifact));
+                    Ok((name.clone(), hash))
+                })
+                .collect::<anyhow::Result<BTreeMap<_, _>>>()?;
+            Artifact::Directory(crate::recipe::Directory::from_entries(entries))
+        }
+        ArtifactBuilder::Reference { source_path } => {
+            let source_node =
+                get_subtree(Some(root), &source_path.components).with_context(|| {
+                    format!(
+                        "reference source path {:?} not found",
+                        source_path.display_pretty()
+                    )
+                })?;
+            build_artifact_node(source_node, root, memo, new_recipes)?
+        }
+    };
+
+    memo.insert(key, artifact.clone());
+    Ok(artifact)
 }
 
 enum BlobsFetch {


### PR DESCRIPTION
This PR is the first part of a fix for an issue when similar `Directory` are encountered in the archive cache path.

The cache archive format walked the artifact DAG and emitted one entry per path, re-visiting every child each time a parent was encountered. When the same `Directory` value appears at multiple locations which can be common after autopack, where many binaries share the same set of libraries in `File.resources`, the archive grew exponentially. For packages like `abseil_cpp` this made the archive too large to push to the registry (more than 40Go, yeah it tried once on `brioche-packages` before I saw it).

To solve the problem, a reference tag `R` is being added to the archive format. The first time a `Directory` is written it will be emitted normally. Later occurrences will emit a short `R` entry pointing back to the first one. On read, `R` entries are resolved after the main parse loop by copying the subtree from the anchor path to the target path.

This PR contains only the **read** side: `read_artifact_archive` now recognises and resolves `R` tags. Since existing archives produced by older writers contain no `R` tags, this change is fully backward compatible. Once this lands and a release is cut, all clients will be able to parse archives that contain references, unblocking the write-side PR.

Edit: the description has been edited.