### PR TITLE
chore(typescript): support import attributes at runtime

### DIFF
--- a/crates/brioche-core/runtime/src/check.ts
+++ b/crates/brioche-core/runtime/src/check.ts
@@ -1,6 +1,6 @@
 import ts from "typescript";
 import * as eslint from "eslint";
-import { TS_CONFIG, DEFAULT_LIB_URL, toTsUrl, fromTsUrl, readFile, fileExists, resolveModule } from "./ts-common.ts";
+import { TS_CONFIG, DEFAULT_LIB_URL, toTsUrl, fromTsUrl, readFile, fileExists, resolveModule, importAttributeType, resolveAttributeModule, attributeModuleSource } from "./ts-common.ts";
 import { buildEslintConfig } from "./eslint-common.ts";
 
 export function check(files: string[]): Diagnostic[] {
@@ -145,7 +145,8 @@ class BriocheCompilerHost implements ts.CompilerHost {
     if (sourceText == null) {
       return undefined;
     }
-    return ts.createSourceFile(fileName, sourceText, languageVersionOrOptions, false, ts.ScriptKind.TS);
+    const scriptKind = fileName.endsWith(".json") ? ts.ScriptKind.JSON : ts.ScriptKind.TS;
+    return ts.createSourceFile(fileName, sourceText, languageVersionOrOptions, false, scriptKind);
   }
   getDefaultLibFileName(options: ts.CompilerOptions): string {
     return DEFAULT_LIB_URL;
@@ -166,28 +167,41 @@ class BriocheCompilerHost implements ts.CompilerHost {
     return "\n";
   }
   fileExists(fileName: string): boolean {
+    if (attributeModuleSource(fileName) != null) {
+      return true;
+    }
     return fileExists(fromTsUrl(fileName));
   }
   readFile(fileName: string): string | undefined {
+    const attributeSource = attributeModuleSource(fileName);
+    if (attributeSource != null) {
+      return attributeSource;
+    }
     return readFile(fromTsUrl(fileName));
   }
   resolveModuleNameLiterals(moduleLiterals: readonly ts.StringLiteralLike[], containingFile: string): readonly ts.ResolvedModuleWithFailedLookupLocations[] {
     return moduleLiterals.map(moduleLiteral => {
-
       const resolvedName = resolveModule(moduleLiteral.text, fromTsUrl(containingFile));
+      if (resolvedName == null) {
+        return { resolvedModule: undefined };
+      }
 
-      if (resolvedName != null) {
+      // Imports carrying a type attribute are typed from that attribute.
+      const attributeModule = resolveAttributeModule(importAttributeType(moduleLiteral) ?? "", resolvedName);
+      if (attributeModule != null) {
+        return { resolvedModule: attributeModule };
+      }
+
+      if (resolvedName.endsWith(".bri")) {
         return {
           resolvedModule: {
             extension: ".ts",
             resolvedFileName: toTsUrl(resolvedName),
           }
-        }
-      } else {
-        return {
-          resolvedModule: undefined,
         };
       }
+
+      return { resolvedModule: undefined };
     });
   }
 }

--- a/crates/brioche-core/runtime/src/lsp.ts
+++ b/crates/brioche-core/runtime/src/lsp.ts
@@ -43,10 +43,18 @@ class BriocheLanguageServiceHost implements ts.LanguageServiceHost {
   }
 
   fileExists(fileName: string): boolean {
+    if (brioche.attributeModuleSource(fileName) != null) {
+      return true;
+    }
     return brioche.fileExists(brioche.fromTsUrl(fileName));
   }
 
   readFile(fileName: string): string | undefined {
+    const attributeSource = brioche.attributeModuleSource(fileName);
+    if (attributeSource != null) {
+      return attributeSource;
+    }
+
     const uri = brioche.fromTsUrl(fileName);
     if (fileName.startsWith("file://")) {
       this.files.add(uri);
@@ -67,19 +75,26 @@ class BriocheLanguageServiceHost implements ts.LanguageServiceHost {
   resolveModuleNameLiterals(moduleLiterals: readonly ts.StringLiteralLike[], containingFile: string): readonly ts.ResolvedModuleWithFailedLookupLocations[] {
     return moduleLiterals.map(moduleLiteral => {
       const resolvedName = brioche.resolveModule(moduleLiteral.text, brioche.fromTsUrl(containingFile));
+      if (resolvedName == null) {
+        return { resolvedModule: undefined };
+      }
 
-      if (resolvedName != null) {
+      // Imports carrying a type attribute are typed from that attribute.
+      const attributeModule = brioche.resolveAttributeModule(brioche.importAttributeType(moduleLiteral) ?? "", resolvedName);
+      if (attributeModule != null) {
+        return { resolvedModule: attributeModule };
+      }
+
+      if (resolvedName.endsWith(".bri")) {
         return {
           resolvedModule: {
             extension: ".ts",
             resolvedFileName: brioche.toTsUrl(resolvedName),
           }
-        }
-      } else {
-        return {
-          resolvedModule: undefined,
         };
       }
+
+      return { resolvedModule: undefined };
     });
   }
 }

--- a/crates/brioche-core/runtime/src/lsp.ts
+++ b/crates/brioche-core/runtime/src/lsp.ts
@@ -17,6 +17,10 @@ class BriocheLanguageServiceHost implements ts.LanguageServiceHost {
   }
 
   getScriptVersion(fileName: string): string {
+    // Virtual attribute modules have fixed source, so their version is constant.
+    if (brioche.attributeModuleSource(fileName) != null) {
+      return "0";
+    }
     const version = brioche.fileVersion(brioche.fromTsUrl(fileName)) ?? -1;
     return version.toString();
   }

--- a/crates/brioche-core/runtime/src/ts-common.ts
+++ b/crates/brioche-core/runtime/src/ts-common.ts
@@ -8,6 +8,7 @@ export const TS_CONFIG = {
   noUncheckedIndexedAccess: true,
   module: ts.ModuleKind.ESNext,
   target: ts.ScriptTarget.ES2025,
+  resolveJsonModule: true,
 } satisfies ts.CompilerOptions;
 
 export const DEFAULT_LIB_URL = "briocheruntime:///tslib/lib.esnext.d.ts";
@@ -44,4 +45,66 @@ export function fileExists(specifierUrl: string): boolean {
 
 export function fileVersion(specifierUrl: string): number | null | undefined {
   return ops.op_brioche_file_version(specifierUrl);
+}
+
+// Virtual declaration files backing `text` and `bytes` import attributes.
+// They are keyed only by the attribute type, so every import of a given type
+// shares one declaration.
+const ATTRIBUTE_MODULE_PREFIX = "briocheattr:///";
+
+const ATTRIBUTE_MODULE_SOURCES = {
+  text: "declare const value: string;\nexport default value;\n",
+  bytes: "declare const value: Uint8Array;\nexport default value;\n",
+} as const;
+
+type AttributeModuleType = keyof typeof ATTRIBUTE_MODULE_SOURCES;
+
+// Read the `type` value from a module specifier's import attribute, if any.
+export function importAttributeType(moduleLiteral: ts.StringLiteralLike): string | undefined {
+  const parent = moduleLiteral.parent;
+  const attributes = ts.isImportDeclaration(parent) || ts.isExportDeclaration(parent)
+    ? parent.attributes
+    : undefined;
+  if (attributes == null) {
+    return undefined;
+  }
+
+  for (const element of attributes.elements) {
+    if (element.name.text === "type" && ts.isStringLiteralLike(element.value)) {
+      return element.value.text;
+    }
+  }
+
+  return undefined;
+}
+
+// Resolve an import from its attribute type. `json` points at the real file so
+// `resolveJsonModule` can type it from its contents, while `text` and `bytes`
+// resolve to a shared virtual declaration. Returns undefined for anything else,
+// which falls back to normal file lookup.
+export function resolveAttributeModule(attributeType: string, resolvedName: string): ts.ResolvedModuleFull | undefined {
+  if (attributeType === "json") {
+    return {
+      extension: ts.Extension.Json,
+      resolvedFileName: resolvedName,
+    };
+  } else if (attributeType in ATTRIBUTE_MODULE_SOURCES) {
+    return {
+      extension: ts.Extension.Dts,
+      resolvedFileName: `${ATTRIBUTE_MODULE_PREFIX}${attributeType}.d.ts`,
+    };
+  }
+
+  return undefined;
+}
+
+// Source text for a virtual attribute declaration file, or undefined if the
+// name doesn't refer to one.
+export function attributeModuleSource(fileName: string): string | undefined {
+  if (!fileName.startsWith(ATTRIBUTE_MODULE_PREFIX)) {
+    return undefined;
+  }
+
+  const type = fileName.slice(ATTRIBUTE_MODULE_PREFIX.length, -".d.ts".length);
+  return ATTRIBUTE_MODULE_SOURCES[type as AttributeModuleType];
 }

--- a/crates/brioche-core/src/project.rs
+++ b/crates/brioche-core/src/project.rs
@@ -689,6 +689,8 @@ pub struct Project {
     pub definition: ProjectDefinition,
     pub dependencies: HashMap<String, DependencyRef>,
     pub modules: HashMap<RelativePathBuf, FileId>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub assets: HashMap<RelativePathBuf, FileId>,
     #[serde_as(as = "HashMap<_, Vec<(_, _)>>")]
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub statics: HashMap<RelativePathBuf, BTreeMap<StaticQuery, Option<StaticOutput>>>,

--- a/crates/brioche-core/src/project/analyze.rs
+++ b/crates/brioche-core/src/project/analyze.rs
@@ -18,6 +18,7 @@ use super::{DependencyDefinition, ProjectDefinition, Version};
 pub struct ProjectAnalysis {
     pub definition: super::ProjectDefinition,
     pub local_modules: HashMap<BriocheModuleSpecifier, ModuleAnalysis>,
+    pub local_assets: HashMap<BriocheModuleSpecifier, AssetAnalysis>,
     pub root_module: BriocheModuleSpecifier,
 }
 
@@ -61,9 +62,33 @@ pub struct ModuleAnalysis {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AssetAnalysis {
+    pub file_id: FileId,
+    pub project_subpath: RelativePathBuf,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ImportAnalysis {
     ExternalProject(String),
     LocalModule(BriocheModuleSpecifier),
+    LocalAsset(BriocheModuleSpecifier),
+}
+
+/// An import found while analyzing a module, along with the type from its
+/// import attribute if one was given.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AnalyzedImport {
+    pub specifier: BriocheImportSpecifier,
+    pub attribute_type: Option<ImportAttributeType>,
+}
+
+/// The `type` value from an import attribute. This is what tells us a local
+/// import is an asset rather than another module.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ImportAttributeType {
+    Json,
+    Text,
+    Bytes,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize)]
@@ -226,6 +251,7 @@ pub async fn analyze_project(vfs: &Vfs, project_path: &Path) -> anyhow::Result<P
         .collect::<HashMap<_, _>>();
 
     let mut local_modules = HashMap::new();
+    let mut local_assets = HashMap::new();
     let root_module = analyze_module(
         vfs,
         &root_module_path,
@@ -233,12 +259,14 @@ pub async fn analyze_project(vfs: &Vfs, project_path: &Path) -> anyhow::Result<P
         Some(&module),
         &root_module_env,
         &mut local_modules,
+        &mut local_assets,
     )
     .await?;
 
     Ok(ProjectAnalysis {
         definition: project_definition,
         local_modules,
+        local_assets,
         root_module,
     })
 }
@@ -251,6 +279,7 @@ pub async fn analyze_module(
     module: Option<&'async_recursion biome_js_syntax::JsModule>,
     env: &HashMap<String, serde_json::Value>,
     local_modules: &mut HashMap<BriocheModuleSpecifier, ModuleAnalysis>,
+    local_assets: &mut HashMap<BriocheModuleSpecifier, AssetAnalysis>,
 ) -> anyhow::Result<BriocheModuleSpecifier> {
     let module_path = if module_path == project_path {
         module_path.join("project.bri")
@@ -333,9 +362,12 @@ pub async fn analyze_module(
 
     let mut imports = HashMap::new();
 
-    let import_specifiers = find_imports(module, display_location);
-    for import_specifier in import_specifiers {
-        let import_specifier = import_specifier?;
+    let imported = find_imports(module, display_location);
+    for import in imported {
+        let AnalyzedImport {
+            specifier: import_specifier,
+            attribute_type,
+        } = import?;
 
         let import_analysis = match &import_specifier {
             BriocheImportSpecifier::Local(local_import) => {
@@ -355,20 +387,39 @@ pub async fn analyze_module(
                     "invalid import path: must be within project root",
                 );
 
-                let env = HashMap::default();
+                // An import is an asset when it carries a type attribute, which
+                // loads a file regardless of its extension.
+                if attribute_type.is_some() {
+                    let asset_specifier =
+                        analyze_asset(vfs, &import_module_path, project_path, local_assets).await?;
+                    ImportAnalysis::LocalAsset(asset_specifier)
+                } else {
+                    // Without an attribute we treat the import as another module,
+                    // which only makes sense for Brioche source files.
+                    anyhow::ensure!(
+                        import_module_path
+                            .extension()
+                            .is_none_or(|ext| ext == "bri"),
+                        "{}: non-module imports require a type attribute",
+                        import_module_path.display(),
+                    );
 
-                // Analyze the imported module, but start with a separate
-                // environment
-                let import_module_specifier = analyze_module(
-                    vfs,
-                    &import_module_path,
-                    project_path,
-                    None,
-                    &env,
-                    local_modules,
-                )
-                .await?;
-                ImportAnalysis::LocalModule(import_module_specifier)
+                    let env = HashMap::default();
+
+                    // Analyze the imported module, but start with a separate
+                    // environment
+                    let import_module_specifier = analyze_module(
+                        vfs,
+                        &import_module_path,
+                        project_path,
+                        None,
+                        &env,
+                        local_modules,
+                        local_assets,
+                    )
+                    .await?;
+                    ImportAnalysis::LocalModule(import_module_specifier)
+                }
             }
             BriocheImportSpecifier::External(dependency) => {
                 ImportAnalysis::ExternalProject(dependency.clone())
@@ -389,10 +440,54 @@ pub async fn analyze_module(
     Ok(module_specifier)
 }
 
+async fn analyze_asset(
+    vfs: &Vfs,
+    asset_path: &Path,
+    project_path: &Path,
+    local_assets: &mut HashMap<BriocheModuleSpecifier, AssetAnalysis>,
+) -> anyhow::Result<BriocheModuleSpecifier> {
+    let asset_specifier = BriocheModuleSpecifier::File {
+        path: asset_path.to_owned(),
+    };
+
+    if local_assets.contains_key(&asset_specifier) {
+        return Ok(asset_specifier);
+    }
+
+    let display_path = asset_path.display();
+
+    let project_subpath = asset_path.relative_to(project_path).with_context(|| {
+        format!(
+            "{display_path}: failed to resolve relative to project root {}",
+            project_path.display(),
+        )
+    })?;
+    let project_subpath = project_subpath.normalize();
+    anyhow::ensure!(
+        crate::fs_utils::is_subpath(&project_subpath),
+        "{display_path}: asset escapes project root"
+    );
+
+    let (file_id, _) = vfs
+        .load(asset_path)
+        .await
+        .with_context(|| format!("{display_path}: failed to read asset"))?;
+
+    local_assets.insert(
+        asset_specifier.clone(),
+        AssetAnalysis {
+            file_id,
+            project_subpath,
+        },
+    );
+
+    Ok(asset_specifier)
+}
+
 pub fn find_imports<'a, D>(
     module: &'a biome_js_syntax::JsModule,
     display_location: impl FnMut(usize) -> D + Clone + 'a,
-) -> impl Iterator<Item = anyhow::Result<BriocheImportSpecifier>> + 'a
+) -> impl Iterator<Item = anyhow::Result<AnalyzedImport>> + 'a
 where
     D: std::fmt::Display,
 {
@@ -403,7 +498,7 @@ where
 fn find_top_level_imports<'a, D>(
     module: &'a biome_js_syntax::JsModule,
     mut display_location: impl FnMut(usize) -> D + 'a,
-) -> impl Iterator<Item = anyhow::Result<BriocheImportSpecifier>> + 'a
+) -> impl Iterator<Item = anyhow::Result<AnalyzedImport>> + 'a
 where
     D: std::fmt::Display,
 {
@@ -412,7 +507,7 @@ where
         .iter()
         .map(move |item| {
             let location = display_location(item.syntax().text_range().start().into());
-            let import_source = match item {
+            let import_source = match &item {
                 biome_js_syntax::AnyJsModuleItem::JsExport(export_item) => {
                     let export_clause = export_item
                         .export_clause()
@@ -454,18 +549,79 @@ where
                 .inner_string_text()
                 .with_context(|| format!("{location}: failed to get import source text"))?;
             let import_source = import_source.text();
-            let import_specifier: BriocheImportSpecifier = import_source
+            let specifier: BriocheImportSpecifier = import_source
                 .parse()
                 .with_context(|| format!("{location}: invalid import specifier"))?;
-            Ok(Some(import_specifier))
+            let attribute_type = find_import_attribute_type(item.syntax(), &location)?;
+            Ok(Some(AnalyzedImport {
+                specifier,
+                attribute_type,
+            }))
         })
         .filter_map(std::result::Result::transpose)
+}
+
+/// Read the `type` value from an import/export statement's import attribute,
+/// if present. Errors on a `type` we don't support.
+fn find_import_attribute_type<D>(
+    item: &biome_js_syntax::JsSyntaxNode,
+    location: &D,
+) -> anyhow::Result<Option<ImportAttributeType>>
+where
+    D: std::fmt::Display,
+{
+    let Some(assertion) = item
+        .descendants()
+        .find_map(biome_js_syntax::JsImportAssertion::cast)
+    else {
+        return Ok(None);
+    };
+
+    for entry in assertion.assertions().iter() {
+        let entry =
+            entry.with_context(|| format!("{location}: failed to parse import attribute"))?;
+        let Some(entry) = entry.as_js_import_assertion_entry() else {
+            continue;
+        };
+        let key = entry
+            .key()
+            .with_context(|| format!("{location}: failed to parse import attribute key"))?;
+        if unquote(key.text_trimmed()) != "type" {
+            continue;
+        }
+
+        let value = entry
+            .value_token()
+            .with_context(|| format!("{location}: failed to parse import attribute value"))?;
+        let attribute_type = match unquote(value.text_trimmed()) {
+            "json" => ImportAttributeType::Json,
+            "text" => ImportAttributeType::Text,
+            "bytes" => ImportAttributeType::Bytes,
+            other => anyhow::bail!(
+                "{location}: unsupported import attribute type {other:?}, expected \"json\", \"text\", or \"bytes\""
+            ),
+        };
+        return Ok(Some(attribute_type));
+    }
+
+    Ok(None)
+}
+
+/// Strip a single pair of matching surrounding quotes, leaving bare tokens
+/// untouched. Import attribute keys may be bare or quoted; values are quoted.
+fn unquote(text: &str) -> &str {
+    for quote in ['"', '\''] {
+        if let Some(inner) = text.strip_prefix(quote).and_then(|t| t.strip_suffix(quote)) {
+            return inner;
+        }
+    }
+    text
 }
 
 pub fn find_dynamic_imports<'a, D>(
     module: &'a biome_js_syntax::JsModule,
     mut display_location: impl FnMut(usize) -> D + 'a,
-) -> impl Iterator<Item = anyhow::Result<BriocheImportSpecifier>> + 'a
+) -> impl Iterator<Item = anyhow::Result<AnalyzedImport>> + 'a
 where
     D: std::fmt::Display,
 {
@@ -501,10 +657,16 @@ where
                         );
                     }
                 };
-                let import_specifier: BriocheImportSpecifier = specifier
+                let specifier: BriocheImportSpecifier = specifier
                     .parse()
                     .with_context(|| format!("{location}: invalid import specifier"))?;
-                Ok(Some(import_specifier))
+
+                // Dynamic imports don't carry a type attribute, since they
+                // currently only accept a single argument.
+                Ok(Some(AnalyzedImport {
+                    specifier,
+                    attribute_type: None,
+                }))
             } else {
                 Ok(None)
             }

--- a/crates/brioche-core/src/project/artifact.rs
+++ b/crates/brioche-core/src/project/artifact.rs
@@ -331,6 +331,25 @@ async fn project_artifact(
         .await?;
     }
 
+    // Add each asset to the artifact
+    for (asset_path, file_id) in &project.assets {
+        let content_blob = crate::vfs::commit_blob(brioche, *file_id).await?;
+
+        let asset_artifact = Artifact::File(crate::recipe::File {
+            content_blob,
+            executable: false,
+            resources: Directory::default(),
+        });
+
+        insert_non_conflicting(
+            brioche,
+            &mut project_artifact,
+            asset_path.as_str().as_bytes(),
+            &asset_artifact,
+        )
+        .await?;
+    }
+
     // Add the lockfile to the artifact
     let lockfile = super::project_lockfile(project);
     let lockfile_contents =

--- a/crates/brioche-core/src/project/load.rs
+++ b/crates/brioche-core/src/project/load.rs
@@ -451,10 +451,17 @@ async fn load_project_inner(
                 .values()
                 .map(|module| (module.project_subpath.clone(), module.file_id))
                 .collect();
+            let assets = details
+                .project_analysis
+                .local_assets
+                .values()
+                .map(|asset| (asset.project_subpath.clone(), asset.file_id))
+                .collect();
             let project = Arc::new(Project {
                 definition: details.project_analysis.definition,
                 dependencies,
                 modules,
+                assets,
                 statics,
             });
 

--- a/crates/brioche-core/src/references.rs
+++ b/crates/brioche-core/src/references.rs
@@ -79,6 +79,7 @@ pub async fn project_references(
             definition: _,
             dependencies,
             modules,
+            assets,
             statics,
         } = &*project;
 
@@ -97,6 +98,17 @@ pub async fn project_references(
                 .vfs
                 .read(*module_file_id)?
                 .with_context(|| format!("failed to read module file {module_path}"))?;
+
+            references.loaded_blobs.insert(blob_hash, contents);
+        }
+
+        for (asset_path, asset_file_id) in assets {
+            let blob_hash = asset_file_id.as_blob_hash()?;
+
+            let contents = brioche
+                .vfs
+                .read(*asset_file_id)?
+                .with_context(|| format!("failed to read asset file {asset_path}"))?;
 
             references.loaded_blobs.insert(blob_hash, contents);
         }

--- a/crates/brioche-core/src/script.rs
+++ b/crates/brioche-core/src/script.rs
@@ -82,11 +82,45 @@ impl BriocheModuleLoader {
     fn load_module_source(
         &self,
         module_specifier: &deno_core::ModuleSpecifier,
+        requested_module_type: &deno_core::RequestedModuleType,
     ) -> Result<deno_core::ModuleSource, anyhow::Error> {
         let brioche_module_specifier: BriocheModuleSpecifier = module_specifier.try_into()?;
         let contents = self
             .bridge
             .read_specifier_contents(brioche_module_specifier.clone())?;
+
+        match requested_module_type {
+            deno_core::RequestedModuleType::Json => {
+                let code = std::str::from_utf8(&contents)
+                    .context("failed to parse JSON module contents as UTF-8 string")?;
+                return Ok(deno_core::ModuleSource::new(
+                    deno_core::ModuleType::Json,
+                    deno_core::ModuleSourceCode::String(code.to_owned().into()),
+                    module_specifier,
+                    None,
+                ));
+            }
+            deno_core::RequestedModuleType::Text => {
+                let code = std::str::from_utf8(&contents)
+                    .context("failed to parse text module contents as UTF-8 string")?;
+                return Ok(deno_core::ModuleSource::new(
+                    deno_core::ModuleType::Text,
+                    deno_core::ModuleSourceCode::String(code.to_owned().into()),
+                    module_specifier,
+                    None,
+                ));
+            }
+            deno_core::RequestedModuleType::Bytes => {
+                let bytes = std::sync::Arc::<[u8]>::from(contents.as_slice());
+                return Ok(deno_core::ModuleSource::new(
+                    deno_core::ModuleType::Bytes,
+                    deno_core::ModuleSourceCode::Bytes(bytes.into()),
+                    module_specifier,
+                    None,
+                ));
+            }
+            deno_core::RequestedModuleType::None | deno_core::RequestedModuleType::Other(_) => {}
+        }
 
         let code = std::str::from_utf8(&contents)
             .context("failed to parse module contents as UTF-8 string")?;
@@ -172,10 +206,10 @@ impl deno_core::ModuleLoader for BriocheModuleLoader {
         &self,
         module_specifier: &deno_core::ModuleSpecifier,
         _maybe_referrer: Option<&deno_core::ModuleLoadReferrer>,
-        _options: deno_core::ModuleLoadOptions,
+        options: deno_core::ModuleLoadOptions,
     ) -> deno_core::ModuleLoadResponse {
         deno_core::ModuleLoadResponse::Sync(
-            self.load_module_source(module_specifier)
+            self.load_module_source(module_specifier, &options.requested_module_type)
                 .map_err(|error| AnyError(error).into()),
         )
     }

--- a/crates/brioche-core/src/script/compiler_host.rs
+++ b/crates/brioche-core/src/script/compiler_host.rs
@@ -117,9 +117,9 @@ impl BriocheCompilerHost {
                 find_imports(&parsed_module, |_| "<unknown>").collect::<Vec<_>>()
             };
 
-            for import_specifier in import_specifiers {
-                let import_specifier = match import_specifier {
-                    Ok(import_specifier) => import_specifier,
+            for import in import_specifiers {
+                let import_specifier = match import {
+                    Ok(import) => import.specifier,
                     Err(error) => {
                         tracing::warn!("error parsing import specifier: {error:#}");
                         continue;

--- a/crates/brioche-core/tests/lsp_completions.rs
+++ b/crates/brioche-core/tests/lsp_completions.rs
@@ -143,6 +143,66 @@ async fn test_lsp_completions_from_import() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+async fn test_lsp_completions_from_text_import_attribute() -> anyhow::Result<()> {
+    let (_brioche, context, lsp) = brioche_test_support::brioche_lsp_test().await;
+
+    context
+        .write_file("myproject/notes.txt", "hello world!")
+        .await;
+
+    let project_root_contents = indoc::indoc! {r#"
+        import notes from "./notes.txt" with { type: "text" };
+
+        notes.toUpperCa // <-- completion here
+    "#};
+    let project_root = context
+        .write_file("myproject/project.bri", project_root_contents)
+        .await;
+
+    lsp.notify::<notification::DidOpenTextDocument>(lsp_types::DidOpenTextDocumentParams {
+        text_document: TextDocumentItem::new(
+            Url::from_file_path(&project_root).unwrap(),
+            "brioche".to_string(),
+            1,
+            project_root_contents.to_string(),
+        ),
+    });
+
+    let completion_response = lsp
+        .request::<request::Completion>(lsp_types::CompletionParams {
+            text_document_position: TextDocumentPositionParams::new(
+                TextDocumentIdentifier::new(Url::from_file_path(&project_root).unwrap()),
+                Position::new(2, 15),
+            ),
+            context: None,
+            partial_result_params: PartialResultParams::default(),
+            work_done_progress_params: WorkDoneProgressParams::default(),
+        })
+        .await
+        .expect("no completion response returned");
+    let completion_items = match completion_response {
+        lsp_types::CompletionResponse::Array(completion_items) => completion_items,
+        lsp_types::CompletionResponse::List(completion_list) => {
+            assert!(
+                !completion_list.is_incomplete,
+                "expected complete completion list"
+            );
+            completion_list.items
+        }
+    };
+
+    // The text import is typed as a string, so string methods complete
+    assert!(
+        completion_items
+            .iter()
+            .any(|item| item.label == "toUpperCase"),
+        "expected string completions for text import attribute"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_lsp_completions_from_local_registry_import() -> anyhow::Result<()> {
     let (_brioche, context, lsp) = brioche_test_support::brioche_lsp_test().await;
 

--- a/crates/brioche-core/tests/script_eval.rs
+++ b/crates/brioche-core/tests/script_eval.rs
@@ -272,6 +272,182 @@ async fn test_eval_import_local() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+async fn test_eval_import_attribute_json() -> anyhow::Result<()> {
+    let (brioche, context) = brioche_test_support::brioche_test().await;
+
+    let project_dir = context.mkdir("myproject").await;
+
+    context
+        .write_file("myproject/data.json", r#"{"value": 42}"#)
+        .await;
+
+    context
+        .write_file(
+            "myproject/project.bri",
+            r#"
+                import data from "./data.json" with { type: "json" };
+                export const project = {};
+                export default () => {
+                    return {
+                        briocheSerialize: () => {
+                            return {
+                                type: "create_file",
+                                content: JSON.stringify(data),
+                                executable: false,
+                                resources: {
+                                    type: "directory",
+                                    entries: {},
+                                },
+                            };
+                        },
+                    };
+                };
+            "#,
+        )
+        .await;
+
+    let (projects, project_hash) =
+        brioche_test_support::load_project(&brioche, &project_dir).await?;
+
+    let resolved = evaluate(
+        &brioche,
+        initialize_js_platform(),
+        &projects,
+        project_hash,
+        "default",
+    )
+    .await?
+    .value;
+
+    let brioche_core::recipe::Recipe::CreateFile { content, .. } = resolved else {
+        panic!("expected create_file recipe, got {resolved:?}");
+    };
+
+    let parsed: serde_json::Value = serde_json::from_slice(&content)?;
+    assert_eq!(parsed, serde_json::json!({"value": 42}));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_eval_import_attribute_text() -> anyhow::Result<()> {
+    let (brioche, context) = brioche_test_support::brioche_test().await;
+
+    let project_dir = context.mkdir("myproject").await;
+
+    context
+        .write_file("myproject/notes.txt", "hello brioche")
+        .await;
+
+    context
+        .write_file(
+            "myproject/project.bri",
+            r#"
+                import notes from "./notes.txt" with { type: "text" };
+                export const project = {};
+                export default () => {
+                    return {
+                        briocheSerialize: () => {
+                            return {
+                                type: "create_file",
+                                content: notes,
+                                executable: false,
+                                resources: {
+                                    type: "directory",
+                                    entries: {},
+                                },
+                            };
+                        },
+                    };
+                };
+            "#,
+        )
+        .await;
+
+    let (projects, project_hash) =
+        brioche_test_support::load_project(&brioche, &project_dir).await?;
+
+    let resolved = evaluate(
+        &brioche,
+        initialize_js_platform(),
+        &projects,
+        project_hash,
+        "default",
+    )
+    .await?
+    .value;
+
+    let brioche_core::recipe::Recipe::CreateFile { content, .. } = resolved else {
+        panic!("expected create_file recipe, got {resolved:?}");
+    };
+
+    assert_eq!(AsRef::<[u8]>::as_ref(&content), b"hello brioche");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_eval_import_attribute_bytes() -> anyhow::Result<()> {
+    let (brioche, context) = brioche_test_support::brioche_test().await;
+
+    let project_dir = context.mkdir("myproject").await;
+
+    context
+        .write_file("myproject/logo.bin", [0x42u8, 0x72, 0x69, 0x6f].as_slice())
+        .await;
+
+    context
+        .write_file(
+            "myproject/project.bri",
+            r#"
+                import bytes from "./logo.bin" with { type: "bytes" };
+                export const project = {};
+                export default () => {
+                    const summary = `kind=${bytes.constructor.name},len=${bytes.length},first=${bytes[0]},last=${bytes[bytes.length - 1]}`;
+                    return {
+                        briocheSerialize: () => {
+                            return {
+                                type: "create_file",
+                                content: summary,
+                                executable: false,
+                                resources: {
+                                    type: "directory",
+                                    entries: {},
+                                },
+                            };
+                        },
+                    };
+                };
+            "#,
+        )
+        .await;
+
+    let (projects, project_hash) =
+        brioche_test_support::load_project(&brioche, &project_dir).await?;
+
+    let resolved = evaluate(
+        &brioche,
+        initialize_js_platform(),
+        &projects,
+        project_hash,
+        "default",
+    )
+    .await?
+    .value;
+
+    let brioche_core::recipe::Recipe::CreateFile { content, .. } = resolved else {
+        panic!("expected create_file recipe, got {resolved:?}");
+    };
+
+    assert_eq!(
+        AsRef::<[u8]>::as_ref(&content),
+        b"kind=Uint8Array,len=4,first=66,last=111",
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_eval_import_dep() -> anyhow::Result<()> {
     let (brioche, mut context) = brioche_test_support::brioche_test().await;
 

--- a/crates/brioche-core/tests/script_project_analyze.rs
+++ b/crates/brioche-core/tests/script_project_analyze.rs
@@ -24,6 +24,7 @@ fn get_local_module(
 
     match module {
         ImportAnalysis::LocalModule(module) => module.clone(),
+        ImportAnalysis::LocalAsset(_) => panic!("module {specifier} is a local asset"),
         ImportAnalysis::ExternalProject(_) => panic!("module {specifier} is an external module"),
     }
 }


### PR DESCRIPTION
This PR adds support for ECMAScript import attributes in Brioche projects:

```ts
import data from "./data.json" with { type: "json" };
import notes from "./notes.txt" with { type: "text" };
import bytes from "./logo.bin" with { type: "bytes" };
```

A local import is treated as an asset when it carries a `type` attribute, and the attribute is the single signal used across the runtime, the analyzer, and the type-checker (the file extension does not affect classification). A local import without an attribute is a Brioche module and must be a `.bri` file; a non-`.bri` import that omits the attribute is rejected during analysis with a clear diagnostic.

In the runtime (`crates/brioche-core/src/script.rs`), the module loader reads `RequestedModuleType` from `deno_core` and serves the `Json`, `Text`, and `Bytes` module kinds straight to V8, skipping the TypeScript transpile step. `Json` and `Text` are decoded as UTF-8; `Bytes` is handed over as an `Arc<[u8]>`.

In the analyzer (`crates/brioche-core/src/project/analyze.rs`), each import is parsed together with its import attribute. An import with a `type` attribute is recorded as an opaque asset (`ImportAnalysis::LocalAsset`) regardless of extension, including `.bri`. Unsupported attribute `type` values are rejected during analysis.

For the project and artifact (`project.rs`, `project/load.rs`, `project/artifact.rs`, `references.rs`), `Project` gains `assets: HashMap<RelativePathBuf, FileId>`. It is populated in `load.rs`, committed to the published artifact at the asset path relative to the project root (same layout as modules) in `artifact.rs`, and collected for reference walks in `references.rs`.

For type-checking (`runtime/src/ts-common.ts`, `check.ts`, `lsp.ts`), `resolveModuleNameLiterals` resolves imports from their attribute through a single `resolveAttributeModule` helper. A `json` import resolves to the real file with `resolveJsonModule` enabled, so the type is inferred from the JSON contents. A `text` or `bytes` import resolves to a shared virtual declaration (typed `string` and `Uint8Array`), so no hand-written `.d.ts` is needed to type them. `resolveJsonModule` is set in the runtime tsconfig, and `.json` source files are parsed with the JSON script kind.
