### PR TITLE
feat(cache/archive): emit R tag references for shared Directory values

### DIFF
--- a/crates/brioche-core/src/cache/archive.rs
+++ b/crates/brioche-core/src/cache/archive.rs
@@ -738,8 +738,9 @@ pub async fn read_artifact_archive(
         insert_into_artifact(&mut result, &entry.path, &entry.path.components, entry.node)?;
     }
 
-    // Process directory references: copy subtrees from source paths to target paths
-    for (target_path, source_path) in references {
+    // Resolve references deepest-first so source subtrees are fully populated
+    // before being copied
+    for (target_path, source_path) in references.into_iter().rev() {
         copy_artifact_subtree(&mut result, &target_path, &source_path)?;
     }
 

--- a/crates/brioche-core/src/cache/archive.rs
+++ b/crates/brioche-core/src/cache/archive.rs
@@ -23,7 +23,7 @@ use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
 use crate::{
     Brioche,
     blob::{BlobHash, SaveBlobOptions},
-    recipe::{Artifact, Recipe, RecipeHash},
+    recipe::{Artifact, Directory, Recipe, RecipeHash},
     reporter::{
         JobId,
         job::{CacheFetchKind, NewJob, UpdateJob},
@@ -49,6 +49,10 @@ pub async fn write_artifact_archive(
 
     // Track all the blobs we need to add in the archive
     let mut artifact_blobs = BTreeSet::<BlobHash>::new();
+
+    // Track directories we've already written to avoid exponential expansion
+    // from shared nested resources
+    let mut seen_dirs: HashMap<Directory, ArtifactPath> = HashMap::new();
 
     // Use a queue to walk through the artifact, starting from the root
     let mut queue = VecDeque::from_iter([(ArtifactPath::default(), artifact)]);
@@ -85,14 +89,27 @@ pub async fn write_artifact_archive(
                 writer.write_all(target.as_slice()).await?;
             }
             Artifact::Directory(directory) => {
-                if directory.is_empty() {
+                // Check if we've already written this exact directory structure
+                if let Some(reference_path) = seen_dirs.get(&directory) {
+                    // Write a reference entry: tag, path, reference_path
+
+                    writer.write_all(b"R").await?;
+                    write_path(&path, writer).await?;
+                    write_path(reference_path, writer).await?;
+                } else if directory.is_empty() {
                     // Write an empty directory entry: tag, path. Non-empty
                     // directories don't need an entry, since they get created
                     // implicitly by its sub-entries.
 
                     writer.write_all(b"d").await?;
                     write_path(&path, writer).await?;
+
+                    // Track this empty directory
+                    seen_dirs.insert(directory, path);
                 } else {
+                    // Track this directory before traversing its children
+                    seen_dirs.insert(directory.clone(), path.clone());
+
                     // Enqueue each entry within the directory
                     let directory_entries = directory.entries(brioche).await?;
                     for (name, entry) in directory_entries {

--- a/crates/brioche-core/src/cache/archive.rs
+++ b/crates/brioche-core/src/cache/archive.rs
@@ -368,6 +368,7 @@ pub async fn read_artifact_archive(
     }
 
     let mut entries = vec![];
+    let mut references = vec![];
     let mut artifact_blobs = BTreeSet::new();
     let mut blobs = BTreeMap::new();
     let mut blob_offset = 0;
@@ -516,6 +517,15 @@ pub async fn read_artifact_archive(
                 );
 
                 chunk_offset += length;
+            }
+            b"R" => {
+                // Reference tag: read the target path and the source path
+
+                let target_path = read_path(reader).await?;
+                let source_path = read_path(reader).await?;
+
+                // Store the reference to process after all entries are read
+                references.push((target_path, source_path));
             }
             tag => {
                 // Unknown tag
@@ -726,6 +736,11 @@ pub async fn read_artifact_archive(
     let mut result: Option<ArtifactBuilder> = None;
     for entry in entries {
         insert_into_artifact(&mut result, &entry.path, &entry.path.components, entry.node)?;
+    }
+
+    // Process directory references: copy subtrees from source paths to target paths
+    for (target_path, source_path) in references {
+        copy_artifact_subtree(&mut result, &target_path, &source_path)?;
     }
 
     let mut new_recipes = HashMap::new();
@@ -943,6 +958,88 @@ fn insert_into_artifact(
     Ok(())
 }
 
+/// Copy a subtree from `source_path` to `target_path` within the artifact builder.
+fn copy_artifact_subtree(
+    root: &mut Option<ArtifactBuilder>,
+    target_path: &ArtifactPath,
+    source_path: &ArtifactPath,
+) -> anyhow::Result<()> {
+    // First, find and clone the source subtree
+    let source_subtree = get_subtree(root.as_ref(), &source_path.components)
+        .with_context(|| {
+            format!(
+                "reference source path {:?} not found",
+                source_path.display_pretty()
+            )
+        })?
+        .clone();
+
+    // Then, insert the cloned subtree at the target path
+    set_subtree(root, &target_path.components, source_subtree).with_context(|| {
+        format!(
+            "failed to set reference target path {:?}",
+            target_path.display_pretty()
+        )
+    })?;
+
+    Ok(())
+}
+
+/// Get a reference to a subtree at the given path components.
+fn get_subtree<'a>(
+    container: Option<&'a ArtifactBuilder>,
+    components: &[ArtifactPathComponent],
+) -> Option<&'a ArtifactBuilder> {
+    match components {
+        [] => container,
+        [ArtifactPathComponent::DirectoryEntry(name), rest @ ..] => {
+            let ArtifactBuilder::Directory { entries } = container.as_ref()? else {
+                return None;
+            };
+            let entry = entries.get(name)?;
+            get_subtree(entry.as_ref(), rest)
+        }
+        [ArtifactPathComponent::FileResources, rest @ ..] => {
+            let ArtifactBuilder::File { resources, .. } = container.as_ref()? else {
+                return None;
+            };
+            get_subtree(resources.as_ref().as_ref(), rest)
+        }
+    }
+}
+
+/// Set a subtree at the given path components.
+fn set_subtree(
+    container: &mut Option<ArtifactBuilder>,
+    components: &[ArtifactPathComponent],
+    subtree: ArtifactBuilder,
+) -> anyhow::Result<()> {
+    match components {
+        [] => {
+            *container = Some(subtree);
+            Ok(())
+        }
+        [ArtifactPathComponent::DirectoryEntry(name), rest @ ..] => {
+            let container = container.get_or_insert_with(ArtifactBuilder::empty_dir);
+            let ArtifactBuilder::Directory { entries } = container else {
+                anyhow::bail!("tried to descend into non-directory");
+            };
+            let entry = entries.entry(name.to_owned()).or_default();
+            set_subtree(entry, rest, subtree)
+        }
+        [ArtifactPathComponent::FileResources, rest @ ..] => {
+            let Some(container) = container else {
+                anyhow::bail!("tried to set resources on non-existent file");
+            };
+            let ArtifactBuilder::File { resources, .. } = container else {
+                anyhow::bail!("tried to set resources on non-file");
+            };
+            set_subtree(resources.as_mut(), rest, subtree)
+        }
+    }
+}
+
+#[derive(Clone)]
 enum ArtifactBuilder {
     File {
         executable: bool,

--- a/crates/brioche-core/src/cache/archive.rs
+++ b/crates/brioche-core/src/cache/archive.rs
@@ -738,15 +738,20 @@ pub async fn read_artifact_archive(
         insert_into_artifact(&mut result, &entry.path, &entry.path.components, entry.node)?;
     }
 
-    // Resolve references deepest-first so source subtrees are fully populated
-    // before being copied
-    for (target_path, source_path) in references.into_iter().rev() {
-        copy_artifact_subtree(&mut result, &target_path, &source_path)?;
+    // Record each reference as a placeholder in the tree. Sources are
+    // resolved lazily during artifact construction, so insertion order
+    // doesn't matter.
+    for (target_path, source_path) in references {
+        set_subtree(
+            &mut result,
+            &target_path.components,
+            ArtifactBuilder::Reference { source_path },
+        )?;
     }
 
+    let result_root = result.context("no artifact entries in archive")?;
     let mut new_recipes = HashMap::new();
-    let result = result.context("no artifact entries in archive")?;
-    let result = result.build(&mut new_recipes);
+    let result = build_artifact(&result_root, &mut new_recipes)?;
 
     brioche.reporter.update_job(
         job_id,
@@ -959,33 +964,6 @@ fn insert_into_artifact(
     Ok(())
 }
 
-/// Copy a subtree from `source_path` to `target_path` within the artifact builder.
-fn copy_artifact_subtree(
-    root: &mut Option<ArtifactBuilder>,
-    target_path: &ArtifactPath,
-    source_path: &ArtifactPath,
-) -> anyhow::Result<()> {
-    // First, find and clone the source subtree
-    let source_subtree = get_subtree(root.as_ref(), &source_path.components)
-        .with_context(|| {
-            format!(
-                "reference source path {:?} not found",
-                source_path.display_pretty()
-            )
-        })?
-        .clone();
-
-    // Then, insert the cloned subtree at the target path
-    set_subtree(root, &target_path.components, source_subtree).with_context(|| {
-        format!(
-            "failed to set reference target path {:?}",
-            target_path.display_pretty()
-        )
-    })?;
-
-    Ok(())
-}
-
 /// Get a reference to a subtree at the given path components.
 fn get_subtree<'a>(
     container: Option<&'a ArtifactBuilder>,
@@ -1040,7 +1018,6 @@ fn set_subtree(
     }
 }
 
-#[derive(Clone)]
 enum ArtifactBuilder {
     File {
         executable: bool,
@@ -1052,6 +1029,9 @@ enum ArtifactBuilder {
     },
     Directory {
         entries: HashMap<bstr::BString, Option<Self>>,
+    },
+    Reference {
+        source_path: ArtifactPath,
     },
 }
 
@@ -1080,48 +1060,85 @@ impl ArtifactBuilder {
             entries: HashMap::new(),
         }
     }
+}
 
-    fn build(self, new_recipes: &mut HashMap<RecipeHash, Recipe>) -> Artifact {
-        match self {
-            Self::File {
-                executable,
-                content_blob,
-                resources,
-            } => {
-                let resources = resources.unwrap_or_else(Self::empty_dir);
-                let resources = resources.build(new_recipes);
-                let Artifact::Directory(resources) = resources else {
-                    panic!("file resources builder did not return a directory");
-                };
+/// Build the final `Artifact` from the partial builder tree, resolving
+/// `Reference` placeholders against the same tree.
+fn build_artifact(
+    root: &ArtifactBuilder,
+    new_recipes: &mut HashMap<RecipeHash, Recipe>,
+) -> anyhow::Result<Artifact> {
+    // Identity-keyed memo so each unique subtree converts to an `Artifact`
+    // exactly once, regardless of how many references resolve to it.
+    let mut memo = HashMap::new();
+    build_artifact_node(root, root, &mut memo, new_recipes)
+}
 
-                Artifact::File(crate::recipe::File {
-                    content_blob,
-                    executable,
-                    resources,
-                })
-            }
-            Self::Symlink { target } => Artifact::Symlink { target },
-            Self::Directory { entries } => {
-                let mut entry_artifact_hashes = BTreeMap::new();
-                let entries = entries
-                    .into_iter()
-                    .filter_map(|(name, entry)| Some((name, entry?)));
-                for (name, entry) in entries {
-                    let entry = entry.build(new_recipes);
-                    let entry_hash = entry.hash();
-
-                    entry_artifact_hashes.insert(name, entry_hash);
-                    new_recipes
-                        .entry(entry_hash)
-                        .or_insert_with(|| Recipe::from(entry));
-                }
-
-                Artifact::Directory(crate::recipe::Directory::from_entries(
-                    entry_artifact_hashes,
-                ))
-            }
-        }
+fn build_artifact_node(
+    node: &ArtifactBuilder,
+    root: &ArtifactBuilder,
+    memo: &mut HashMap<usize, Artifact>,
+    new_recipes: &mut HashMap<RecipeHash, Recipe>,
+) -> anyhow::Result<Artifact> {
+    let key = std::ptr::from_ref(node).addr();
+    if let Some(cached) = memo.get(&key) {
+        return Ok(cached.clone());
     }
+
+    let artifact = match node {
+        ArtifactBuilder::File {
+            executable,
+            content_blob,
+            resources,
+        } => {
+            let resources = match resources.as_ref().as_ref() {
+                Some(resources) => {
+                    let resources = build_artifact_node(resources, root, memo, new_recipes)?;
+                    let Artifact::Directory(resources) = resources else {
+                        anyhow::bail!("file resources builder did not return a directory");
+                    };
+                    resources
+                }
+                None => crate::recipe::Directory::default(),
+            };
+            Artifact::File(crate::recipe::File {
+                content_blob: *content_blob,
+                executable: *executable,
+                resources,
+            })
+        }
+        ArtifactBuilder::Symlink { target } => Artifact::Symlink {
+            target: target.clone(),
+        },
+        ArtifactBuilder::Directory { entries } => {
+            let entries = entries
+                .iter()
+                .filter_map(|(name, entry)| Some((name, entry.as_ref()?)))
+                .map(|(name, entry)| {
+                    let artifact = build_artifact_node(entry, root, memo, new_recipes)?;
+                    let hash = artifact.hash();
+                    new_recipes
+                        .entry(hash)
+                        .or_insert_with(|| Recipe::from(artifact));
+                    Ok((name.clone(), hash))
+                })
+                .collect::<anyhow::Result<BTreeMap<_, _>>>()?;
+            Artifact::Directory(crate::recipe::Directory::from_entries(entries))
+        }
+        ArtifactBuilder::Reference { source_path } => {
+            let source_node =
+                get_subtree(Some(root), &source_path.components).with_context(|| {
+                    format!(
+                        "reference source path {:?} not found",
+                        source_path.display_pretty()
+                    )
+                })?;
+            build_artifact_node(source_node, root, memo, new_recipes)?
+        }
+    };
+
+    memo.insert(key, artifact.clone());
+    Ok(artifact)
 }
 
 enum BlobsFetch {

--- a/crates/brioche-core/tests/cache_client.rs
+++ b/crates/brioche-core/tests/cache_client.rs
@@ -477,14 +477,74 @@ async fn build_directory(
 }
 
 #[tokio::test]
-async fn test_cache_client_save_and_load_artifact_with_shared_subtrees() -> anyhow::Result<()> {
+async fn test_cache_client_save_and_load_artifact_with_shared_subtrees_simple() -> anyhow::Result<()>
+{
     let cache = brioche_test_support::new_cache();
     let artifact_hash;
+
+    let build_artifact = async |brioche: &Brioche| -> Artifact {
+        let lib_foo_blob = brioche_test_support::blob(brioche, b"foo").await;
+        let lib_bar_blob = brioche_test_support::blob(brioche, b"bar").await;
+        let bin_baz_blob = brioche_test_support::blob(brioche, b"baz").await;
+        let bin_qux_blob = brioche_test_support::blob(brioche, b"qux").await;
+        let inner_blob = brioche_test_support::blob(brioche, b"inner").await;
+
+        let inner_shared = brioche_test_support::dir_value(
+            brioche,
+            [("inner.so", brioche_test_support::file(inner_blob, false))],
+        )
+        .await;
+
+        let shared_resources = brioche_test_support::dir_value(
+            brioche,
+            [
+                (
+                    "foo.so",
+                    brioche_test_support::file_with_resources(
+                        lib_foo_blob,
+                        false,
+                        inner_shared.clone(),
+                    ),
+                ),
+                (
+                    "bar.so",
+                    brioche_test_support::file_with_resources(lib_bar_blob, false, inner_shared),
+                ),
+            ],
+        )
+        .await;
+
+        Artifact::Directory(
+            brioche_test_support::dir_value(
+                brioche,
+                [
+                    (
+                        "bin/baz",
+                        brioche_test_support::file_with_resources(
+                            bin_baz_blob,
+                            true,
+                            shared_resources.clone(),
+                        ),
+                    ),
+                    (
+                        "bin/qux",
+                        brioche_test_support::file_with_resources(
+                            bin_qux_blob,
+                            true,
+                            shared_resources.clone(),
+                        ),
+                    ),
+                    ("lib", Artifact::Directory(shared_resources)),
+                ],
+            )
+            .await,
+        )
+    };
 
     {
         let (brioche, _) = brioche_test_with_cache(cache.clone(), true).await;
 
-        let artifact = build_artifact_with_shared_subtrees(&brioche).await;
+        let artifact = build_artifact(&brioche).await;
         artifact_hash = artifact.hash();
 
         brioche_core::cache::save_artifact(&brioche, artifact).await?;
@@ -500,69 +560,93 @@ async fn test_cache_client_save_and_load_artifact_with_shared_subtrees() -> anyh
         )
         .await?;
 
-        let expected_artifact = build_artifact_with_shared_subtrees(&brioche).await;
+        let expected_artifact = build_artifact(&brioche).await;
         assert_eq!(loaded_artifact, Some(expected_artifact));
     }
 
     Ok(())
 }
 
-#[expect(clippy::similar_names)]
-async fn build_artifact_with_shared_subtrees(brioche: &Brioche) -> Artifact {
-    let foo_blob = brioche_test_support::blob(brioche, b"foo").await;
-    let bar_blob = brioche_test_support::blob(brioche, b"bar").await;
-    let baz_blob = brioche_test_support::blob(brioche, b"baz").await;
-    let qux_blob = brioche_test_support::blob(brioche, b"qux").await;
-    let inner_blob = brioche_test_support::blob(brioche, b"inner").await;
+#[tokio::test]
+async fn test_cache_client_save_and_load_artifact_with_shared_subtrees_advanced()
+-> anyhow::Result<()> {
+    let cache = brioche_test_support::new_cache();
+    let artifact_hash;
 
-    // Inner shared Directory nested inside `shared_resources`
-    let inner_shared = brioche_test_support::dir_value(
-        brioche,
-        [("inner.so", brioche_test_support::file(inner_blob, false))],
-    )
-    .await;
+    let build_artifact = async |brioche: &Brioche| -> Artifact {
+        let k_z_blob = brioche_test_support::blob(brioche, b"z").await;
+        let m_w_blob = brioche_test_support::blob(brioche, b"w").await;
+        let top_file_blob = brioche_test_support::blob(brioche, b"top").await;
+        let deep_file_blob = brioche_test_support::blob(brioche, b"deep").await;
 
-    // One Directory value shared by two files' resources and a sibling subtree
-    let shared_resources = brioche_test_support::dir_value(
-        brioche,
-        [
-            (
-                "foo.so",
-                brioche_test_support::file_with_resources(foo_blob, false, inner_shared.clone()),
-            ),
-            (
-                "bar.so",
-                brioche_test_support::file_with_resources(bar_blob, false, inner_shared),
-            ),
-        ],
-    )
-    .await;
+        let k = brioche_test_support::dir_value(
+            brioche,
+            [("z", brioche_test_support::file(k_z_blob, false))],
+        )
+        .await;
 
-    Artifact::Directory(
-        brioche_test_support::dir_value(
+        let m = brioche_test_support::dir_value(
+            brioche,
+            [("w", brioche_test_support::file(m_w_blob, false))],
+        )
+        .await;
+
+        let shared_x = brioche_test_support::dir_value(
             brioche,
             [
-                (
-                    "bin/baz",
-                    brioche_test_support::file_with_resources(
-                        baz_blob,
-                        true,
-                        shared_resources.clone(),
-                    ),
-                ),
-                (
-                    "bin/qux",
-                    brioche_test_support::file_with_resources(
-                        qux_blob,
-                        true,
-                        shared_resources.clone(),
-                    ),
-                ),
-                ("lib", Artifact::Directory(shared_resources)),
+                ("p", Artifact::Directory(k.clone())),
+                ("q", Artifact::Directory(m)),
             ],
         )
-        .await,
-    )
+        .await;
+
+        Artifact::Directory(
+            brioche_test_support::dir_value(
+                brioche,
+                [
+                    (
+                        "F_top",
+                        brioche_test_support::file_with_resources(
+                            top_file_blob,
+                            false,
+                            shared_x.clone(),
+                        ),
+                    ),
+                    ("K_dir", Artifact::Directory(k)),
+                    (
+                        "big_dir/l/ll",
+                        brioche_test_support::file_with_resources(deep_file_blob, false, shared_x),
+                    ),
+                ],
+            )
+            .await,
+        )
+    };
+
+    {
+        let (brioche, _) = brioche_test_with_cache(cache.clone(), true).await;
+
+        let artifact = build_artifact(&brioche).await;
+        artifact_hash = artifact.hash();
+
+        brioche_core::cache::save_artifact(&brioche, artifact).await?;
+    }
+
+    {
+        let (brioche, _) = brioche_test_with_cache(cache.clone(), false).await;
+
+        let loaded_artifact = brioche_core::cache::load_artifact(
+            &brioche,
+            artifact_hash,
+            brioche_core::reporter::job::CacheFetchKind::Bake,
+        )
+        .await?;
+
+        let expected_artifact = build_artifact(&brioche).await;
+        assert_eq!(loaded_artifact, Some(expected_artifact));
+    }
+
+    Ok(())
 }
 
 async fn list_chunks(

--- a/crates/brioche-core/tests/cache_client.rs
+++ b/crates/brioche-core/tests/cache_client.rs
@@ -476,6 +476,81 @@ async fn build_directory(
     .await
 }
 
+#[tokio::test]
+async fn test_cache_client_save_and_load_artifact_with_shared_subtrees() -> anyhow::Result<()> {
+    let cache = brioche_test_support::new_cache();
+    let artifact_hash;
+
+    {
+        let (brioche, _) = brioche_test_with_cache(cache.clone(), true).await;
+
+        let artifact = build_artifact_with_shared_subtrees(&brioche).await;
+        artifact_hash = artifact.hash();
+
+        brioche_core::cache::save_artifact(&brioche, artifact).await?;
+    }
+
+    {
+        let (brioche, _) = brioche_test_with_cache(cache.clone(), false).await;
+
+        let loaded_artifact = brioche_core::cache::load_artifact(
+            &brioche,
+            artifact_hash,
+            brioche_core::reporter::job::CacheFetchKind::Bake,
+        )
+        .await?;
+
+        let expected_artifact = build_artifact_with_shared_subtrees(&brioche).await;
+        assert_eq!(loaded_artifact, Some(expected_artifact));
+    }
+
+    Ok(())
+}
+
+#[expect(clippy::similar_names)]
+async fn build_artifact_with_shared_subtrees(brioche: &Brioche) -> Artifact {
+    let foo_blob = brioche_test_support::blob(brioche, b"foo").await;
+    let bar_blob = brioche_test_support::blob(brioche, b"bar").await;
+    let baz_blob = brioche_test_support::blob(brioche, b"baz").await;
+    let qux_blob = brioche_test_support::blob(brioche, b"qux").await;
+
+    // One Directory value shared by two files' resources and a sibling subtree
+    let shared_resources = brioche_test_support::dir_value(
+        brioche,
+        [
+            ("foo.so", brioche_test_support::file(foo_blob, false)),
+            ("bar.so", brioche_test_support::file(bar_blob, false)),
+        ],
+    )
+    .await;
+
+    Artifact::Directory(
+        brioche_test_support::dir_value(
+            brioche,
+            [
+                (
+                    "bin/baz",
+                    brioche_test_support::file_with_resources(
+                        baz_blob,
+                        true,
+                        shared_resources.clone(),
+                    ),
+                ),
+                (
+                    "bin/qux",
+                    brioche_test_support::file_with_resources(
+                        qux_blob,
+                        true,
+                        shared_resources.clone(),
+                    ),
+                ),
+                ("lib", Artifact::Directory(shared_resources)),
+            ],
+        )
+        .await,
+    )
+}
+
 async fn list_chunks(
     cache: &dyn object_store::ObjectStore,
 ) -> anyhow::Result<Vec<object_store::path::Path>> {

--- a/crates/brioche-core/tests/cache_client.rs
+++ b/crates/brioche-core/tests/cache_client.rs
@@ -513,13 +513,27 @@ async fn build_artifact_with_shared_subtrees(brioche: &Brioche) -> Artifact {
     let bar_blob = brioche_test_support::blob(brioche, b"bar").await;
     let baz_blob = brioche_test_support::blob(brioche, b"baz").await;
     let qux_blob = brioche_test_support::blob(brioche, b"qux").await;
+    let inner_blob = brioche_test_support::blob(brioche, b"inner").await;
+
+    // Inner shared Directory nested inside `shared_resources`
+    let inner_shared = brioche_test_support::dir_value(
+        brioche,
+        [("inner.so", brioche_test_support::file(inner_blob, false))],
+    )
+    .await;
 
     // One Directory value shared by two files' resources and a sibling subtree
     let shared_resources = brioche_test_support::dir_value(
         brioche,
         [
-            ("foo.so", brioche_test_support::file(foo_blob, false)),
-            ("bar.so", brioche_test_support::file(bar_blob, false)),
+            (
+                "foo.so",
+                brioche_test_support::file_with_resources(foo_blob, false, inner_shared.clone()),
+            ),
+            (
+                "bar.so",
+                brioche_test_support::file_with_resources(bar_blob, false, inner_shared),
+            ),
         ],
     )
     .await;


### PR DESCRIPTION
Follow up of #460

This PR is the second part of a fix for an issue when similar `Directory` are encountered in the archive cache path.

`write_artifact_archive` now tracks every `Directory` it has already emitted. When the same `Directory` value is encountered again, it writes a short `R` reference entry pointing back to the first occurrence instead of re-emitting the full subtree. Archive size is now bounded by the number of distinct `Directory` values rather than the number of paths.