### PR TITLE
Add TUI source labels

### DIFF
--- a/crates/brioche-core/src/bake.rs
+++ b/crates/brioche-core/src/bake.rs
@@ -46,6 +46,7 @@ pub enum BakeScope {
     },
     Child {
         parent_hash: RecipeHash,
+        parent_meta: Arc<Meta>,
     },
     Anonymous,
 }
@@ -55,6 +56,7 @@ pub async fn bake(
     recipe: WithMeta<Recipe>,
     scope: &BakeScope,
 ) -> anyhow::Result<WithMeta<Artifact>> {
+    let recipe = inherit_source_from_scope(recipe, scope);
     let recipe_hash = recipe.hash();
     let result = bake_inner(brioche, recipe).await?;
 
@@ -87,7 +89,7 @@ pub async fn bake(
 
                 db_transaction.commit().await?;
             }
-            BakeScope::Child { parent_hash } => {
+            BakeScope::Child { parent_hash, .. } => {
                 let mut db_conn = brioche.db_conn.lock().await;
                 let mut db_transaction = db_conn.begin().await?;
 
@@ -325,9 +327,23 @@ async fn bake_inner(
     }
 }
 
+fn inherit_source_from_scope(recipe: WithMeta<Recipe>, scope: &BakeScope) -> WithMeta<Recipe> {
+    if recipe.meta.source.is_some() {
+        return recipe;
+    }
+    let BakeScope::Child { parent_meta, .. } = scope else {
+        return recipe;
+    };
+    if parent_meta.source.is_none() {
+        return recipe;
+    }
+    WithMeta::new(recipe.value, parent_meta.clone())
+}
+
 async fn run_bake(brioche: &Brioche, recipe: Recipe, meta: &Arc<Meta>) -> anyhow::Result<Artifact> {
     let scope = BakeScope::Child {
         parent_hash: recipe.hash(),
+        parent_meta: meta.clone(),
     };
 
     match recipe {

--- a/crates/brioche-core/src/bake.rs
+++ b/crates/brioche-core/src/bake.rs
@@ -11,6 +11,7 @@ use tracing::Instrument as _;
 use crate::{
     project::ProjectHash,
     recipe::{ArtifactDiscriminants, ProxyRecipe},
+    reporter::job::{CacheFetchKind, JobContext},
 };
 
 use super::{
@@ -232,19 +233,21 @@ async fn bake_inner(
     } else {
         None
     };
-    let artifact_from_cache = match artifact_hash_from_cache {
-        Some(artifact_hash) => crate::cache::load_artifact(
+    let artifact_from_cache = if let Some(artifact_hash) = artifact_hash_from_cache {
+        crate::cache::load_artifact(
             brioche,
             artifact_hash,
-            crate::reporter::job::CacheFetchKind::Bake,
+            CacheFetchKind::Bake,
+            JobContext::default(),
         )
         .await
         .inspect_err(|error| {
             tracing::warn!("failed to load artifact from cache: {error:#}");
         })
         .ok()
-        .flatten(),
-        None => None,
+        .flatten()
+    } else {
+        None
     };
 
     let result_artifact = if let Some(artifact) = artifact_from_cache {

--- a/crates/brioche-core/src/bake.rs
+++ b/crates/brioche-core/src/bake.rs
@@ -238,7 +238,7 @@ async fn bake_inner(
             brioche,
             artifact_hash,
             CacheFetchKind::Bake,
-            JobContext::default(),
+            JobContext::from_meta(&meta),
         )
         .await
         .inspect_err(|error| {
@@ -349,7 +349,7 @@ async fn run_bake(brioche: &Brioche, recipe: Recipe, meta: &Arc<Meta>) -> anyhow
         Recipe::Directory(directory) => Ok(Artifact::Directory(directory)),
         Recipe::Symlink { target } => Ok(Artifact::Symlink { target }),
         Recipe::Download(download) => {
-            let downloaded = download::bake_download(brioche, download).await?;
+            let downloaded = download::bake_download(brioche, meta, download).await?;
             Ok(Artifact::File(downloaded))
         }
         Recipe::Unarchive(unarchive) => {

--- a/crates/brioche-core/src/bake/download.rs
+++ b/crates/brioche-core/src/bake/download.rs
@@ -1,10 +1,17 @@
 use crate::{
     Brioche,
     recipe::{Directory, DownloadRecipe, File},
+    reporter::job::JobContext,
 };
 
 pub async fn bake_download(brioche: &Brioche, download: DownloadRecipe) -> anyhow::Result<File> {
-    let blob_hash = crate::download::download(brioche, &download.url, Some(download.hash)).await?;
+    let blob_hash = crate::download::download(
+        brioche,
+        &download.url,
+        Some(download.hash),
+        JobContext::default(),
+    )
+    .await?;
 
     Ok(File {
         content_blob: blob_hash,

--- a/crates/brioche-core/src/bake/download.rs
+++ b/crates/brioche-core/src/bake/download.rs
@@ -1,15 +1,21 @@
+use std::sync::Arc;
+
 use crate::{
     Brioche,
-    recipe::{Directory, DownloadRecipe, File},
+    recipe::{Directory, DownloadRecipe, File, Meta},
     reporter::job::JobContext,
 };
 
-pub async fn bake_download(brioche: &Brioche, download: DownloadRecipe) -> anyhow::Result<File> {
+pub async fn bake_download(
+    brioche: &Brioche,
+    meta: &Arc<Meta>,
+    download: DownloadRecipe,
+) -> anyhow::Result<File> {
     let blob_hash = crate::download::download(
         brioche,
         &download.url,
         Some(download.hash),
-        JobContext::default(),
+        JobContext::from_meta(meta),
     )
     .await?;
 

--- a/crates/brioche-core/src/bake/process.rs
+++ b/crates/brioche-core/src/bake/process.rs
@@ -314,7 +314,7 @@ pub async fn bake_process(
         NewJob::Process {
             status: job_status.clone(),
         },
-        JobContext::default(),
+        JobContext::from_meta(meta),
     );
 
     tracing::Span::current().record("recipe_hash", tracing::field::display(hash));

--- a/crates/brioche-core/src/bake/process.rs
+++ b/crates/brioche-core/src/bake/process.rs
@@ -23,7 +23,7 @@ use crate::{
     },
     reporter::{
         JobId,
-        job::{NewJob, ProcessPacket, ProcessStatus, ProcessStream, UpdateJob},
+        job::{JobContext, NewJob, ProcessPacket, ProcessStatus, ProcessStream, UpdateJob},
     },
     sandbox::{
         HostPathMode, SandboxBackend, SandboxExecutionConfig, SandboxPath, SandboxPathOptions,
@@ -310,9 +310,12 @@ pub async fn bake_process(
     let hash = Recipe::CompleteProcess(process.clone()).hash();
     let created_at = std::time::Instant::now();
     let mut job_status = ProcessStatus::Preparing { created_at };
-    let job_id = brioche.reporter.add_job(NewJob::Process {
-        status: job_status.clone(),
-    });
+    let job_id = brioche.reporter.add_job(
+        NewJob::Process {
+            status: job_status.clone(),
+        },
+        JobContext::default(),
+    );
 
     tracing::Span::current().record("recipe_hash", tracing::field::display(hash));
 

--- a/crates/brioche-core/src/bake/unarchive.rs
+++ b/crates/brioche-core/src/bake/unarchive.rs
@@ -10,7 +10,7 @@ use crate::{
     recipe::{
         ArchiveFormat, Artifact, CompressionFormat, Directory, File, Meta, Unarchive, WithMeta,
     },
-    reporter::job::{NewJob, UpdateJob},
+    reporter::job::{JobContext, NewJob, UpdateJob},
 };
 
 pub async fn bake_unarchive(
@@ -36,10 +36,13 @@ pub async fn bake_unarchive(
     let archive_file = tokio::io::BufReader::new(archive_file);
     let archive_file = crate::utils::io::ReadTracker::new(archive_file);
 
-    let job_id = brioche.reporter.add_job(NewJob::Unarchive {
-        started_at: std::time::Instant::now(),
-        total_bytes: uncompressed_archive_size,
-    });
+    let job_id = brioche.reporter.add_job(
+        NewJob::Unarchive {
+            started_at: std::time::Instant::now(),
+            total_bytes: uncompressed_archive_size,
+        },
+        JobContext::default(),
+    );
 
     let (entry_tx, mut entry_rx) = tokio::sync::mpsc::channel(16);
 

--- a/crates/brioche-core/src/bake/unarchive.rs
+++ b/crates/brioche-core/src/bake/unarchive.rs
@@ -41,7 +41,7 @@ pub async fn bake_unarchive(
             started_at: std::time::Instant::now(),
             total_bytes: uncompressed_archive_size,
         },
-        JobContext::default(),
+        JobContext::from_meta(meta),
     );
 
     let (entry_tx, mut entry_rx) = tokio::sync::mpsc::channel(16);

--- a/crates/brioche-core/src/cache.rs
+++ b/crates/brioche-core/src/cache.rs
@@ -9,7 +9,7 @@ use crate::{
     Brioche,
     project::ProjectHash,
     recipe::{Artifact, RecipeHash},
-    reporter::job::CacheFetchKind,
+    reporter::job::{CacheFetchKind, JobContext},
 };
 
 mod archive;
@@ -280,6 +280,7 @@ pub async fn load_artifact(
     brioche: &Brioche,
     artifact_hash: RecipeHash,
     fetch_kind: CacheFetchKind,
+    context: JobContext,
 ) -> anyhow::Result<Option<Artifact>> {
     // Check if this artifact should be skipped
     if SKIP_CACHE_ARTIFACTS.contains(&artifact_hash.to_string()) {
@@ -310,7 +311,8 @@ pub async fn load_artifact(
         async_compression::tokio::bufread::ZstdDecoder::new(archive_reader_buffered);
 
     let artifact =
-        archive::read_artifact_archive(brioche, &store, fetch_kind, &mut archive_reader).await?;
+        archive::read_artifact_archive(brioche, &store, fetch_kind, context, &mut archive_reader)
+            .await?;
 
     let actual_hash = artifact.hash();
     anyhow::ensure!(

--- a/crates/brioche-core/src/cache/archive.rs
+++ b/crates/brioche-core/src/cache/archive.rs
@@ -26,7 +26,7 @@ use crate::{
     recipe::{Artifact, Recipe, RecipeHash},
     reporter::{
         JobId,
-        job::{CacheFetchKind, NewJob, UpdateJob},
+        job::{CacheFetchKind, JobContext, NewJob, UpdateJob},
     },
 };
 
@@ -351,14 +351,18 @@ pub async fn read_artifact_archive(
     brioche: &Brioche,
     store: &Arc<dyn object_store::ObjectStore>,
     fetch_kind: CacheFetchKind,
+    context: JobContext,
     mut reader: &mut (impl tokio::io::AsyncRead + Unpin),
 ) -> anyhow::Result<Artifact> {
-    let job_id = brioche.reporter.add_job(NewJob::CacheFetch {
-        kind: fetch_kind,
-        downloaded_bytes: None,
-        total_bytes: None,
-        started_at: std::time::Instant::now(),
-    });
+    let job_id = brioche.reporter.add_job(
+        NewJob::CacheFetch {
+            kind: fetch_kind,
+            downloaded_bytes: None,
+            total_bytes: None,
+            started_at: std::time::Instant::now(),
+        },
+        context,
+    );
 
     // Read and validate the marker from the archive
     let mut marker = [0; MARKER.len()];

--- a/crates/brioche-core/src/download.rs
+++ b/crates/brioche-core/src/download.rs
@@ -4,7 +4,7 @@ use tokio_util::compat::FuturesAsyncReadCompatExt as _;
 
 use crate::{
     Brioche,
-    reporter::job::{NewJob, UpdateJob},
+    reporter::job::{JobContext, NewJob, UpdateJob},
 };
 
 #[tracing::instrument(skip_all, fields(%url))]
@@ -12,6 +12,7 @@ pub async fn download(
     brioche: &Brioche,
     url: &url::Url,
     expected_hash: Option<crate::Hash>,
+    context: JobContext,
 ) -> anyhow::Result<crate::blob::BlobHash> {
     // Acquire a permit to save the blob
     let mut save_blob_permit = crate::blob::get_save_blob_permit().await?;
@@ -23,10 +24,13 @@ pub async fn download(
 
     tracing::debug!(%url, "starting download");
 
-    let job_id = brioche.reporter.add_job(NewJob::Download {
-        url: url.clone(),
-        started_at: std::time::Instant::now(),
-    });
+    let job_id = brioche.reporter.add_job(
+        NewJob::Download {
+            url: url.clone(),
+            started_at: std::time::Instant::now(),
+        },
+        context,
+    );
 
     let response = brioche.download_client.get(url.clone()).send().await?;
     let response = response.error_for_status()?;

--- a/crates/brioche-core/src/process_events/display.rs
+++ b/crates/brioche-core/src/process_events/display.rs
@@ -116,22 +116,11 @@ where
                 let stack_frames = description.meta.source.as_deref().unwrap_or_default();
 
                 for stack_frame in stack_frames {
-                    let Some(file_name) = &stack_frame.file_name else {
+                    if stack_frame.file_name.is_none() {
                         println!("- [unknown]");
-                        continue;
-                    };
-
-                    let Some(line_number) = stack_frame.line_number else {
-                        println!("- {file_name}");
-                        continue;
-                    };
-
-                    let Some(column_number) = stack_frame.column_number else {
-                        println!("- {file_name}:{line_number}");
-                        continue;
-                    };
-
-                    println!("- {file_name}:{line_number}:{column_number}");
+                    } else {
+                        println!("- {stack_frame}");
+                    }
                 }
 
                 if stack_frames.is_empty() {

--- a/crates/brioche-core/src/project/load.rs
+++ b/crates/brioche-core/src/project/load.rs
@@ -15,6 +15,7 @@ use crate::{
     Brioche,
     project::{DependencyRef, ProjectEntry, Workspace, WorkspaceHash},
     recipe::{Artifact, Directory},
+    reporter::job::{CacheFetchKind, JobContext},
 };
 
 use super::{
@@ -792,7 +793,8 @@ pub async fn fetch_project_from_cache(
     let project_artifact = crate::cache::load_artifact(
         brioche,
         project_artifact_hash,
-        crate::reporter::job::CacheFetchKind::Project,
+        CacheFetchKind::Project,
+        JobContext::default(),
     )
     .await?
     .with_context(|| {
@@ -1079,7 +1081,9 @@ async fn resolve_static(
                 }
                 (None, ProjectLocking::Unlocked) => {
                     // Download the URL as a blob
-                    let new_blob_hash = crate::download::download(brioche, url, None).await?;
+                    let new_blob_hash =
+                        crate::download::download(brioche, url, None, JobContext::default())
+                            .await?;
                     let blob_path = crate::blob::local_blob_path(brioche, new_blob_hash);
                     let mut blob = tokio::fs::File::open(&blob_path).await?;
 

--- a/crates/brioche-core/src/project/load.rs
+++ b/crates/brioche-core/src/project/load.rs
@@ -1094,9 +1094,13 @@ async fn resolve_static(
                     // immediately with the stored Hash.
                     let cached_hash = once_cell
                         .get_or_try_init(|| async {
-                            let new_blob_hash =
-                                crate::download::download(brioche, url, None, JobContext::default())
-                                    .await?;
+                            let new_blob_hash = crate::download::download(
+                                brioche,
+                                url,
+                                None,
+                                JobContext::default(),
+                            )
+                            .await?;
                             let blob_path = crate::blob::local_blob_path(brioche, new_blob_hash);
                             let mut blob = tokio::fs::File::open(&blob_path).await?;
 

--- a/crates/brioche-core/src/recipe.rs
+++ b/crates/brioche-core/src/recipe.rs
@@ -455,21 +455,26 @@ pub struct StackFrame {
     pub file_name: Option<String>,
     pub line_number: Option<i64>,
     pub column_number: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub project_name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub module_path: Option<String>,
 }
 
 impl std::fmt::Display for StackFrame {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let file_name = self.file_name.as_deref().unwrap_or("<unknown>");
+        let path: std::borrow::Cow<'_, str> = match (&self.project_name, &self.module_path) {
+            (Some(project), Some(module)) => std::borrow::Cow::Owned(format!("{project}/{module}")),
+            (None, Some(module)) => std::borrow::Cow::Borrowed(module),
+            _ => self.file_name.as_deref().map_or(
+                std::borrow::Cow::Borrowed("<unknown>"),
+                std::borrow::Cow::Borrowed,
+            ),
+        };
         match (self.line_number, self.column_number) {
-            (Some(line), Some(column)) => {
-                write!(f, "{file_name}:{line}:{column}")
-            }
-            (Some(line), None) => {
-                write!(f, "{file_name}:{line}")
-            }
-            (None, _) => {
-                write!(f, "{file_name}")
-            }
+            (Some(line), Some(column)) => write!(f, "{path}:{line}:{column}"),
+            (Some(line), None) => write!(f, "{path}:{line}"),
+            (None, _) => write!(f, "{path}"),
         }
     }
 }
@@ -1462,7 +1467,7 @@ impl CompressionFormat {
 
 #[cfg(test)]
 mod tests {
-    use super::{CompleteProcessTemplate, CompleteProcessTemplateComponent};
+    use super::{CompleteProcessTemplate, CompleteProcessTemplateComponent, StackFrame};
 
     fn tpl(
         components: impl IntoIterator<Item = CompleteProcessTemplateComponent>,
@@ -1608,5 +1613,60 @@ mod tests {
                 tpl([]),
             ]
         );
+    }
+
+    #[test]
+    fn test_stack_frame_display() {
+        let cases: &[(_, _, _, _, _, &str)] = &[
+            // project+module wins over file_name
+            (
+                Some("file:///abs/path/myproj/build.bri"),
+                Some("myproj"),
+                Some("build.bri"),
+                Some(7),
+                Some(25),
+                "myproj/build.bri:7:25",
+            ),
+            // module_path alone is used when project_name is absent
+            (
+                Some("file:///abs/path/myproj/sub/build.bri"),
+                None,
+                Some("sub/build.bri"),
+                Some(3),
+                None,
+                "sub/build.bri:3",
+            ),
+            // file_name is the final fallback when neither field is set
+            (
+                Some("briocheruntime:///dist/std/process.js"),
+                None,
+                None,
+                Some(42),
+                Some(1),
+                "briocheruntime:///dist/std/process.js:42:1",
+            ),
+            // entirely-empty frame renders the placeholder
+            (None, None, None, None, None, "<unknown>"),
+            // line-only (no column) still produces `:line`
+            (
+                None,
+                Some("myproj"),
+                Some("main.bri"),
+                Some(10),
+                None,
+                "myproj/main.bri:10",
+            ),
+        ];
+
+        for (file_name, project_name, module_path, line, col, expected) in cases {
+            let frame = StackFrame {
+                file_name: file_name.map(str::to_owned),
+                line_number: *line,
+                column_number: *col,
+                project_name: project_name.map(str::to_owned),
+                module_path: module_path.map(str::to_owned),
+            };
+            assert_eq!(frame.to_string(), *expected);
+        }
     }
 }

--- a/crates/brioche-core/src/recipe.rs
+++ b/crates/brioche-core/src/recipe.rs
@@ -354,6 +354,13 @@ pub struct Meta {
     pub source: Option<Vec<StackFrame>>,
 }
 
+impl Meta {
+    #[must_use]
+    pub fn source_frame(&self) -> Option<&StackFrame> {
+        self.source.as_ref().and_then(|frames| frames.first())
+    }
+}
+
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct WithMeta<T> {
     #[serde(default, skip_serializing)]
@@ -390,7 +397,7 @@ impl<T> WithMeta<T> {
     }
 
     pub fn source_frame(&self) -> Option<&StackFrame> {
-        self.meta.source.as_ref().and_then(|frames| frames.first())
+        self.meta.source_frame()
     }
 }
 

--- a/crates/brioche-core/src/reporter.rs
+++ b/crates/brioche-core/src/reporter.rs
@@ -183,13 +183,13 @@ impl Reporter {
     }
 
     #[must_use]
-    pub fn add_job(&self, job: job::NewJob) -> JobId {
+    pub fn add_job(&self, job: job::NewJob, context: job::JobContext) -> JobId {
         let id = self
             .num_jobs
             .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
         let id = JobId(id);
 
-        let _ = self.tx.send(ReportEvent::AddJob { id, job });
+        let _ = self.tx.send(ReportEvent::AddJob { id, job, context });
 
         id
     }
@@ -238,9 +238,18 @@ impl std::io::Write for ReporterWriter {
 }
 
 enum ReportEvent {
-    Emit { lines: superconsole::Lines },
-    AddJob { id: JobId, job: job::NewJob },
-    UpdateJobState { id: JobId, update: job::UpdateJob },
+    Emit {
+        lines: superconsole::Lines,
+    },
+    AddJob {
+        id: JobId,
+        job: job::NewJob,
+        context: job::JobContext,
+    },
+    UpdateJobState {
+        id: JobId,
+        update: job::UpdateJob,
+    },
     Shutdown,
 }
 

--- a/crates/brioche-core/src/reporter/console.rs
+++ b/crates/brioche-core/src/reporter/console.rs
@@ -751,8 +751,7 @@ impl superconsole::Component for JobComponent<'_> {
                 url,
                 downloaded_bytes,
                 total_bytes,
-                started_at: _,
-                finished_at: _,
+                ..
             } => {
                 let progress_fraction = total_bytes
                     .map(|total_bytes| fraction_of(*downloaded_bytes as f32, total_bytes as f32));
@@ -822,8 +821,7 @@ impl superconsole::Component for JobComponent<'_> {
             Job::Unarchive {
                 read_bytes,
                 total_bytes,
-                started_at: _,
-                finished_at: _,
+                ..
             } => {
                 let progress_fraction = fraction_of(*read_bytes as f32, *total_bytes as f32);
                 let progress_percent = (progress_fraction * 100.0).floor() as u8;
@@ -873,10 +871,7 @@ impl superconsole::Component for JobComponent<'_> {
 
                 superconsole::Lines::from_iter([line])
             }
-            Job::Process {
-                packet_queue: _,
-                status,
-            } => {
+            Job::Process { status, .. } => {
                 let child_id = status
                     .child_id()
                     .map_or_else(|| "?".to_string(), |id| id.to_string());
@@ -946,11 +941,9 @@ impl superconsole::Component for JobComponent<'_> {
                 superconsole::Lines::from_iter([line])
             }
             Job::CacheFetch {
-                kind,
                 downloaded_bytes,
                 total_bytes,
-                started_at: _,
-                finished_at: _,
+                ..
             } => {
                 let progress_fraction = total_bytes.map_or(0.0, |total_bytes| {
                     fraction_of(*downloaded_bytes as f32, total_bytes as f32)
@@ -980,17 +973,10 @@ impl superconsole::Component for JobComponent<'_> {
                 let downloaded_size = bytesize::ByteSize(*downloaded_bytes);
                 let total_size = total_bytes.map(bytesize::ByteSize);
 
-                let fetch_kind = match kind {
-                    super::job::CacheFetchKind::Bake => "artifact",
-                    super::job::CacheFetchKind::Project => "project",
-                };
-                let fetching_message = if job.is_complete() {
-                    format!("{fetch_kind}{SECTION_SEPARATOR}{downloaded_size}")
-                } else if let Some(total_size) = total_size {
-                    format!("{fetch_kind}{SECTION_SEPARATOR}{downloaded_size} / {total_size}")
-                } else {
-                    fetch_kind.to_string()
-                };
+                let fetching_message = total_size.map_or_else(
+                    || downloaded_size.to_string(),
+                    |total_size| format!("{downloaded_size} / {total_size}"),
+                );
 
                 let label_reserved = source_label_reserved_width(source_label);
                 let remaining_width = dimensions

--- a/crates/brioche-core/src/reporter/console.rs
+++ b/crates/brioche-core/src/reporter/console.rs
@@ -571,7 +571,13 @@ impl superconsole::Component for JobsComponent {
 
         let jobs_lines = job_list
             .map(|(job_id, job)| {
-                JobComponent(**job_id, job).draw(
+                let context = self.contexts.get(job_id);
+                JobComponent {
+                    id: **job_id,
+                    job,
+                    context,
+                }
+                .draw(
                     superconsole::Dimensions {
                         width: dimensions.width,
                         height: 1,
@@ -687,7 +693,11 @@ impl superconsole::Component for JobsComponent {
     }
 }
 
-struct JobComponent<'a>(JobId, &'a Job);
+struct JobComponent<'a> {
+    id: JobId,
+    job: &'a Job,
+    context: Option<&'a JobContext>,
+}
 
 impl superconsole::Component for JobComponent<'_> {
     #[expect(
@@ -700,7 +710,9 @@ impl superconsole::Component for JobComponent<'_> {
         dimensions: superconsole::Dimensions,
         _mode: superconsole::DrawMode,
     ) -> anyhow::Result<superconsole::Lines> {
-        let &JobComponent(job_id, job) = self;
+        let job_id = self.id;
+        let job = self.job;
+        let source_label = self.context.and_then(|c| c.source_label.as_deref());
 
         let elapsed_span = match (job.started_at(), job.finished_at()) {
             (Some(started_at), Some(finished_at)) => {
@@ -760,10 +772,12 @@ impl superconsole::Component for JobComponent<'_> {
                     superconsole::Span::new_unstyled_lossy(" "),
                 ]);
 
+                let label_reserved = source_label_reserved_width(source_label);
                 let remaining_width = dimensions
                     .width
                     .saturating_sub(1)
-                    .saturating_sub(line.len());
+                    .saturating_sub(line.len())
+                    .saturating_sub(label_reserved);
 
                 let downloaded_size = bytesize::ByteSize(*downloaded_bytes);
                 let total_size = total_bytes.map(bytesize::ByteSize);
@@ -787,6 +801,8 @@ impl superconsole::Component for JobComponent<'_> {
                     remaining_width,
                     progress_fraction.unwrap_or(0.0),
                 ));
+
+                append_source_label(&mut line, source_label, dimensions);
 
                 superconsole::Lines::from_iter([line])
             }
@@ -817,10 +833,12 @@ impl superconsole::Component for JobComponent<'_> {
                     superconsole::Span::new_unstyled_lossy(" "),
                 ]);
 
+                let label_reserved = source_label_reserved_width(source_label);
                 let remaining_width = dimensions
                     .width
                     .saturating_sub(1)
-                    .saturating_sub(line.len());
+                    .saturating_sub(line.len())
+                    .saturating_sub(label_reserved);
 
                 let read_size = bytesize::ByteSize(*read_bytes);
                 let total_size = bytesize::ByteSize(*total_bytes);
@@ -835,6 +853,8 @@ impl superconsole::Component for JobComponent<'_> {
                     remaining_width,
                     progress_fraction,
                 ));
+
+                append_source_label(&mut line, source_label, dimensions);
 
                 superconsole::Lines::from_iter([line])
             }
@@ -893,7 +913,7 @@ impl superconsole::Component for JobComponent<'_> {
                 let child_id_span =
                     superconsole::Span::new_colored_lossy(&child_id, job_color(job_id));
 
-                superconsole::Lines::from_iter([[
+                let mut line: superconsole::Line = [
                     elapsed_span,
                     superconsole::Span::new_unstyled_lossy(" "),
                     indicator_span(indicator),
@@ -901,8 +921,13 @@ impl superconsole::Component for JobComponent<'_> {
                     child_id_span,
                 ]
                 .into_iter()
-                .chain(note_span)
-                .collect::<superconsole::Line>()])
+                .collect();
+
+                append_source_label(&mut line, source_label, dimensions);
+
+                line.extend(note_span);
+
+                superconsole::Lines::from_iter([line])
             }
             Job::CacheFetch {
                 kind,
@@ -950,15 +975,19 @@ impl superconsole::Component for JobComponent<'_> {
                     format!("Fetch {fetch_kind}")
                 };
 
+                let label_reserved = source_label_reserved_width(source_label);
                 let remaining_width = dimensions
                     .width
                     .saturating_sub(1)
-                    .saturating_sub(line.len());
+                    .saturating_sub(line.len())
+                    .saturating_sub(label_reserved);
                 line.extend(progress_bar_spans(
                     &fetching_message,
                     remaining_width,
                     progress_fraction,
                 ));
+
+                append_source_label(&mut line, source_label, dimensions);
 
                 superconsole::Lines::from_iter([line])
             }
@@ -1000,6 +1029,36 @@ fn cmp_job_entries(
                 })
         }
     }
+}
+
+/// Width the caller must reserve for the trailing source label so the
+/// progress bar doesn't consume the space and squeeze the label out
+/// entirely. Accounts for the leading space and the parens.
+fn source_label_reserved_width(label: Option<&str>) -> usize {
+    label.map_or(0, |label| label.chars().count() + 3)
+}
+
+/// Shared across every job kind so the label position and styling stay
+/// consistent.
+fn append_source_label(
+    line: &mut superconsole::Line,
+    label: Option<&str>,
+    dimensions: superconsole::Dimensions,
+) {
+    let Some(label) = label else { return };
+    let remaining_width = dimensions
+        .width
+        .saturating_sub(1)
+        .saturating_sub(line.len());
+    if remaining_width == 0 {
+        return;
+    }
+    let label_with_parens = format!(" ({label})");
+    let truncated = string_with_width(&label_with_parens, remaining_width, "...");
+    line.push(superconsole::Span::new_colored_lossy(
+        &truncated,
+        superconsole::style::Color::DarkGrey,
+    ));
 }
 
 fn with_label(message: &str, context: &JobContext) -> String {

--- a/crates/brioche-core/src/reporter/console.rs
+++ b/crates/brioche-core/src/reporter/console.rs
@@ -18,6 +18,22 @@ use super::{
     tracing_debug_filter, tracing_output_filter, tracing_root_filter,
 };
 
+// Render at 30 fps
+const RENDER_RATE: std::time::Duration = std::time::Duration::from_nanos(1_000_000_000 / 30);
+
+// Minimum amount of time to sleep before rendering next frame, even if
+// the next frame will be late
+const MIN_RENDER_WAIT: std::time::Duration = std::time::Duration::from_millis(1);
+
+/// Pads every job-kind keyword to the same width so kinds line up in a
+/// right-aligned column across rows.
+const JOB_KIND_WIDTH: usize = 9;
+
+/// Visual separator between independent sections of the details column.
+/// Leading and trailing spaces are baked in so callers don't add their own
+/// and risk doubling them up.
+const SECTION_SEPARATOR: &str = " · ";
+
 #[derive(Debug, Clone, Copy)]
 pub enum ConsoleReporterKind {
     Auto,
@@ -25,13 +41,6 @@ pub enum ConsoleReporterKind {
     Plain,
     PlainReduced,
 }
-
-// Render at 30 fps
-const RENDER_RATE: std::time::Duration = std::time::Duration::from_nanos(1_000_000_000 / 30);
-
-// Minimum amount of time to sleep before rendering next frame, even if
-// the next frame will be late
-const MIN_RENDER_WAIT: std::time::Duration = std::time::Duration::from_millis(1);
 
 pub fn start_console_reporter(
     kind: ConsoleReporterKind,
@@ -225,9 +234,7 @@ impl ConsoleReporter {
                 root.jobs.insert(id, new_job);
                 root.contexts.insert(id, context);
             }
-            Self::Plain {
-                jobs, contexts, ..
-            } => {
+            Self::Plain { jobs, contexts, .. } => {
                 match &job {
                     NewJob::Download { url, started_at: _ } => {
                         eprintln!("{}", with_label(&format!("Downloading {url}"), &context));
@@ -235,16 +242,17 @@ impl ConsoleReporter {
                     NewJob::Unarchive {
                         started_at: _,
                         total_bytes: _,
+                    } => {}
+                    NewJob::Process { status: _ } => {
+                        if context.source_label.is_some() {
+                            eprintln!("{}", with_label("Preparing process", &context));
+                        }
                     }
-                    | NewJob::Process { status: _ } => {}
                     NewJob::CacheFetch {
                         kind: super::job::CacheFetchKind::Bake,
                         ..
                     } => {
-                        eprintln!(
-                            "{}",
-                            with_label("Fetching artifact from cache", &context)
-                        );
+                        eprintln!("{}", with_label("Fetching artifact from cache", &context));
                     }
                     NewJob::CacheFetch {
                         kind: super::job::CacheFetchKind::Project,
@@ -340,7 +348,9 @@ impl ConsoleReporter {
                             eprintln!(
                                 "{}",
                                 with_label(
-                                    &format!("Finished unarchiving {read_size} in {elapsed_duration}"),
+                                    &format!(
+                                        "Finished unarchiving {read_size} in {elapsed_duration}"
+                                    ),
                                     &context,
                                 )
                             );
@@ -767,7 +777,8 @@ impl superconsole::Component for JobComponent<'_> {
                     elapsed_span,
                     superconsole::Span::new_unstyled_lossy(" "),
                     indicator_span(indicator),
-                    superconsole::Span::new_unstyled_lossy(" Download  "),
+                    job_kind_span("Download"),
+                    superconsole::Span::new_unstyled_lossy(" "),
                     percentage_span,
                     superconsole::Span::new_unstyled_lossy(" "),
                 ]);
@@ -781,25 +792,27 @@ impl superconsole::Component for JobComponent<'_> {
 
                 let downloaded_size = bytesize::ByteSize(*downloaded_bytes);
                 let total_size = total_bytes.map(bytesize::ByteSize);
-                let mut download_message = total_size.map_or_else(
-                    || downloaded_size.to_string(),
-                    |total_size| format!("{downloaded_size} / {total_size}"),
-                );
-                let truncated_url = string_with_width(
-                    url.as_str(),
-                    remaining_width
-                        .saturating_sub(download_message.len())
-                        .saturating_sub(2),
-                    "…",
-                );
+                let size_text = match (job.is_complete(), total_size) {
+                    (false, Some(total)) => format!("{downloaded_size} / {total}"),
+                    (true, _) | (false, None) => downloaded_size.to_string(),
+                };
 
-                download_message += "  ";
-                download_message += &truncated_url;
+                let url_budget = remaining_width
+                    .saturating_sub(size_text.chars().count())
+                    .saturating_sub(SECTION_SEPARATOR.chars().count());
+                let url_str = url.as_str();
+                let url_text = if url_str.chars().count() > url_budget {
+                    string_with_width_keep_end(url_str, url_budget, "…")
+                } else {
+                    Cow::Borrowed(url_str)
+                };
+                let details = format!("{url_text}{SECTION_SEPARATOR}{size_text}");
 
-                line.extend(progress_bar_spans(
-                    &download_message,
+                line.extend(details_spans(
+                    &details,
                     remaining_width,
                     progress_fraction.unwrap_or(0.0),
+                    job.is_complete(),
                 ));
 
                 append_source_label(&mut line, source_label, dimensions);
@@ -828,7 +841,8 @@ impl superconsole::Component for JobComponent<'_> {
                     elapsed_span,
                     superconsole::Span::new_unstyled_lossy(" "),
                     indicator_span(indicator),
-                    superconsole::Span::new_unstyled_lossy(" Unarchive "),
+                    job_kind_span("Unarchive"),
+                    superconsole::Span::new_unstyled_lossy(" "),
                     percentage_span,
                     superconsole::Span::new_unstyled_lossy(" "),
                 ]);
@@ -843,15 +857,16 @@ impl superconsole::Component for JobComponent<'_> {
                 let read_size = bytesize::ByteSize(*read_bytes);
                 let total_size = bytesize::ByteSize(*total_bytes);
                 let unarchive_message = if job.is_complete() {
-                    format!("Unarchive: {read_size}")
+                    read_size.to_string()
                 } else {
-                    format!("Unarchive: {read_size} / {total_size}")
+                    format!("{read_size} / {total_size}")
                 };
 
-                line.extend(progress_bar_spans(
+                line.extend(details_spans(
                     &unarchive_message,
                     remaining_width,
                     progress_fraction,
+                    job.is_complete(),
                 ));
 
                 append_source_label(&mut line, source_label, dimensions);
@@ -917,7 +932,8 @@ impl superconsole::Component for JobComponent<'_> {
                     elapsed_span,
                     superconsole::Span::new_unstyled_lossy(" "),
                     indicator_span(indicator),
-                    superconsole::Span::new_unstyled_lossy(" Process "),
+                    job_kind_span("Process"),
+                    superconsole::Span::new_unstyled_lossy(" "),
                     child_id_span,
                 ]
                 .into_iter()
@@ -955,7 +971,8 @@ impl superconsole::Component for JobComponent<'_> {
                     elapsed_span,
                     superconsole::Span::new_unstyled_lossy(" "),
                     indicator_span(indicator),
-                    superconsole::Span::new_unstyled_lossy(" Cache     "),
+                    job_kind_span("Cache"),
+                    superconsole::Span::new_unstyled_lossy(" "),
                     percentage_span,
                     superconsole::Span::new_unstyled_lossy(" "),
                 ]);
@@ -968,11 +985,11 @@ impl superconsole::Component for JobComponent<'_> {
                     super::job::CacheFetchKind::Project => "project",
                 };
                 let fetching_message = if job.is_complete() {
-                    format!("Fetch {fetch_kind}: {downloaded_size}")
+                    format!("{fetch_kind}{SECTION_SEPARATOR}{downloaded_size}")
                 } else if let Some(total_size) = total_size {
-                    format!("Fetch {fetch_kind}: {downloaded_size} / {total_size}")
+                    format!("{fetch_kind}{SECTION_SEPARATOR}{downloaded_size} / {total_size}")
                 } else {
-                    format!("Fetch {fetch_kind}")
+                    fetch_kind.to_string()
                 };
 
                 let label_reserved = source_label_reserved_width(source_label);
@@ -981,10 +998,11 @@ impl superconsole::Component for JobComponent<'_> {
                     .saturating_sub(1)
                     .saturating_sub(line.len())
                     .saturating_sub(label_reserved);
-                line.extend(progress_bar_spans(
+                line.extend(details_spans(
                     &fetching_message,
                     remaining_width,
                     progress_fraction,
+                    job.is_complete(),
                 ));
 
                 append_source_label(&mut line, source_label, dimensions);
@@ -1029,6 +1047,55 @@ fn cmp_job_entries(
                 })
         }
     }
+}
+
+/// Plain padded text for completed jobs and the progress-bar background
+/// for active ones. Splitting the two visually so completed rows feel
+/// quieter than active ones, otherwise a screen full of finished jobs
+/// reads the same as a screen full of running ones.
+fn details_spans(
+    message: &str,
+    width: usize,
+    progress_fraction: f32,
+    is_complete: bool,
+) -> Vec<superconsole::Span> {
+    if is_complete {
+        let padded = format!("{message:width$.width$}");
+        vec![superconsole::Span::new_unstyled_lossy(padded)]
+    } else {
+        progress_bar_spans(message, width, progress_fraction).to_vec()
+    }
+}
+
+/// Truncates from the LEFT so the tail of `s` survives. URLs have their
+/// identifying portion at the end, so middle-truncation cuts through the
+/// most useful chars.
+fn string_with_width_keep_end<'a>(s: &'a str, num_chars: usize, replacement: &str) -> Cow<'a, str> {
+    if num_chars == 0 {
+        return Cow::Borrowed("");
+    }
+
+    let s_chars = s.chars().count();
+
+    match s_chars.cmp(&num_chars) {
+        std::cmp::Ordering::Equal => Cow::Borrowed(s),
+        std::cmp::Ordering::Less => Cow::Owned(format!("{s:num_chars$}")),
+        std::cmp::Ordering::Greater => {
+            let replacement_chars = replacement.chars().count();
+            if num_chars <= replacement_chars {
+                return Cow::Owned(replacement.chars().take(num_chars).collect());
+            }
+            let keep_chars = num_chars - replacement_chars;
+            let skip_chars = s_chars - keep_chars;
+            let kept: String = s.chars().skip(skip_chars).collect();
+            Cow::Owned(format!("{replacement}{kept}"))
+        }
+    }
+}
+
+fn job_kind_span(name: &str) -> superconsole::Span {
+    let padded = format!(" {name:>JOB_KIND_WIDTH$}");
+    superconsole::Span::new_styled_lossy(padded.with(superconsole::style::Color::Green).bold())
 }
 
 /// Width the caller must reserve for the trailing source label so the

--- a/crates/brioche-core/src/reporter/console.rs
+++ b/crates/brioche-core/src/reporter/console.rs
@@ -13,7 +13,7 @@ use crate::utils::{DisplayDuration, output_buffer::OutputBuffer};
 
 use super::{
     JobId, ReportEvent, Reporter, ReporterGuard,
-    job::{Job, NewJob, ProcessStatus, ProcessStream, UpdateJob},
+    job::{Job, JobContext, NewJob, ProcessStatus, ProcessStream, UpdateJob},
     otel::OtelProvider,
     tracing_debug_filter, tracing_output_filter, tracing_root_filter,
 };
@@ -61,12 +61,14 @@ pub fn start_console_reporter(
         };
 
         let jobs = HashMap::new();
+        let contexts = HashMap::new();
         let job_outputs = OutputBuffer::with_max_capacity(1024 * 1024);
         let mut console = match (superconsole, kind) {
             (Some(console), _) => {
                 let root = JobsComponent {
                     start,
                     jobs,
+                    contexts,
                     job_outputs,
                 };
                 ConsoleReporter::SuperConsole { console, root }
@@ -76,10 +78,12 @@ pub fn start_console_reporter(
             }
             (_, ConsoleReporterKind::Auto | ConsoleReporterKind::Plain) => ConsoleReporter::Plain {
                 jobs,
+                contexts,
                 job_outputs: Some(job_outputs),
             },
             (_, ConsoleReporterKind::PlainReduced) => ConsoleReporter::Plain {
                 jobs,
+                contexts,
                 job_outputs: None,
             },
         };
@@ -106,8 +110,8 @@ pub fn start_console_reporter(
                     ReportEvent::Emit { lines } => {
                         console.emit(lines);
                     }
-                    ReportEvent::AddJob { id, job } => {
-                        console.add_job(id, job);
+                    ReportEvent::AddJob { id, job, context } => {
+                        console.add_job(id, job, context);
                     }
                     ReportEvent::UpdateJobState { id, update } => {
                         console.update_job(id, update);
@@ -194,6 +198,7 @@ enum ConsoleReporter {
     },
     Plain {
         jobs: HashMap<JobId, Job>,
+        contexts: HashMap<JobId, JobContext>,
         job_outputs: Option<OutputBuffer<JobOutputStream>>,
     },
 }
@@ -213,16 +218,19 @@ impl ConsoleReporter {
         }
     }
 
-    fn add_job(&mut self, id: JobId, job: NewJob) {
+    fn add_job(&mut self, id: JobId, job: NewJob, context: JobContext) {
         match self {
             Self::SuperConsole { root, .. } => {
                 let new_job = Job::new(job);
                 root.jobs.insert(id, new_job);
+                root.contexts.insert(id, context);
             }
-            Self::Plain { jobs, .. } => {
+            Self::Plain {
+                jobs, contexts, ..
+            } => {
                 match &job {
                     NewJob::Download { url, started_at: _ } => {
-                        eprintln!("Downloading {url}");
+                        eprintln!("{}", with_label(&format!("Downloading {url}"), &context));
                     }
                     NewJob::Unarchive {
                         started_at: _,
@@ -231,24 +239,24 @@ impl ConsoleReporter {
                     | NewJob::Process { status: _ } => {}
                     NewJob::CacheFetch {
                         kind: super::job::CacheFetchKind::Bake,
-                        downloaded_bytes: _,
-                        total_bytes: _,
-                        started_at: _,
+                        ..
                     } => {
-                        eprintln!("Fetching artifact from cache");
+                        eprintln!(
+                            "{}",
+                            with_label("Fetching artifact from cache", &context)
+                        );
                     }
                     NewJob::CacheFetch {
                         kind: super::job::CacheFetchKind::Project,
-                        downloaded_bytes: _,
-                        total_bytes: _,
-                        started_at: _,
+                        ..
                     } => {
-                        eprintln!("Fetching project from cache");
+                        eprintln!("{}", with_label("Fetching project from cache", &context));
                     }
                 }
 
                 let new_job = Job::new(job);
                 jobs.insert(id, new_job);
+                contexts.insert(id, context);
             }
         }
     }
@@ -279,10 +287,15 @@ impl ConsoleReporter {
                 };
                 let _ = job.update(update);
             }
-            Self::Plain { jobs, job_outputs } => {
+            Self::Plain {
+                jobs,
+                contexts,
+                job_outputs,
+            } => {
                 let Some(job) = jobs.get(&id) else {
                     return;
                 };
+                let context = contexts.get(&id).cloned().unwrap_or_default();
 
                 match &update {
                     UpdateJob::Download {
@@ -303,7 +316,13 @@ impl ConsoleReporter {
                             let elapsed_duration = DisplayDuration(elapsed);
 
                             eprintln!(
-                                "Finished downloading {url} ({downloaded_size}) in {elapsed_duration}"
+                                "{}",
+                                with_label(
+                                    &format!(
+                                        "Finished downloading {url} ({downloaded_size}) in {elapsed_duration}"
+                                    ),
+                                    &context,
+                                )
                             );
                         }
                     }
@@ -318,7 +337,13 @@ impl ConsoleReporter {
                             let read_size = bytesize::ByteSize(*read_bytes);
                             let elapsed_duration = DisplayDuration(elapsed);
 
-                            eprintln!("Finished unarchiving {read_size} in {elapsed_duration}");
+                            eprintln!(
+                                "{}",
+                                with_label(
+                                    &format!("Finished unarchiving {read_size} in {elapsed_duration}"),
+                                    &context,
+                                )
+                            );
                         }
                     }
                     UpdateJob::ProcessUpdateStatus { status } => {
@@ -348,7 +373,13 @@ impl ConsoleReporter {
                                     );
                                 }
 
-                                eprintln!("Launched process {child_id_label}");
+                                eprintln!(
+                                    "{}",
+                                    with_label(
+                                        &format!("Launched process {child_id_label}"),
+                                        &context,
+                                    )
+                                );
                             }
                             ProcessStatus::Ran {
                                 started_at,
@@ -433,7 +464,13 @@ impl ConsoleReporter {
                         let elapsed_duration = DisplayDuration(elapsed);
 
                         eprintln!(
-                            "Fetched {downloaded_size} for {fetch_kind} from cache in {elapsed_duration}",
+                            "{}",
+                            with_label(
+                                &format!(
+                                    "Fetched {downloaded_size} for {fetch_kind} from cache in {elapsed_duration}"
+                                ),
+                                &context,
+                            )
                         );
                     }
                 }
@@ -501,6 +538,7 @@ const JOB_LABEL_WIDTH: usize = 7;
 struct JobsComponent {
     start: std::time::Instant,
     jobs: HashMap<JobId, Job>,
+    contexts: HashMap<JobId, JobContext>,
     job_outputs: OutputBuffer<JobOutputStream>,
 }
 
@@ -962,6 +1000,13 @@ fn cmp_job_entries(
                 })
         }
     }
+}
+
+fn with_label(message: &str, context: &JobContext) -> String {
+    context.source_label.as_ref().map_or_else(
+        || message.to_string(),
+        |label| format!("{message} ({label})"),
+    )
 }
 
 fn string_with_width<'a>(s: &'a str, num_chars: usize, replacement: &str) -> Cow<'a, str> {

--- a/crates/brioche-core/src/reporter/job.rs
+++ b/crates/brioche-core/src/reporter/job.rs
@@ -2,9 +2,20 @@ use std::sync::{Arc, RwLock};
 
 use debug_ignore::DebugIgnore;
 
+use crate::recipe::{Meta, StackFrame};
+
 #[derive(Debug, Clone, Default)]
 pub struct JobContext {
     pub source_label: Option<String>,
+}
+
+impl JobContext {
+    #[must_use]
+    pub fn from_meta(meta: &Meta) -> Self {
+        Self {
+            source_label: meta.source_frame().map(StackFrame::to_string),
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/crates/brioche-core/src/reporter/job.rs
+++ b/crates/brioche-core/src/reporter/job.rs
@@ -2,6 +2,11 @@ use std::sync::{Arc, RwLock};
 
 use debug_ignore::DebugIgnore;
 
+#[derive(Debug, Clone, Default)]
+pub struct JobContext {
+    pub source_label: Option<String>,
+}
+
 #[derive(Debug)]
 pub enum NewJob {
     Download {

--- a/crates/brioche-core/src/script.rs
+++ b/crates/brioche-core/src/script.rs
@@ -9,10 +9,11 @@ use std::{
 
 use anyhow::Context as _;
 use bridge::{GetStaticOptions, RuntimeBridge};
-use deno_core::OpState;
+use deno_core::{OpState, v8};
+use relative_path::PathExt as _;
 use specifier::BriocheModuleSpecifier;
 
-use crate::bake::BakeScope;
+use crate::{bake::BakeScope, project::Projects, recipe::StackFrame};
 
 use super::{
     blob::BlobHash,
@@ -225,14 +226,17 @@ deno_core::extension!(brioche_rt,
         op_brioche_create_proxy,
         op_brioche_read_blob,
         op_brioche_get_static,
+        op_brioche_stack_frames_from_exception,
     ],
     options = {
         bridge: RuntimeBridge,
         bake_scope: BakeScope,
+        projects: Projects,
     },
     state = |state, options| {
         state.put(options.bridge);
         state.put(options.bake_scope);
+        state.put(options.projects);
     },
 );
 
@@ -319,6 +323,69 @@ pub async fn op_brioche_get_static(
 
     let recipe = bridge.get_static(specifier, options).await?;
     Ok(recipe)
+}
+
+#[deno_core::op2(reentrant)]
+#[serde]
+fn op_brioche_stack_frames_from_exception<'a>(
+    state: Rc<RefCell<OpState>>,
+    scope: &mut v8::PinScope<'a, 'a>,
+    exception: v8::Local<'a, v8::Value>,
+) -> Vec<StackFrame> {
+    let projects = state.borrow().try_borrow::<Projects>().cloned();
+    drop(state);
+
+    let error = deno_core::error::JsError::from_v8_exception(scope, exception);
+    error
+        .frames
+        .into_iter()
+        .map(|frame| enrich_stack_frame(projects.as_ref(), frame))
+        .collect()
+}
+
+fn enrich_stack_frame(
+    projects: Option<&Projects>,
+    frame: deno_core::error::JsStackFrame,
+) -> StackFrame {
+    let (project_name, module_path) = projects
+        .and_then(|p| resolve_frame_project_context(p, frame.file_name.as_deref()))
+        .unzip();
+    StackFrame {
+        file_name: frame.file_name,
+        line_number: frame.line_number,
+        column_number: frame.column_number,
+        project_name,
+        module_path,
+    }
+}
+
+fn resolve_frame_project_context(
+    projects: &Projects,
+    file_name: Option<&str>,
+) -> Option<(String, String)> {
+    let file_name = file_name?;
+    let url: url::Url = file_name.parse().ok()?;
+    let specifier = BriocheModuleSpecifier::try_from(&url).ok()?;
+    let path = match specifier {
+        BriocheModuleSpecifier::File { path } => path,
+        BriocheModuleSpecifier::Runtime { .. } => return None,
+    };
+
+    let project_hash = projects.find_containing_project(&path).ok().flatten()?;
+    let project_root = projects
+        .find_containing_project_root(&path, project_hash)
+        .ok()?;
+    let project = projects.project(project_hash).ok()?;
+
+    let project_name = project.definition.name.clone().or_else(|| {
+        project_root
+            .file_name()
+            .and_then(|n| n.to_str())
+            .map(str::to_owned)
+    })?;
+    let module_path = path.relative_to(&project_root).ok()?.to_string();
+
+    Some((project_name, module_path))
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/brioche-core/src/script/evaluate.rs
+++ b/crates/brioche-core/src/script/evaluate.rs
@@ -28,6 +28,7 @@ pub async fn evaluate(
         export.to_string(),
         main_module,
         bridge,
+        projects.clone(),
     )
     .await?;
     Ok(result)
@@ -39,6 +40,7 @@ async fn evaluate_with_deno(
     export: String,
     main_module: super::specifier::BriocheModuleSpecifier,
     bridge: RuntimeBridge,
+    projects: Projects,
 ) -> anyhow::Result<WithMeta<Recipe>> {
     // Create a channel to get the result from the other Tokio runtime
     let (result_tx, result_rx) =
@@ -72,7 +74,7 @@ async fn evaluate_with_deno(
             let mut js_runtime = deno_core::JsRuntime::new(deno_core::RuntimeOptions {
                 module_loader: Some(Rc::new(module_loader)),
                 extensions: vec![
-                    super::brioche_rt::init(bridge, bake_scope),
+                    super::brioche_rt::init(bridge, bake_scope, projects),
                     super::js::brioche_js::init(),
                 ],
                 ..Default::default()

--- a/crates/brioche-core/src/script/js.rs
+++ b/crates/brioche-core/src/script/js.rs
@@ -2,15 +2,12 @@ use anyhow::Context as _;
 use deno_core::v8;
 use std::borrow::Cow;
 
-use crate::recipe::StackFrame;
-
 deno_core::extension!(
     brioche_js,
     ops = [
         op_brioche_version,
         op_brioche_current_platform,
         op_brioche_console,
-        op_brioche_stack_frames_from_exception,
         op_brioche_utf8_encode,
         op_brioche_utf8_decode,
         op_brioche_tick_encode,
@@ -49,26 +46,6 @@ fn op_brioche_console(#[serde] level: ConsoleLevel, #[string] message: &str) {
         ConsoleLevel::Warn => tracing::warn!("{message}"),
         ConsoleLevel::Error => tracing::error!("{message}"),
     }
-}
-
-#[deno_core::op2(reentrant)]
-#[serde]
-fn op_brioche_stack_frames_from_exception<'a>(
-    scope: &mut v8::PinScope<'a, 'a>,
-    exception: v8::Local<'a, v8::Value>,
-) -> Vec<StackFrame> {
-    let error = deno_core::error::JsError::from_v8_exception(scope, exception);
-    error
-        .frames
-        .into_iter()
-        .map(|frame| StackFrame {
-            file_name: frame.file_name,
-            line_number: frame.line_number,
-            column_number: frame.column_number,
-            project_name: None,
-            module_path: None,
-        })
-        .collect()
 }
 
 #[deno_core::op2]

--- a/crates/brioche-core/src/script/js.rs
+++ b/crates/brioche-core/src/script/js.rs
@@ -65,6 +65,8 @@ fn op_brioche_stack_frames_from_exception<'a>(
             file_name: frame.file_name,
             line_number: frame.line_number,
             column_number: frame.column_number,
+            project_name: None,
+            module_path: None,
         })
         .collect()
 }

--- a/crates/brioche-core/tests/cache_client.rs
+++ b/crates/brioche-core/tests/cache_client.rs
@@ -63,6 +63,7 @@ async fn test_cache_client_save_and_load_artifact() -> anyhow::Result<()> {
             &brioche,
             artifact_hash,
             brioche_core::reporter::job::CacheFetchKind::Bake,
+            brioche_core::reporter::job::JobContext::default(),
         )
         .await?;
 
@@ -109,6 +110,7 @@ async fn test_cache_client_save_and_load_artifact_with_some_small_files() -> any
             &brioche,
             artifact_hash,
             brioche_core::reporter::job::CacheFetchKind::Bake,
+            brioche_core::reporter::job::JobContext::default(),
         )
         .await?;
 
@@ -155,6 +157,7 @@ async fn test_cache_client_save_and_load_big_artifact() -> anyhow::Result<()> {
             &brioche,
             artifact_hash,
             brioche_core::reporter::job::CacheFetchKind::Bake,
+            brioche_core::reporter::job::JobContext::default(),
         )
         .await?;
 
@@ -203,6 +206,7 @@ async fn test_cache_client_save_and_load_big_artifact_with_some_small_files() ->
             &brioche,
             artifact_hash,
             brioche_core::reporter::job::CacheFetchKind::Bake,
+            brioche_core::reporter::job::JobContext::default(),
         )
         .await?;
 
@@ -267,6 +271,7 @@ async fn test_cache_client_load_artifact_hash_mismatch_error() -> anyhow::Result
             &brioche,
             real_artifact_hash,
             brioche_core::reporter::job::CacheFetchKind::Bake,
+            brioche_core::reporter::job::JobContext::default(),
         )
         .await;
         assert_matches!(result, Err(_));
@@ -303,6 +308,7 @@ async fn test_cache_client_load_artifact_missing_chunks_error() -> anyhow::Resul
             &brioche,
             artifact_hash,
             brioche_core::reporter::job::CacheFetchKind::Bake,
+            brioche_core::reporter::job::JobContext::default(),
         )
         .await;
         assert_matches!(loaded_artifact, Err(_));
@@ -339,6 +345,7 @@ async fn test_cache_client_load_artifact_chunk_mismatch_error() -> anyhow::Resul
             &brioche,
             artifact_hash,
             brioche_core::reporter::job::CacheFetchKind::Bake,
+            brioche_core::reporter::job::JobContext::default(),
         )
         .await;
         assert_matches!(loaded_artifact, Err(_));

--- a/crates/brioche-core/tests/script_ops.rs
+++ b/crates/brioche-core/tests/script_ops.rs
@@ -55,6 +55,10 @@ async fn test_script_ops_version() -> anyhow::Result<()> {
 struct TestStackFrame {
     file_name: String,
     line_number: i32,
+    #[serde(default)]
+    project_name: Option<String>,
+    #[serde(default)]
+    module_path: Option<String>,
 }
 
 #[tokio::test]
@@ -117,14 +121,14 @@ async fn test_script_osp_stack_frames_from_exception() -> anyhow::Result<()> {
                     const error = new Error();
                     const frames = (globalThis as any).Deno.core.ops.op_brioche_stack_frames_from_exception(error);
 
-                    // Get just the filename and line number
                     return frames.map((frame: any) => {
                         return {
                             fileName: frame.fileName.split("/").at(-1),
                             lineNumber: frame.lineNumber,
+                            projectName: frame.projectName ?? null,
+                            modulePath: frame.modulePath ?? null,
                         };
                     });
-                    return frames;
                 }
             "#,
         )
@@ -158,18 +162,26 @@ async fn test_script_osp_stack_frames_from_exception() -> anyhow::Result<()> {
             TestStackFrame {
                 file_name: "stack_frames.bri".to_string(),
                 line_number: 3,
+                project_name: Some("myproject".to_string()),
+                module_path: Some("stack_frames.bri".to_string()),
             },
             TestStackFrame {
                 file_name: "bar.bri".to_string(),
                 line_number: 4,
+                project_name: Some("myproject".to_string()),
+                module_path: Some("bar.bri".to_string()),
             },
             TestStackFrame {
                 file_name: "foo.bri".to_string(),
                 line_number: 4,
+                project_name: Some("myproject".to_string()),
+                module_path: Some("foo.bri".to_string()),
             },
             TestStackFrame {
                 file_name: "project.bri".to_string(),
                 line_number: 9,
+                project_name: Some("myproject".to_string()),
+                module_path: Some("project.bri".to_string()),
             },
         ]
     );

--- a/crates/brioche-test-support/src/lib.rs
+++ b/crates/brioche-test-support/src/lib.rs
@@ -225,6 +225,7 @@ async fn cached_download(
                 brioche,
                 &download.url,
                 Some(download.hash.clone()),
+                brioche_core::reporter::job::JobContext::default(),
             )
             .await;
             let blob_hash = match blob_hash {


### PR DESCRIPTION
Resolves https://github.com/brioche-dev/brioche/issues/340.

This PR updates the job row of the TUI and every event in plain-mode output, they now carry the source location of the recipe that produced it, formatted as `(project_name/module_path:line:col)`. The label is captured once, at the JS-runtime boundary where stack frames are created, and rendered uniformly across `Download` / `Unarchive` / `Process` / `Cache` jobs. Sub-recipes inherit a parent's source when they have none of their own, so deep cache fetches and downloads still get useful attribution.

### Before / after

Before, a process row read:

```
21.34s ◝ Process 22670
```

After:

```
13.87s ◜     Download   45%  https://crates.io/api/v1/crates/syn/2.0.48/download · 1.1 MiB / 2.5 MiB    (rust/cargo_vendor.bri:110:6)
 5.69s ✓     Download  100%  https://crates.io/api/v1/crates/zerocopy/0.4.14/download · 1.7 MiB         (rust/cargo_vendor.bri:110:6)
 2m15s ◞        Cache   98%  artifact · 58.0 MiB / 58.9 MiB                                             (git/project.bri:204:10)
 0.91s ◝    Unarchive   43%  1.2 MiB / 2.8 MiB                                                          (rust/cargo_vendor.bri:114:6)
21.34s ◝      Process        #22670                                                                     (rust/project.bri:315:6)
```

Plus a cargo-style right-aligned kind column, URLs left-truncated so the resource tail stays readable, progress bar dropped on completed lines, and the trailing source label in dim grey parens.

### Commits

- b21a3a0: introduces `Meta::source_frame()`; `WithMeta::source_frame` delegates. Pure refactor.
- adc163e: adds `project_name` and `module_path` fields, extends `Display` to render `project/module:line:col` with fallbacks to `module_path` alone and then `file_name`. Table-driven test pins the rendering.
- c9fd5be: replaces the hand-written formatter in the process-event log with the new `Display`.
- 106e478: moves `op_brioche_stack_frames_from_exception` from `brioche_js` to `brioche_rt` so it can read `Projects` from `OpState`; resolves `project_name`/`module_path` at capture time; extends the integration test to assert both.
- 627115c: introduces `JobContext`, changes `Reporter::add_job(NewJob, JobContext)`, stores context per-job, and decorates plain-mode messages with `(label)`. Every call site (cache, archive, download, bake, project loader, tests, brioche-test-support) starts passing `JobContext::default()`.
- f4feb2a: adds `JobContext::from_meta(&Meta)`; bake-side call sites compute the context from the recipe's meta; `bake_download` gains a `&Arc<Meta>` parameter.
- 0b4cf17: adds `append_source_label`, `source_label_reserved_width`, applies them in every `SuperConsole` render arm.
- 2b236a8: adds `JOB_KIND_WIDTH`, `SECTION_SEPARATOR`, `job_kind_span`, `details_spans`, `string_with_width_keep_end`; right-aligns the kind keyword, drops the progress bar on completed rows, left-truncates URLs to keep the identifying tail.
- 9ec8d26: adds `BakeScope::Child::parent_meta`, an `inherit_source_from_scope` helper applied at the top of `bake()`, and `run_bake` sets the parent meta on child scopes. Closes the gap where deep sub-recipes (downloads, unarchives, intermediate processes) lose attribution.

### Why now ?

Same approach as in #464, I'm in the process to rework the Rust building recipes in `brioche-packages`, and I thought that it could be the right moment to update the TUI output, here is a preview of the new output with the new building process:

<img width="1783" height="945" alt="image" src="https://github.com/user-attachments/assets/f5e40d90-bbba-4a5a-befa-6a15b9525b3e" />
