### PR TITLE
perf(script): speed up JavaScript runtime startup

### DIFF
--- a/crates/brioche-core/runtime/build.ts
+++ b/crates/brioche-core/runtime/build.ts
@@ -21,7 +21,7 @@ await esbuild.build({
   entryPoints: ["./src/index.ts"],
   format: "esm",
   outfile: "dist/index.js",
-  minifyWhitespace: true,
+  minify: true,
   define: {
     global: "globalThis",
     "__filename": "\"\"",

--- a/crates/brioche-core/src/recipe.rs
+++ b/crates/brioche-core/src/recipe.rs
@@ -1617,7 +1617,12 @@ mod tests {
 
     #[test]
     fn test_stack_frame_display() {
-        let cases: &[(_, _, _, _, _, &str)] = &[
+        let runtime_url = format!(
+            "{}:///dist/std/process.js",
+            crate::script::specifier::RUNTIME_SCHEME
+        );
+
+        let cases = [
             // project+module wins over file_name
             (
                 Some("file:///abs/path/myproj/build.bri"),
@@ -1625,7 +1630,7 @@ mod tests {
                 Some("build.bri"),
                 Some(7),
                 Some(25),
-                "myproj/build.bri:7:25",
+                "myproj/build.bri:7:25".to_owned(),
             ),
             // module_path alone is used when project_name is absent
             (
@@ -1634,19 +1639,19 @@ mod tests {
                 Some("sub/build.bri"),
                 Some(3),
                 None,
-                "sub/build.bri:3",
+                "sub/build.bri:3".to_owned(),
             ),
             // file_name is the final fallback when neither field is set
             (
-                Some("briocheruntime:///dist/std/process.js"),
+                Some(&runtime_url),
                 None,
                 None,
                 Some(42),
                 Some(1),
-                "briocheruntime:///dist/std/process.js:42:1",
+                format!("{runtime_url}:42:1"),
             ),
             // entirely-empty frame renders the placeholder
-            (None, None, None, None, None, "<unknown>"),
+            (None, None, None, None, None, "<unknown>".to_owned()),
             // line-only (no column) still produces `:line`
             (
                 None,
@@ -1654,19 +1659,19 @@ mod tests {
                 Some("main.bri"),
                 Some(10),
                 None,
-                "myproj/main.bri:10",
+                "myproj/main.bri:10".to_owned(),
             ),
         ];
 
         for (file_name, project_name, module_path, line, col, expected) in cases {
             let frame = StackFrame {
                 file_name: file_name.map(str::to_owned),
-                line_number: *line,
-                column_number: *col,
+                line_number: line,
+                column_number: col,
                 project_name: project_name.map(str::to_owned),
                 module_path: module_path.map(str::to_owned),
             };
-            assert_eq!(frame.to_string(), *expected);
+            assert_eq!(frame.to_string(), expected);
         }
     }
 }

--- a/crates/brioche-core/src/script.rs
+++ b/crates/brioche-core/src/script.rs
@@ -11,7 +11,7 @@ use anyhow::Context as _;
 use bridge::{GetStaticOptions, RuntimeBridge};
 use deno_core::{OpState, v8};
 use relative_path::PathExt as _;
-use specifier::BriocheModuleSpecifier;
+use specifier::{BriocheModuleSpecifier, RUNTIME_SCHEME};
 
 use crate::{bake::BakeScope, project::Projects, recipe::StackFrame};
 
@@ -167,18 +167,20 @@ impl BriocheModuleLoader {
             });
         }
 
-        // Look up cached bytecode for this source.
-        let hash = code_cache_hash(text.as_bytes());
-        let code_cache = self.read_code_cache(hash).map(Cow::Owned);
+        // Only look up cached bytecode for the prebuilt runtime bundle.
+        let code_cache_info = if module_specifier.scheme() == RUNTIME_SCHEME {
+            let hash = code_cache_hash(text.as_bytes());
+            let data = self.read_code_cache(hash).map(Cow::Owned);
+            Some(deno_core::SourceCodeCacheInfo { hash, data })
+        } else {
+            None
+        };
 
         Ok(deno_core::ModuleSource::new(
             deno_core::ModuleType::JavaScript,
             deno_core::ModuleSourceCode::String(text.into()),
             module_specifier,
-            Some(deno_core::SourceCodeCacheInfo {
-                hash,
-                data: code_cache,
-            }),
+            code_cache_info,
         ))
     }
 
@@ -256,11 +258,13 @@ impl deno_core::ModuleLoader for BriocheModuleLoader {
 
     fn code_cache_ready(
         &self,
-        _module_specifier: deno_core::ModuleSpecifier,
+        module_specifier: deno_core::ModuleSpecifier,
         hash: u64,
         code_cache: &[u8],
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()>>> {
-        self.write_code_cache(hash, code_cache);
+        if module_specifier.scheme() == RUNTIME_SCHEME {
+            self.write_code_cache(hash, code_cache);
+        }
         Box::pin(std::future::ready(()))
     }
 

--- a/crates/brioche-core/src/script.rs
+++ b/crates/brioche-core/src/script.rs
@@ -125,35 +125,45 @@ impl BriocheModuleLoader {
         let code = std::str::from_utf8(&contents)
             .context("failed to parse module contents as UTF-8 string")?;
 
-        let parsed = deno_ast::parse_module(deno_ast::ParseParams {
-            specifier: brioche_module_specifier.clone().into(),
-            text: code.into(),
-            media_type: deno_ast::MediaType::TypeScript,
-            capture_tokens: false,
-            scope_analysis: false,
-            maybe_syntax: None,
-        })?;
-        let transpiled = parsed.transpile(
-            &deno_ast::TranspileOptions {
-                imports_not_used_as_values: deno_ast::ImportsNotUsedAsValues::Preserve,
-                ..Default::default()
-            },
-            &deno_ast::TranspileModuleOptions {
-                module_kind: Some(deno_ast::ModuleKind::Esm),
-            },
-            &deno_ast::EmitOptions {
-                source_map: deno_ast::SourceMapOption::Separate,
-                ..Default::default()
-            },
-        )?;
+        // Serve prebuilt JS directly; transpile TypeScript sources.
+        let media_type = deno_ast::MediaType::from_specifier(module_specifier);
+        let (text, source_map) = if matches!(
+            media_type,
+            deno_ast::MediaType::JavaScript | deno_ast::MediaType::Mjs | deno_ast::MediaType::Cjs
+        ) {
+            (code.to_string(), Vec::new())
+        } else {
+            let parsed = deno_ast::parse_module(deno_ast::ParseParams {
+                specifier: brioche_module_specifier.clone().into(),
+                text: code.into(),
+                media_type: deno_ast::MediaType::TypeScript,
+                capture_tokens: false,
+                scope_analysis: false,
+                maybe_syntax: None,
+            })?;
+            let transpiled = parsed.transpile(
+                &deno_ast::TranspileOptions {
+                    imports_not_used_as_values: deno_ast::ImportsNotUsedAsValues::Preserve,
+                    ..Default::default()
+                },
+                &deno_ast::TranspileModuleOptions {
+                    module_kind: Some(deno_ast::ModuleKind::Esm),
+                },
+                &deno_ast::EmitOptions {
+                    source_map: deno_ast::SourceMapOption::Separate,
+                    ..Default::default()
+                },
+            )?;
 
-        let deno_ast::EmittedSourceText { text, source_map } = transpiled.into_source();
+            let deno_ast::EmittedSourceText { text, source_map } = transpiled.into_source();
+            let source_map = source_map.context("source map not generated")?.into_bytes();
+            (text, source_map)
+        };
 
         if let Entry::Vacant(entry) = self.sources.borrow_mut().entry(brioche_module_specifier) {
-            let source_map = source_map.context("source map not generated")?;
             entry.insert(ModuleSource {
                 source_contents: contents.clone(),
-                source_map: source_map.into_bytes(),
+                source_map,
             });
         }
 

--- a/crates/brioche-core/src/script.rs
+++ b/crates/brioche-core/src/script.rs
@@ -199,7 +199,7 @@ impl BriocheModuleLoader {
         if std::fs::create_dir_all(dir).is_err() {
             return;
         }
-        let tmp = dir.join(format!("{hash:016x}.{}.tmp", std::process::id()));
+        let tmp = dir.join(format!("{hash:016x}.{}.tmp", ulid::Ulid::new()));
         if std::fs::write(&tmp, data).is_ok() {
             let _ = std::fs::rename(&tmp, self.code_cache_path(hash));
         }

--- a/crates/brioche-core/src/script.rs
+++ b/crates/brioche-core/src/script.rs
@@ -167,12 +167,42 @@ impl BriocheModuleLoader {
             });
         }
 
+        // Look up cached bytecode for this source.
+        let hash = code_cache_hash(text.as_bytes());
+        let code_cache = self.read_code_cache(hash).map(Cow::Owned);
+
         Ok(deno_core::ModuleSource::new(
             deno_core::ModuleType::JavaScript,
             deno_core::ModuleSourceCode::String(text.into()),
             module_specifier,
-            None,
+            Some(deno_core::SourceCodeCacheInfo {
+                hash,
+                data: code_cache,
+            }),
         ))
+    }
+
+    fn code_cache_path(&self, hash: u64) -> PathBuf {
+        self.bridge
+            .code_cache_dir()
+            .join(format!("{hash:016x}.bin"))
+    }
+
+    fn read_code_cache(&self, hash: u64) -> Option<Vec<u8>> {
+        std::fs::read(self.code_cache_path(hash)).ok()
+    }
+
+    /// Write V8 bytecode for a module to the cache, atomically. Failures are
+    /// ignored.
+    fn write_code_cache(&self, hash: u64, data: &[u8]) {
+        let dir = self.bridge.code_cache_dir();
+        if std::fs::create_dir_all(dir).is_err() {
+            return;
+        }
+        let tmp = dir.join(format!("{hash:016x}.{}.tmp", std::process::id()));
+        if std::fs::write(&tmp, data).is_ok() {
+            let _ = std::fs::rename(&tmp, self.code_cache_path(hash));
+        }
     }
 
     fn resolve_module(
@@ -224,6 +254,16 @@ impl deno_core::ModuleLoader for BriocheModuleLoader {
         )
     }
 
+    fn code_cache_ready(
+        &self,
+        _module_specifier: deno_core::ModuleSpecifier,
+        hash: u64,
+        code_cache: &[u8],
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()>>> {
+        self.write_code_cache(hash, code_cache);
+        Box::pin(std::future::ready(()))
+    }
+
     fn get_source_map(&self, file_name: &str) -> Option<Cow<'_, [u8]>> {
         let sources = self.sources.borrow();
         let specifier: BriocheModuleSpecifier = file_name.parse().ok()?;
@@ -249,6 +289,16 @@ impl deno_core::ModuleLoader for BriocheModuleLoader {
 struct ModuleSource {
     pub source_contents: Arc<Vec<u8>>,
     pub source_map: Vec<u8>,
+}
+
+/// 64-bit blake3 digest of a module's source.
+fn code_cache_hash(bytes: &[u8]) -> u64 {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(bytes);
+
+    let mut digest = [0u8; 8];
+    hasher.finalize_xof().fill(&mut digest);
+    u64::from_le_bytes(digest)
 }
 
 pub enum ModuleLoaderMessage {

--- a/crates/brioche-core/src/script/bridge.rs
+++ b/crates/brioche-core/src/script/bridge.rs
@@ -17,6 +17,8 @@ use crate::{
 
 use super::specifier::{self, BriocheImportSpecifier, BriocheModuleSpecifier};
 
+const CODE_CACHE_DIR_NAME: &str = "code-cache";
+
 /// A type used to call Brioche functions across Tokio runtimes. This is used
 /// to interact with Brioche from JavaScript code, due to restrictions that
 /// require the V8 runtime to run in its own Tokio runtime.
@@ -27,10 +29,12 @@ use super::specifier::{self, BriocheImportSpecifier, BriocheModuleSpecifier};
 #[derive(Clone)]
 pub struct RuntimeBridge {
     tx: tokio::sync::mpsc::UnboundedSender<RuntimeBridgeMessage>,
+    code_cache_dir: PathBuf,
 }
 
 impl RuntimeBridge {
     pub fn new(brioche: Brioche, projects: Projects) -> Self {
+        let code_cache_dir = brioche.data_dir.join(CODE_CACHE_DIR_NAME);
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
 
         tokio::spawn(async move {
@@ -303,7 +307,12 @@ impl RuntimeBridge {
             }
         }.instrument(tracing::Span::current()));
 
-        Self { tx }
+        Self { tx, code_cache_dir }
+    }
+
+    /// Directory where V8 bytecode caches are stored.
+    pub fn code_cache_dir(&self) -> &std::path::Path {
+        &self.code_cache_dir
     }
 
     pub async fn load_project_from_module_path(

--- a/crates/brioche-core/src/script/check.rs
+++ b/crates/brioche-core/src/script/check.rs
@@ -8,7 +8,10 @@ use crate::{
     vfs::Vfs,
 };
 
-use super::{bridge::RuntimeBridge, specifier::BriocheModuleSpecifier};
+use super::{
+    bridge::RuntimeBridge,
+    specifier::{BriocheModuleSpecifier, RUNTIME_SCHEME},
+};
 
 #[tracing::instrument(skip(brioche, projects), err)]
 pub async fn check(
@@ -70,7 +73,7 @@ async fn check_with_deno(
 
             // Get the specifier for the built-in runtime module
             let main_module: deno_core::ModuleSpecifier =
-                "briocheruntime:///dist/index.js".parse()?;
+                format!("{RUNTIME_SCHEME}:///dist/index.js").parse()?;
 
             tracing::debug!(%main_module, "evaluating module");
 

--- a/crates/brioche-core/src/script/lsp.rs
+++ b/crates/brioche-core/src/script/lsp.rs
@@ -27,7 +27,7 @@ use crate::script::format::format_code;
 use crate::{Brioche, BriocheBuilder};
 
 use super::bridge::RuntimeBridge;
-use super::specifier::BriocheModuleSpecifier;
+use super::specifier::{BriocheModuleSpecifier, RUNTIME_SCHEME};
 
 /// The maximum time we spend resolving projects when regenerating a
 /// lockfile in the Language Server
@@ -748,7 +748,7 @@ fn js_lsp_task(
             });
 
             let main_module: deno_core::ModuleSpecifier =
-                "briocheruntime:///dist/index.js".parse()?;
+                format!("{RUNTIME_SCHEME}:///dist/index.js").parse()?;
 
             tracing::info!(%main_module, "evaluating module");
 

--- a/crates/brioche-core/src/script/specifier.rs
+++ b/crates/brioche-core/src/script/specifier.rs
@@ -83,6 +83,9 @@ pub enum BriocheLocalImportSpecifier {
     ProjectRoot(String),
 }
 
+/// URL scheme for modules served from the prebuilt runtime bundle.
+pub const RUNTIME_SCHEME: &str = "briocheruntime";
+
 /// A specifier for a Brioche module, either from the filesystem or
 /// from the internal runtime package. A module specifier can be converted
 /// from/to a URL.
@@ -114,7 +117,7 @@ impl TryFrom<&'_ url::Url> for BriocheModuleSpecifier {
                     .map_err(|()| anyhow::anyhow!("failed to convert specifier {value} to path"))?;
                 Ok(Self::File { path })
             }
-            "briocheruntime" => {
+            RUNTIME_SCHEME => {
                 anyhow::ensure!(!value.has_host(), "invalid specifier: {value}");
                 let subpath = RelativePathBuf::from(value.path().trim_start_matches('/'));
                 Ok(Self::Runtime { subpath })
@@ -138,7 +141,9 @@ impl From<&'_ BriocheModuleSpecifier> for url::Url {
     fn from(value: &BriocheModuleSpecifier) -> Self {
         match value {
             BriocheModuleSpecifier::Runtime { subpath } => {
-                let mut url: Self = "briocheruntime:///".parse().expect("failed to build URL");
+                let mut url: Self = format!("{RUNTIME_SCHEME}:///")
+                    .parse()
+                    .expect("failed to build URL");
                 url.set_path(subpath.as_str());
                 url
             }

--- a/crates/brioche-core/tests/script_specifiers.rs
+++ b/crates/brioche-core/tests/script_specifiers.rs
@@ -2,7 +2,8 @@ use assert_matches::assert_matches;
 use brioche_core::{
     project::Projects,
     script::specifier::{
-        self, BriocheImportSpecifier, BriocheModuleSpecifier, read_specifier_contents,
+        self, BriocheImportSpecifier, BriocheModuleSpecifier, RUNTIME_SCHEME,
+        read_specifier_contents,
     },
 };
 
@@ -21,7 +22,7 @@ fn resolve(
 async fn test_specifier_read_runtime() -> anyhow::Result<()> {
     let (brioche, _context) = brioche_test_support::brioche_test().await;
 
-    let specifier: BriocheModuleSpecifier = "briocheruntime:///dist/index.js"
+    let specifier: BriocheModuleSpecifier = format!("{RUNTIME_SCHEME}:///dist/index.js")
         .parse()
         .expect("failed to parse specifier");
     let contents = read_specifier_contents(&brioche.vfs, &specifier)?;


### PR DESCRIPTION
This PR speeds up the JavaScript runtime startup. The change is in the module loader, so it helps the commands that start that runtime: mostly `check` and the LSP, which load the whole runtime bundle, and to a smaller degree `build`, `run`, `install` and `live-update`, which run project code through the same runtime. `fmt` is unaffected, since it formats with biome and never starts the runtime.

The first commit stops transpiling the prebuilt runtime bundle (`crates/brioche-core/runtime/dist/index.js`, about 10 MB). It is already plain JavaScript, but the loader parsed and transpiled it as TypeScript on every cold start, which alone took around 950 ms. The loader now serves built JavaScript as-is and only transpiles real TypeScript sources, so a cold runtime start drops from about 1094 ms to about 144 ms. `check` and the LSP gain the most here because they load that bundle; the build-style commands load TypeScript project code instead, so they see little from this part.

The second commit caches the compiled V8 bytecode on disk so it survives between runs, which helps every command that starts the runtime. On a miss the loader takes the bytecode from V8 and writes it; on a hit it hands the stored bytecode back and skips compiling, saving roughly 120 ms more (a small `check` goes from about 0.90 s to about 0.75 s). The cache is a new folder `code-cache` under the data dir, one file per module keyed by a blake3 hash of its source, covering both the runtime bundle and project code. Each file is written atomically (temp file then rename) and shared across processes. The folder is unbounded, like Brioche's other data folders: a file appears the first time a source is compiled and stays until the source changes (a new hash, so a new file) or the V8 version changes, in which case V8 ignores the old bytecode and the loader rewrites it next run. Cleaning it up should be handled by https://github.com/brioche-dev/brioche/issues/135. If the folder cannot be read or written, the loader just compiles, so the cache is never required for correctness.

The third commit shrinks the runtime bundle itself. The esbuild build only stripped whitespace, so switching it to full minification (identifiers and syntax as well) takes `dist/index.js` from about 10.8 MB down to about 6.1 MB, roughly 41% smaller. Fewer bytes mean less V8 parse and compile work on a cold start and a smaller bytecode cache on disk, and since this only reshapes the source it leaves type checking behaviour unchanged. `check` and the LSP gain the most again, since they load the whole bundle.