### PR TITLE
chore(v8): set max stack frames to 6 (default is 10)

### DIFF
--- a/crates/brioche-core/src/script.rs
+++ b/crates/brioche-core/src/script.rs
@@ -30,6 +30,9 @@ mod js;
 pub mod lsp;
 pub mod specifier;
 
+/// Cap on stack frames retained per recipe meta.
+pub const MAX_STACK_FRAMES: usize = 6;
+
 /// A type representing a global JavaScript runtime platform, which is required
 /// to create a JavaScript runtime.
 ///
@@ -339,6 +342,7 @@ fn op_brioche_stack_frames_from_exception<'a>(
     error
         .frames
         .into_iter()
+        .take(MAX_STACK_FRAMES)
         .map(|frame| enrich_stack_frame(projects.as_ref(), frame))
         .collect()
 }

--- a/crates/brioche-core/src/script/evaluate.rs
+++ b/crates/brioche-core/src/script/evaluate.rs
@@ -80,6 +80,12 @@ async fn evaluate_with_deno(
                 ..Default::default()
             });
 
+            // Match V8's stack trace capture to the op cap.
+            js_runtime.execute_script(
+                "[brioche:stack_trace_limit]",
+                format!("Error.stackTraceLimit = {};", super::MAX_STACK_FRAMES),
+            )?;
+
             let main_module: deno_core::ModuleSpecifier = main_module.into();
 
             tracing::debug!(%main_module, "evaluating module");


### PR DESCRIPTION
This PR tries to mitigate issue https://github.com/brioche-dev/brioche/issues/327 which reappeared after the merged of https://github.com/brioche-dev/brioche/pull/466. The CI of `brioche-packages` is affected when the package `openmpi` is processed (see https://github.com/brioche-dev/brioche-packages/actions/runs/25983860428/job/76383751567):

```
./packages/openmpi (703 / 1046)
  
<--- Last few GCs --->

[24008:0xfffe80200000]    48409 ms: Scavenge (during sweeping) 1382.8 (1397.1) -> 1382.1 (1397.6) MB, pooled: 4.5 MB, 27.13 / 0.00 ms (average mu = 0.238, current mu = 0.161) allocation failure; 
[24008:0xfffe80200000]    48726 ms: Incremental Mark-Compact (reduce) 1388.8 (1401.9) -> 1383.4 (1397.9) MB, pooled: 0.0 MB, 258.47 / 0.00 ms (+ 7.4 ms in 46 steps since start of marking, biggest step 5.0 ms, walltime since start of marking 297 ms) (avera


#
# Fatal JavaScript out of memory: Ineffective mark-compacts near heap limit
#
==== C stack trace ===============================

    brioche(+0x26cd8c0) [0xfffed563d8c0]
    brioche(+0x1bd88b0) [0xfffed4b488b0]
    brioche(+0x26c5ea0) [0xfffed5635ea0]
    brioche(+0x1c110a8) [0xfffed4b810a8]
    brioche(+0x1d4b958) [0xfffed4cbb958]
    brioche(+0x1d4a8e4) [0xfffed4cba8e4]
    brioche(+0x1d495d4) [0xfffed4cb95d4]
    brioche(+0x1d3edc8) [0xfffed4caedc8]
    brioche(+0x1d3eb64) [0xfffed4caeb64]
    brioche(+0x1d3e4e8) [0xfffed4cae4e8]
    brioche(+0x1d13f64) [0xfffed4c83f64]
    brioche(+0x1d21a78) [0xfffed4c91a78]
    brioche(+0x1c20974) [0xfffed4b90974]
    brioche(+0x1ac55e0) [0xfffed4a355e0]
    brioche(+0x1ac773c) [0xfffed4a3773c]
    brioche(+0x1accadc) [0xfffed4a3cadc]
    brioche(+0x1ce6668) [0xfffed4c56668]
    brioche(+0x1cec358) [0xfffed4c5c358]
    brioche(+0x1c2d3d8) [0xfffed4b9d3d8]
    brioche(+0x27470c8) [0xfffed56b70c8]
    brioche(+0x2746d1c) [0xfffed56b6d1c]
    brioche(+0x1fbd3a8) [0xfffed4f2d3a8]
    brioche(+0x1fbcb58) [0xfffed4f2cb58]
    brioche(+0x208db90) [0xfffed4ffdb90]
    brioche(+0x1c1be60) [0xfffed4b8be60]
    brioche(+0x1ac8b50) [0xfffed4a38b50]
    brioche(+0x1ac8274) [0xfffed4a38274]
    brioche(+0xa402a4) [0xfffed39b02a4]
    brioche(+0xa40940) [0xfffed39b0940]
    brioche(+0x24c02b0) [0xfffed54302b0]
/home/runner/_work/_temp/1073dc04-728e-41fd-99d3-bda2f69f6a44.sh: line 4: 24008 Trace/breakpoint trap   (core dumped) brioche build "$package" --sync --locked --display plain-reduced --experimental-lazy
```

It can also be reproduced locally by executing `brioche build -p ./packages/openmpi`.

In order to mitigate the aforementioned issue, I decided to reduce the number of stack frames created to 6, knowing that the default value is 10 when not overriding anything.

Here is some figures of the usage of RAM, before the land of the TUI PR, after the land of the TUI PR and with this PR:

```
# before the land of the TUI PR
cargo clean
git checkout 360e6ce
cargo build --release
rm -rf /tmp/output
/usr/bin/time -v ./target/release/brioche build -o /tmp/output -p /tmp/brioche-packages/packages/openmpi 2>&1 | tee /tmp/baseline.log

# after the land of the TUI PR
cargo clean
git checkout 0456f6e
cargo build --release
rm -rf /tmp/output
/usr/bin/time -v ./target/release/brioche build -o /tmp/output -p /tmp/brioche-packages/packages/openmpi 2>&1 | tee /tmp/regression.log

# with this PR
git checkout max-stack-frames
cargo clean
cargo build --release
rm -rf /tmp/output
/usr/bin/time -v ./target/release/brioche build -o /tmp/output -p /tmp/brioche-packages/packages/openmpi 2>&1 | tee /tmp/fixed.log
```

| Run           | Peak RSS                | Time | Outcome   |
| ------------- | ----------------------- | ---- | --------- |
| Baseline      | 1,622,988 KB (1.55 GiB) | 1:32 | Completed |
| Regression    | 1,651,784 KB (1.58 GiB) | 0:56 | OOM       |
| Fixed (cap=5) | 1,454,560 KB (1.39 GiB) | 1:08 | Completed |
| Fixed (cap=6) | 1,477,932 KB (1.41 GiB) | 1:30 | Completed |

So, before the TUI PR we were already near the OOM limit, and by storing more information to stack frame we end it up hitting the OOM path. With this PR, we reduce the peak RAM usage by 10%, it's still quite high, and it's more a workaround that should be revert when the real fix lands, but at least it'll give us more room, knowing that the real fix will come with https://github.com/brioche-dev/brioche/issues/329 and https://github.com/brioche-dev/brioche/issues/328. 