### PR TITLE
feat(git): support SHA-256 git repositories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3398,6 +3398,7 @@ dependencies = [
  "faster-hex",
  "gix-features",
  "sha1-checked",
+ "sha2 0.11.0",
  "thiserror 2.0.18",
 ]
 

--- a/crates/brioche-core/Cargo.toml
+++ b/crates/brioche-core/Cargo.toml
@@ -53,6 +53,7 @@ futures = "0.3.32"
 gix = { version = "0.84.0", features = [
     "blocking-network-client",
     "blocking-http-transport-reqwest",
+    "sha256",
 ] }
 globset = "0.4.18"
 hex = "0.4.3"

--- a/crates/brioche-core/src/git.rs
+++ b/crates/brioche-core/src/git.rs
@@ -23,15 +23,8 @@ pub async fn resolve_ref_to_commit(
     repository: &url::Url,
     reference: &str,
 ) -> anyhow::Result<String> {
-    if is_sha1_hex(reference) {
+    if is_commit_hash(reference) {
         return Ok(reference.to_ascii_lowercase());
-    }
-
-    // See https://github.com/GitoxideLabs/gitoxide/issues/281.
-    if is_sha256_hex(reference) {
-        anyhow::bail!(
-            "git ref '{reference}' looks like a SHA-256 commit hash, which is not yet supported"
-        );
     }
 
     let repository: gix::Url = repository
@@ -69,13 +62,11 @@ fn resolve_named_ref(repository: &gix::Url, reference: &str) -> anyhow::Result<S
     let refs = if let Some(refs) = outcome.refs {
         refs
     } else {
-        match gix::protocol::LsRefsCommand::new(None, &outcome.capabilities, ("agent", None))
-            .invoke_blocking(&mut transport, &mut gix::progress::Discard, false)
-        {
+        match ls_refs(&mut transport, &outcome.capabilities) {
             Ok(refs) => refs,
             Err(error) => {
                 let _ = gix::protocol::indicate_end_of_interaction(&mut transport, false);
-                return Err(error.into());
+                return Err(error);
             }
         }
     };
@@ -120,4 +111,42 @@ fn resolve_named_ref(repository: &gix::Url, reference: &str) -> anyhow::Result<S
         .with_context(|| format!("git ref '{reference}' not found in repo {repository}"))?;
 
     Ok(object_id.to_string())
+}
+
+/// Runs a protocol V2 `ls-refs` command, echoing back the object format the
+/// server advertised during the handshake.
+fn ls_refs(
+    transport: &mut impl gix::protocol::transport::client::blocking_io::Transport,
+    capabilities: &gix::protocol::transport::client::Capabilities,
+) -> anyhow::Result<Vec<gix::protocol::handshake::Ref>> {
+    use gix::protocol::transport::client::blocking_io::TransportV2Ext as _;
+
+    let object_format = capabilities
+        .capability("object-format")
+        .and_then(|capability| capability.value())
+        .map(ToString::to_string);
+    let mut command_capabilities: Vec<(&str, Option<String>)> = vec![("agent", None)];
+    if let Some(object_format) = object_format {
+        command_capabilities.push(("object-format", Some(object_format)));
+    }
+
+    let supports_unborn = capabilities
+        .capability("ls-refs")
+        .and_then(|capability| capability.supports("unborn"))
+        .unwrap_or_default();
+    let mut arguments: Vec<gix::bstr::BString> = Vec::new();
+    if supports_unborn {
+        arguments.push("unborn".into());
+    }
+    arguments.push("symrefs".into());
+    arguments.push("peel".into());
+
+    let mut response = transport.invoke(
+        "ls-refs",
+        command_capabilities.into_iter(),
+        Some(arguments.into_iter()),
+        false,
+    )?;
+    let refs = gix::protocol::handshake::refs::from_v2_refs(&mut response)?;
+    Ok(refs)
 }

--- a/crates/brioche-core/src/git.rs
+++ b/crates/brioche-core/src/git.rs
@@ -121,13 +121,21 @@ fn ls_refs(
 ) -> anyhow::Result<Vec<gix::protocol::handshake::Ref>> {
     use gix::protocol::transport::client::blocking_io::TransportV2Ext as _;
 
-    let object_format = capabilities
+    let advertised_format = capabilities
         .capability("object-format")
         .and_then(|capability| capability.value())
         .map(ToString::to_string);
+    let object_format = match advertised_format.as_deref() {
+        Some("sha1") => Some("sha1"),
+        Some("sha256") => Some("sha256"),
+        Some(other) => {
+            anyhow::bail!("git server advertised unsupported object format: {other}");
+        }
+        None => None,
+    };
     let mut command_capabilities: Vec<(&str, Option<String>)> = vec![("agent", None)];
     if let Some(object_format) = object_format {
-        command_capabilities.push(("object-format", Some(object_format)));
+        command_capabilities.push(("object-format", Some(object_format.to_owned())));
     }
 
     let supports_unborn = capabilities

--- a/crates/brioche-core/src/git.rs
+++ b/crates/brioche-core/src/git.rs
@@ -128,10 +128,10 @@ fn ls_refs(
     let object_format = match advertised_format.as_deref() {
         Some("sha1") => Some("sha1"),
         Some("sha256") => Some("sha256"),
-        Some(other) => {
-            anyhow::bail!("git server advertised unsupported object format: {other}");
-        }
-        None => None,
+        // The server either did not advertise an `object-format` or advertised
+        // one we do not understand. So, omit the capability which will cause
+        // the server to fall back to the default.
+        _ => None,
     };
     let mut command_capabilities: Vec<(&str, Option<String>)> = vec![("agent", None)];
     if let Some(object_format) = object_format {

--- a/crates/brioche-core/tests/script_eval.rs
+++ b/crates/brioche-core/tests/script_eval.rs
@@ -1124,18 +1124,42 @@ async fn test_eval_brioche_git_checkout_with_commit_sha256_hash() -> anyhow::Res
         )
         .await;
 
-    let error = brioche_test_support::load_project(&brioche, &project_dir)
-        .await
-        .err()
-        .expect("expected loading to fail for SHA-256 commit hash");
-    let error_message = format!("{error:#}");
-    assert!(
-        error_message.contains("SHA-256"),
-        "unexpected error: {error_message}"
-    );
+    let (projects, project_hash) =
+        brioche_test_support::load_project(&brioche, &project_dir).await?;
+
+    let resolved = evaluate(
+        &brioche,
+        initialize_js_platform(),
+        &projects,
+        project_hash,
+        "default",
+    )
+    .await?
+    .value;
+
+    let brioche_core::recipe::Recipe::CreateFile { content, .. } = resolved else {
+        panic!("expected create_file recipe, got {resolved:?}");
+    };
 
     mock_git_info_refs.assert_async().await;
     mock_git_upload_pack.assert_async().await;
+
+    let git_ref: serde_json::Value = serde_json::from_slice(&content)?;
+    assert_eq!(
+        git_ref,
+        serde_json::json!({
+            "staticKind": "git_ref",
+            "repository": format!("{mock_repo_url}/"),
+            "commit": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        }),
+    );
+
+    // Commit hashes are self-pinning, so they must not appear in the lockfile.
+    projects.commit_dirty_lockfiles().await?;
+    let lockfile_path = project_dir.join("brioche.lock");
+    let lockfile_contents = tokio::fs::read_to_string(&lockfile_path).await?;
+    let lockfile: brioche_core::project::Lockfile = serde_json::from_str(&lockfile_contents)?;
+    assert!(lockfile.git_refs.is_empty());
 
     Ok(())
 }


### PR DESCRIPTION
This PR adds support for SHA-256 git repositories. Before, Brioche only worked with the old SHA-1 git hashes, and it returned an error when a ref looked like a SHA-256 commit.

This is a follow-up of #474, the Dependabot PR that bumped `gix` from 0.83 to 0.84. That new `gix` version knows how to handle SHA-256, so now we can use it.

What changed:

- Turn on the `sha256` feature of `gix`.
- Accept SHA-256 commit hashes directly, the same way we already do for SHA-1, instead of failing.
- When we talk to the git server, send back the `object-format` it asked for.
- Update the old test that expected SHA-256 to fail.

About the test: these tests are only here to exercise the new code. They do not need to be part of the Brioche unit tests, they are here only to show that this works as expected. It is not a mock: it creates a real git repo, makes a real commit, and checks that Brioche reads the right commit. It does this two times, once with a normal SHA-1 repo, and once with a real SHA-256 repo. So it really exercises real SHA-256 commits.

To run it, put this file at `crates/brioche-core/tests/git_ref.rs`:

```rust
use std::process::Command;

fn init_repo_with_commit(object_format: &str) -> (tempfile::TempDir, url::Url, String) {
    let dir = tempfile::tempdir().expect("failed to create temp dir");
    let path = dir.path();

    let git = || {
        let mut command = Command::new("git");
        command
            .current_dir(path)
            .env("GIT_CONFIG_GLOBAL", "/dev/null")
            .env("GIT_CONFIG_SYSTEM", "/dev/null");
        command
    };

    let run = |args: &[&str]| {
        let status = git().args(args).status().expect("failed to run git");
        assert!(status.success(), "git {args:?} failed");
    };

    run(&[
        "init",
        "-b",
        "main",
        &format!("--object-format={object_format}"),
    ]);
    run(&[
        "-c",
        "user.name=Brioche Test",
        "-c",
        "user.email=test@brioche.dev",
        "commit",
        "--allow-empty",
        "-m",
        "initial commit",
    ]);

    let commit = git()
        .args(["rev-parse", "HEAD"])
        .output()
        .expect("failed to run git rev-parse");
    assert!(commit.status.success(), "git rev-parse failed");
    let commit = String::from_utf8(commit.stdout)
        .expect("commit hash was not utf-8")
        .trim()
        .to_owned();

    let url = url::Url::from_directory_path(path).expect("failed to build file URL");

    (dir, url, commit)
}

#[tokio::test]
async fn resolve_sha1_branch_and_commit() -> anyhow::Result<()> {
    let (_dir, url, commit) = init_repo_with_commit("sha1");
    assert_eq!(commit.len(), 40);

    let resolved = brioche_core::git::resolve_ref_to_commit(&url, "main").await?;
    assert_eq!(resolved, commit);

    let resolved = brioche_core::git::resolve_ref_to_commit(&url, &commit).await?;
    assert_eq!(resolved, commit);

    Ok(())
}

#[tokio::test]
async fn resolve_sha256_branch_and_commit() -> anyhow::Result<()> {
    let (_dir, url, commit) = init_repo_with_commit("sha256");
    assert_eq!(commit.len(), 64);

    let resolved = brioche_core::git::resolve_ref_to_commit(&url, "main").await?;
    assert_eq!(resolved, commit);

    let resolved = brioche_core::git::resolve_ref_to_commit(&url, &commit).await?;
    assert_eq!(resolved, commit);

    Ok(())
}
```

Then run:

```bash
cargo test -p brioche-core --test git_ref
```

Output on my machine with git 2.54.0 (a recent version is needed to test it properly):

```
running 2 tests
test resolve_sha1_branch_and_commit ... ok
test resolve_sha256_branch_and_commit ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.35s
```
