### PR TITLE
chore(project): cache the hash of each download when resolving the statics

### DIFF
--- a/crates/brioche-core/src/lib.rs
+++ b/crates/brioche-core/src/lib.rs
@@ -74,6 +74,8 @@ pub struct Brioche {
 
     pub active_bakes: Arc<RwLock<bake::ActiveBakes>>,
 
+    pub active_static_downloads: Arc<RwLock<project::ActiveStaticDownloads>>,
+
     pub process_semaphore: Arc<tokio::sync::Semaphore>,
 
     pub download_semaphore: Arc<tokio::sync::Semaphore>,
@@ -422,6 +424,9 @@ impl BriocheBuilder {
             sync_tx: Arc::new(sync_tx),
             cached_recipes: Arc::new(RwLock::new(bake::CachedRecipes::default())),
             active_bakes: Arc::new(RwLock::new(bake::ActiveBakes::default())),
+            active_static_downloads: Arc::new(RwLock::new(
+                project::ActiveStaticDownloads::default(),
+            )),
             process_semaphore: Arc::new(tokio::sync::Semaphore::new(MAX_CONCURRENT_PROCESSES)),
             download_semaphore: Arc::new(tokio::sync::Semaphore::new(MAX_CONCURRENT_DOWNLOADS)),
             download_client,

--- a/crates/brioche-core/src/project.rs
+++ b/crates/brioche-core/src/project.rs
@@ -15,6 +15,14 @@ pub mod artifact;
 pub mod edit;
 mod load;
 
+#[derive(Debug, Default)]
+pub struct ActiveStaticDownloads {
+    downloads: std::collections::HashMap<
+        url::Url,
+        std::sync::Arc<tokio::sync::OnceCell<(crate::Hash, crate::blob::BlobHash)>>,
+    >,
+}
+
 #[derive(Debug, Clone, Copy)]
 pub enum ProjectValidation {
     /// Fully validate the project, ensuring all modules and dependencies

--- a/crates/brioche-core/src/project/load.rs
+++ b/crates/brioche-core/src/project/load.rs
@@ -1078,30 +1078,51 @@ async fn resolve_static(
                     blob_hash = None;
                 }
                 (None, ProjectLocking::Unlocked) => {
-                    // Download the URL as a blob
-                    let new_blob_hash = crate::download::download(brioche, url, None).await?;
-                    let blob_path = crate::blob::local_blob_path(brioche, new_blob_hash);
-                    let mut blob = tokio::fs::File::open(&blob_path).await?;
+                    // Get or create the per-URL OnceCell from the shared cache so
+                    // the same URL is downloaded at most once per Brioche instance
+                    let once_cell = {
+                        let mut cache = brioche.active_static_downloads.write().await;
+                        cache.downloads.entry(url.clone()).or_default().clone()
+                    };
 
-                    // Compute a hash to store in the lockfile
-                    let mut hasher = crate::Hasher::new_sha256();
-                    let mut buffer = vec![0u8; 1024 * 1024];
-                    loop {
-                        let length = blob
-                            .read(&mut buffer)
-                            .await
-                            .context("failed to read blob")?;
-                        if length == 0 {
-                            break;
-                        }
+                    let already_cached = once_cell.get().is_some();
 
-                        hasher.update(&buffer[..length]);
-                    }
+                    // Download the URL as a blob and compute a lockfile hash.
+                    // If another call already did this, get_or_try_init returns
+                    // immediately with the stored Hash.
+                    let cached_hash = once_cell
+                        .get_or_try_init(|| async {
+                            let new_blob_hash =
+                                crate::download::download(brioche, url, None).await?;
+                            let blob_path = crate::blob::local_blob_path(brioche, new_blob_hash);
+                            let mut blob = tokio::fs::File::open(&blob_path).await?;
 
-                    // Record both the hash for the recipe plus the output
-                    // blob hash
-                    download_hash = hasher.finish()?;
-                    blob_hash = Some(new_blob_hash);
+                            let mut hasher = crate::Hasher::new_sha256();
+                            let mut buffer = vec![0u8; 1024 * 1024];
+                            loop {
+                                let length = blob
+                                    .read(&mut buffer)
+                                    .await
+                                    .context("failed to read blob")?;
+                                if length == 0 {
+                                    break;
+                                }
+                                hasher.update(&buffer[..length]);
+                            }
+
+                            anyhow::Ok((hasher.finish()?, new_blob_hash))
+                        })
+                        .await?;
+
+                    download_hash = cached_hash.0.clone();
+                    // Only pass the blob hash through when this call ran the
+                    // actual download; for cache hits we skip re-saving the
+                    // bake result (already saved by the first call).
+                    blob_hash = if already_cached {
+                        None
+                    } else {
+                        Some(cached_hash.1)
+                    };
                 }
                 (None, ProjectLocking::Locked) => {
                     // Error out if the download isn't in the lockfile but where

--- a/crates/brioche-core/tests/project_load.rs
+++ b/crates/brioche-core/tests/project_load.rs
@@ -931,6 +931,74 @@ async fn test_project_load_with_remote_registry_dep_with_brioche_download() -> a
 }
 
 #[tokio::test]
+async fn test_project_load_shared_download_url_across_path_deps_fetched_once() -> anyhow::Result<()>
+{
+    let (brioche, context) = brioche_test_support::brioche_test().await;
+
+    let mut server = mockito::Server::new_async().await;
+    let server_url = server.url();
+
+    let hello = "hello";
+    let hello_endpoint = server
+        .mock("GET", "/file.txt")
+        .with_body(hello)
+        .expect(1)
+        .create();
+
+    let download_url = format!("{server_url}/file.txt");
+
+    context.mkdir("foodep").await;
+    context
+        .write_file(
+            "foodep/project.bri",
+            r#"
+                export const project = {};
+                export const hello = Brioche.download("<DOWNLOAD_URL>");
+            "#
+            .replace("<DOWNLOAD_URL>", &download_url),
+        )
+        .await;
+
+    context.mkdir("bardep").await;
+    context
+        .write_file(
+            "bardep/project.bri",
+            r#"
+                export const project = {};
+                export const hello = Brioche.download("<DOWNLOAD_URL>");
+            "#
+            .replace("<DOWNLOAD_URL>", &download_url),
+        )
+        .await;
+
+    let project_dir = context.mkdir("myproject").await;
+    context
+        .write_file(
+            "myproject/project.bri",
+            r#"
+                export const project = {
+                    dependencies: {
+                        foodep: {
+                            path: "../foodep",
+                        },
+                        bardep: {
+                            path: "../bardep",
+                        },
+                    },
+                };
+            "#,
+        )
+        .await;
+
+    let (_projects, _project_hash) =
+        brioche_test_support::load_project(&brioche, &project_dir).await?;
+
+    hello_endpoint.assert_async().await;
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_project_load_with_remote_registry_deps_with_common_children() -> anyhow::Result<()> {
     let cache = brioche_test_support::new_cache();
     let (brioche, mut context) = brioche_test_with_cache(cache.clone(), false).await;


### PR DESCRIPTION
Resolve https://github.com/brioche-dev/brioche/issues/331.

I wanted to work on this issue because I'm currently in the process to update `cargoBuild()` to emulate `cargo chef` in Typescript. At the end, Brioche will download each dependency using `std.download()`, cache it, then build the recipe. It will have two advantages over the current approach:

- Only download newly or updated dependencies when `Cargo.lock` is updated -> today, we redownload everything
- Share the dependencies across recipes -> today, it's not feasible due to the way the input (aka the dependencies vendored) is passed to `cargo build`

Both new behaviours will make the future devenv experience more smoother.

Here is a before and after on `std`:

Before (brioche-runtime-utils is downloaded 11 times (11 x86_64 + 11 aarch64):

```bash
/workspaces/brioche (main) $ cargo run -- check /tmp/brioche-packages/packages/std
   Compiling brioche-core v0.1.7 (/workspaces/brioche/crates/brioche-core)
   Compiling brioche v0.1.7 (/workspaces/brioche/crates/brioche)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 52.65s
     Running `target/debug/brioche check /tmp/brioche-packages/packages/std`
 INFO check: brioche::check: updated lockfiles num_lockfiles_updated=1
 0.10s ✓ Download  100% 2.6 MiB / 2.6 MiB  https://development-content…ioche-runtime-utils.tar.zstd
 0.09s ✓ Download  100% 2.2 MiB / 2.2 MiB  https://development-content…ioche-runtime-utils.tar.zstd
 0.10s ✓ Download  100% 2.6 MiB / 2.6 MiB  https://development-content…ioche-runtime-utils.tar.zstd
 0.09s ✓ Download  100% 2.2 MiB / 2.2 MiB  https://development-content…ioche-runtime-utils.tar.zstd
 9.63s  22 complete   0 running
```

After (brioche-runtime-utils is downloaded 1 time (1 x86_64 + 1 aarch64):

```bash
/workspaces/brioche (main) $ cargo run -- check /tmp/brioche-packages/packages/std
   Compiling brioche-core v0.1.7 (/workspaces/brioche/crates/brioche-core)
   Compiling brioche v0.1.7 (/workspaces/brioche/crates/brioche)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 01s
     Running `target/debug/brioche check /tmp/brioche-packages/packages/std`
 INFO check: brioche::check: updated lockfiles num_lockfiles_updated=1
 0.80s ✓ Download  100% 2.6 MiB / 2.6 MiB  https://development-content…ioche-runtime-utils.tar.zstd
 3.37s ✓ Download  100% 2.1 MiB / 2.1 MiB  https://development-content…ioche-runtime-utils.tar.zstd
19.66s   2 complete   0 running
```  