### PR TITLE
Add missing `data/` dir for Brioche-in-Brioche build

### DIFF
--- a/project.bri
+++ b/project.bri
@@ -30,6 +30,9 @@ export default function (): std.Recipe<std.Directory> {
     "crates/brioche-core/runtime/tslib",
     "crates/brioche-core/runtime/dist",
 
+    // Static data
+    "crates/brioche-core/src/bake/data",
+
     // Makefiles for miscellaneous tasks
     "**/Makefile",
   );


### PR DESCRIPTION
Fast-follow for #459 to update `project.bri` to include the new `data/` dir for some static assets for the sandbox. This fixes the Brioche-in-Brioche build; see https://github.com/brioche-dev/brioche/actions/runs/25514726884:

```
[2458]     Checking brioche-core v0.1.7 (/home/brioche-runner-e0510a739db2fc6bf7fc3a2c0ad825c505bf61555ea1d0377367cceedd641ce1/work/crates/brioche-core)
[2458] error: couldn't read `crates/brioche-core/src/bake/data/etc-services`: No such file or directory (os error 2)
[2458]     --> crates/brioche-core/src/bake/process.rs:1956:48
[2458]      |
[2458] 1956 |     tokio::fs::write(etc_dir.join("services"), include_str!("data/etc-services")).await?;
[2458]      |                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[2458] error: couldn't read `crates/brioche-core/src/bake/data/etc-protocols`: No such file or directory (os error 2)
[2458]     --> crates/brioche-core/src/bake/process.rs:1959:9
[2458]      |
[2458] 1959 |         include_str!("data/etc-protocols"),
[2458]      |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[2458] error: could not compile `brioche-core` (lib) due to 2 previous errors
[2458] error: `cargo check` failed with status: exit status: 101
[2458] make[1]: *** [Makefile:11: check-db-schema] Error 1
[2458] make[1]: Leaving directory '/home/brioche-runner-e0510a739db2fc6bf7fc3a2c0ad825c505bf61555ea1d0377367cceedd641ce1/work/crates/brioche-core'
[2458] make: *** [Makefile:7: check-db-schema] Error 2
 INFO build:bake:bake_process:bake_process_finalize: brioche_core::bake::process: keeping temporary bake dir /home/runner/.local/share/brioche/process-temp/01KR1VP9MSKNB7Y6TSW2KZY88D recipe_hash=e0510a739db2fc6bf7fc3a2c0ad825c505bf61555ea1d0377367cceedd641ce1 bake_dir=/home/runner/.local/share/brioche/process-temp/01KR1VP9MSKNB7Y6TSW2KZY88D
Error occurred with project '.': process failed, view full output by running `brioche jobs logs /home/runner/.local/share/brioche/process-temp/01KR1VP9MSKNB7Y6TSW2KZY88D/events.bin.zst`: process exited with status code exit status: 2
```